### PR TITLE
Replace stringable with fmt.Stringer

### DIFF
--- a/kafka/config.go
+++ b/kafka/config.go
@@ -71,25 +71,21 @@ func (m ConfigMap) Set(kv string) error {
 	return m.SetKey(k, v)
 }
 
-type stringable interface {
-	String() string
-}
-
 func value2string(v ConfigValue) (ret string, errstr string) {
 
-	switch v.(type) {
+	switch x := v.(type) {
 	case bool:
-		if v.(bool) {
+		if x {
 			ret = "true"
 		} else {
 			ret = "false"
 		}
 	case int:
-		ret = fmt.Sprintf("%d", v)
+		ret = fmt.Sprintf("%d", x)
 	case string:
-		ret = v.(string)
-	case stringable:
-		ret = v.(stringable).String()
+		ret = x
+	case fmt.Stringer:
+		ret = x.String()
 	default:
 		return "", fmt.Sprintf("Invalid value type %T", v)
 	}


### PR DESCRIPTION
fmt.Stringer is an existing interface that defines the `String() string` method.
In addition, the case statement now includes the type asserted value that can be
use directly in the case blocks.

Signed-off-by: Byron Ruth b@devel.io
