### PR TITLE
Add Seek API to consumer

### DIFF
--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -189,6 +189,21 @@ func (c *Consumer) CommitOffsets(offsets []TopicPartition) ([]TopicPartition, er
 	return c.commit(offsets)
 }
 
+// Seek seeks the given topic partitions using the offset from the TopicPartition.
+// This is a blocking call.
+// Returns an error on failure or nil otherwise.
+func (c *Consumer) Seek(partition TopicPartition, timeoutMs int) error {
+	rkt := c.handle.getRkt(*partition.Topic)
+	cErr := C.rd_kafka_seek(rkt,
+		C.int32_t(partition.Partition),
+		C.int64_t(partition.Offset),
+		C.int(timeoutMs))
+	if cErr != C.RD_KAFKA_RESP_ERR_NO_ERROR {
+		return newError(cErr)
+	}
+	return nil
+}
+
 // Poll the consumer for messages or events.
 //
 // Will block for at most timeoutMs milliseconds

--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -190,7 +190,18 @@ func (c *Consumer) CommitOffsets(offsets []TopicPartition) ([]TopicPartition, er
 }
 
 // Seek seeks the given topic partitions using the offset from the TopicPartition.
-// This is a blocking call.
+//
+// If timeoutMs is not 0 the call will wait this long for the
+// seek to be performed. If the timeout is reached the internal state
+// will be unknown and this function returns ErrTimedOut.
+// If timeoutMs is 0 it will initiate the seek but return
+// immediately without any error reporting (e.g., async).
+//
+// Seek() may only be used for partitions already being consumed
+// (through Assign() or implicitly through a self-rebalanced Subscribe()).
+// To set the starting offset it is preferred to use Assign() and provide
+// a starting offset for each partition.
+// 
 // Returns an error on failure or nil otherwise.
 func (c *Consumer) Seek(partition TopicPartition, timeoutMs int) error {
 	rkt := c.handle.getRkt(*partition.Topic)

--- a/kafka/consumer_test.go
+++ b/kafka/consumer_test.go
@@ -70,6 +70,11 @@ func TestConsumerAPIs(t *testing.T) {
 		t.Errorf("Assign failed: %s", err)
 	}
 
+	err = c.Seek(TopicPartition{Topic: &topic1, Partition: 2, Offset: -1}, 1000)
+	if err != nil {
+		t.Errorf("Seek failed: %s", err)
+	}
+
 	err = c.Unassign()
 	if err != nil {
 		t.Errorf("Unassign failed: %s", err)


### PR DESCRIPTION
Using rd_kafka_seek implemented in the rdkafka library we just expose this on the consumer interface. I had this take a `TopicPartition` as the argument to match the way other methods worked but I can switch it to take topic/partition/offset args if that makes more sense.