### PR TITLE
safely handle slice message values

### DIFF
--- a/kafka/producer.go
+++ b/kafka/producer.go
@@ -84,22 +84,8 @@ func (p *Producer) produce(msg *Message, msgFlags int, deliveryChan chan Event) 
 
 	crkt := p.handle.getRkt(*msg.TopicPartition.Topic)
 
-	var keyp *byte
-	var empty byte
-	valLen := 0
-	keyLen := 0
-
-	if msg.Value != nil {
-		valLen = len(msg.Value)
-	}
-	if msg.Key != nil {
-		keyLen = len(msg.Key)
-		if keyLen > 0 {
-			keyp = &msg.Key[0]
-		} else {
-			keyp = &empty
-		}
-	}
+	valLen := len(msg.Value)
+	keyLen := len(msg.Key)
 
 	var cgoid int
 
@@ -122,7 +108,7 @@ func (p *Producer) produce(msg *Message, msgFlags int, deliveryChan chan Event) 
 		C.int32_t(msg.TopicPartition.Partition),
 		C.int(msgFlags)|C.RD_KAFKA_MSG_F_COPY,
 		C.CBytes(msg.Value), C.size_t(valLen),
-		unsafe.Pointer(keyp), C.size_t(keyLen),
+		C.CBytes(msg.Key), C.size_t(keyLen),
 		C.int64_t(timestamp),
 		(C.uintptr_t)(cgoid))
 	if cErr != C.RD_KAFKA_RESP_ERR_NO_ERROR {

--- a/kafka/producer.go
+++ b/kafka/producer.go
@@ -84,7 +84,6 @@ func (p *Producer) produce(msg *Message, msgFlags int, deliveryChan chan Event) 
 
 	crkt := p.handle.getRkt(*msg.TopicPartition.Topic)
 
-	var valp *byte
 	var keyp *byte
 	var empty byte
 	valLen := 0
@@ -92,12 +91,6 @@ func (p *Producer) produce(msg *Message, msgFlags int, deliveryChan chan Event) 
 
 	if msg.Value != nil {
 		valLen = len(msg.Value)
-		// allow sending 0-length messages (as opposed to null messages)
-		if valLen > 0 {
-			valp = &msg.Value[0]
-		} else {
-			valp = &empty
-		}
 	}
 	if msg.Key != nil {
 		keyLen = len(msg.Key)
@@ -128,7 +121,7 @@ func (p *Producer) produce(msg *Message, msgFlags int, deliveryChan chan Event) 
 	cErr := C.do_produce(p.handle.rk, crkt,
 		C.int32_t(msg.TopicPartition.Partition),
 		C.int(msgFlags)|C.RD_KAFKA_MSG_F_COPY,
-		unsafe.Pointer(valp), C.size_t(valLen),
+		C.CBytes(msg.Value), C.size_t(valLen),
 		unsafe.Pointer(keyp), C.size_t(keyLen),
 		C.int64_t(timestamp),
 		(C.uintptr_t)(cgoid))

--- a/kafka/producer_test.go
+++ b/kafka/producer_test.go
@@ -22,6 +22,10 @@ import (
 	"time"
 )
 
+type Key struct {
+	K string
+}
+
 type Envelope struct {
 	M string
 }
@@ -45,8 +49,15 @@ func TestProducerAPIs(t *testing.T) {
 	topic1 := "gotest"
 	topic2 := "gotest2"
 
+	key := Key{K: "This is my key"}
+	keyData, err := json.Marshal(key)
+
+	if err != nil {
+		t.Error(err)
+	}
+
 	envelope := Envelope{M: "Own drChan"}
-	data, err := json.Marshal(envelope)
+	envelopeData, err := json.Marshal(envelope)
 
 	if err != nil {
 		t.Error(err)
@@ -54,7 +65,7 @@ func TestProducerAPIs(t *testing.T) {
 
 	// Produce with function, DR on passed drChan
 	err = p.Produce(&Message{TopicPartition: TopicPartition{Topic: &topic1, Partition: 0},
-		Value: data, Key: []byte("This is my key")},
+		Value: envelopeData, Key: keyData},
 		drChan)
 	if err != nil {
 		t.Errorf("Produce failed: %s", err)


### PR DESCRIPTION
This should fix #24.

Note: Requires Go 1.7+ for `C.CBytes()` support. Some of the CI jobs fail due to attempting to build this patch for Go 1.6-.

I tried to rewrite the `C.CBytes()` call using `C.memcpy` for Go 1.6- support, but that's giving me errors. If someone knows cgo really well, maybe we can massage `valp` better.