### PR TITLE
Fix compilation errors on Go 1.2

### DIFF
--- a/kafka/config.go
+++ b/kafka/config.go
@@ -124,11 +124,11 @@ type rdkConf C.rd_kafka_conf_t
 type rdkTopicConf C.rd_kafka_topic_conf_t
 
 func (cConf *rdkConf) set(cKey *C.char, cVal *C.char, cErrstr *C.char, errstrSize int) C.rd_kafka_conf_res_t {
-	return C.rd_kafka_conf_set(cConf, cKey, cVal, cErrstr, C.size_t(errstrSize))
+	return C.rd_kafka_conf_set((*C.rd_kafka_conf_t)(cConf), cKey, cVal, cErrstr, C.size_t(errstrSize))
 }
 
 func (ctopicConf *rdkTopicConf) set(cKey *C.char, cVal *C.char, cErrstr *C.char, errstrSize int) C.rd_kafka_conf_res_t {
-	return C.rd_kafka_topic_conf_set(ctopicConf, cKey, cVal, cErrstr, C.size_t(errstrSize))
+	return C.rd_kafka_topic_conf_set((*C.rd_kafka_conf_t)(ctopicConf), cKey, cVal, cErrstr, C.size_t(errstrSize))
 }
 
 func configConvertAnyconf(m ConfigMap, anyconf rdkAnyconf) (err error) {
@@ -152,8 +152,8 @@ func configConvertAnyconf(m ConfigMap, anyconf rdkAnyconf) (err error) {
 			}
 
 			C.rd_kafka_conf_set_default_topic_conf(
-				anyconf.(*rdkConf),
-				(*rdkTopicConf)(cTopicConf))
+				(*C.rd_kafka_conf_t)(anyconf.(*rdkConf)),
+				(*C.rd_kafka_topic_conf_t)((*rdkTopicConf)(cTopicConf)))
 
 		default:
 			val, errstr := value2string(v)

--- a/kafka/message.go
+++ b/kafka/message.go
@@ -205,11 +205,11 @@ func (h *handle) messageToC(msg *Message, cmsg *C.rd_kafka_message_t) {
 	if allocLen > 0 {
 		payload = C.malloc(C.size_t(allocLen))
 		if valueLen > 0 {
-			copy((*[1 << 31]byte)(payload)[0:valueLen], msg.Value)
+			copy((*[1 << 30]byte)(payload)[0:valueLen], msg.Value)
 			valp = payload
 		}
 		if keyLen > 0 {
-			copy((*[1 << 31]byte)(payload)[valueLen:keyLen], msg.Key)
+			copy((*[1 << 30]byte)(payload)[valueLen:keyLen], msg.Key)
 			keyp = unsafe.Pointer(&((*[1 << 31]byte)(payload)[valueLen]))
 		}
 	}


### PR DESCRIPTION
Golang 1.2 seems to be the default version on Ubuntu 14.04.
This PR fixes compilation errors for Go 1.2