### PR TITLE
Allow users to retrive parsed statistic

### DIFF
--- a/kafka/stats_event_test.go
+++ b/kafka/stats_event_test.go
@@ -18,9 +18,29 @@ package kafka
 
 import (
 	"encoding/json"
+	"reflect"
+	"strconv"
 	"testing"
 	"time"
 )
+
+// Debug function in order to find the error faster
+func checkEqualityDeep(t *testing.T, o1, o2 interface{}, stack string) {
+	for k, v := range o1.(map[string]interface{}) {
+		switch v2 := v.(type) {
+		case []interface{}:
+			for i := range v2 {
+				checkEqualityDeep(t, v2[i], o2.(map[string]interface{})[k].([]interface{})[i], stack+"["+strconv.Itoa(i)+"]")
+			}
+		case map[string]interface{}:
+			checkEqualityDeep(t, v, o2.(map[string]interface{})[k], stack+"."+k)
+		default:
+			if !reflect.DeepEqual(v, o2.(map[string]interface{})[k]) {
+				t.Logf("Unqual %s: org: %v parsed: %v", stack+"."+k, v, o2.(map[string]interface{})[k])
+			}
+		}
+	}
+}
 
 // handleStatsEvent checks for stats event and signals on statsReceived
 func handleStatsEvent(t *testing.T, eventCh chan Event, statsReceived chan bool) {
@@ -30,12 +50,46 @@ func handleStatsEvent(t *testing.T, eventCh chan Event, statsReceived chan bool)
 			t.Logf("Stats: %v", e)
 
 			// test if the stats string can be decoded into JSON
-			var raw map[string]interface{}
-			err := json.Unmarshal([]byte(e.String()), &raw) // convert string to json
+			stats, err := e.Parse() // convert string to json
 			if err != nil {
 				t.Fatalf("json unmarshall error: %s", err)
 			}
-			t.Logf("Stats['name']: %s", raw["name"])
+			t.Logf("Stats['name']: %s", stats.Name)
+
+			// test for json equality
+			str, err := json.Marshal(stats)
+			if err != nil {
+				t.Fatalf("json marshall error: %s", err)
+			}
+
+			var o1 interface{}
+			var o2 interface{}
+			err = json.Unmarshal([]byte(e.String()), &o1)
+			if err != nil {
+				t.Fatalf("json unmarshall raw error: %s", err)
+			}
+			err = json.Unmarshal([]byte(str), &o2)
+			if err != nil {
+				t.Fatalf("json unmarshall raw2 error: %s", err)
+			}
+
+			// workarounds to make this test pass
+			// cgrp might be omited by librdkafka, so remove it too
+			if _, ok := o1.(map[string]interface{})["cgrp"]; !ok {
+				delete(o2.(map[string]interface{}), "cgrp")
+			}
+			// correct that spelling mistake
+			for _, v := range o1.(map[string]interface{})["topics"].(map[string]interface{}) {
+				for _, v2 := range v.(map[string]interface{})["partitions"].(map[string]interface{}) {
+					delete(v2.(map[string]interface{}), "commited_offset")
+				}
+			}
+			if !reflect.DeepEqual(o1, o2) {
+				// print whats actually wrong
+				checkEqualityDeep(t, o1, o2, "")
+				t.Fatalf("parsed json is unequal to original json")
+			}
+
 			close(statsReceived)
 			return
 		default:
@@ -46,19 +100,39 @@ func handleStatsEvent(t *testing.T, eventCh chan Event, statsReceived chan bool)
 
 // TestStatsEventProducerFunc dry-test stats event, no broker is needed.
 func TestStatsEventProducerFunc(t *testing.T) {
-	testProducerFunc(t, false)
+	testProducerFunc(t, false, false)
 }
 
 func TestStatsEventProducerChannel(t *testing.T) {
-	testProducerFunc(t, true)
+	testProducerFunc(t, true, false)
 }
 
-func testProducerFunc(t *testing.T, withProducerChannel bool) {
+func TestStatsEventProducerFuncOnline(t *testing.T) {
+	if !testconfRead() {
+		t.Skipf("Missing testconf.json")
+	}
+	testProducerFunc(t, false, true)
+}
 
-	p, err := NewProducer(&ConfigMap{
-		"statistics.interval.ms": 50,
-		"socket.timeout.ms":      10,
-		"default.topic.config":   ConfigMap{"message.timeout.ms": 10}})
+func testProducerFunc(t *testing.T, withProducerChannel bool, online bool) {
+
+	var conf ConfigMap
+	if online {
+		conf = ConfigMap{
+			"bootstrap.servers":       testconf.Brokers,
+			"statistics.interval.ms":  50,
+			"api.version.request":     "true",
+			"broker.version.fallback": "0.9.0.1",
+			"default.topic.config":    ConfigMap{"acks": 1}}
+		conf.updateFromTestconf()
+	} else {
+		conf = ConfigMap{
+			"statistics.interval.ms": 50,
+			"socket.timeout.ms":      10,
+			"default.topic.config":   ConfigMap{"message.timeout.ms": 10}}
+	}
+
+	p, err := NewProducer(&conf)
 	if err != nil {
 		t.Fatalf("%s", err)
 	}
@@ -66,7 +140,12 @@ func testProducerFunc(t *testing.T, withProducerChannel bool) {
 
 	t.Logf("Producer %s", p)
 
-	topic1 := "gotest"
+	var topic1 string
+	if online {
+		topic1 = testconf.Topic
+	} else {
+		topic1 = "gotest"
+	}
 
 	// go routine to check for stats event
 	statsReceived := make(chan bool)
@@ -97,13 +176,39 @@ func testProducerFunc(t *testing.T, withProducerChannel bool) {
 
 // TestStatsEventConsumerChannel dry-tests stats event for consumer, no broker is needed.
 func TestStatsEventConsumerChannel(t *testing.T) {
+	testConsumerFunc(t, false)
+}
 
-	c, err := NewConsumer(&ConfigMap{
-		"group.id":                 "gotest",
-		"statistics.interval.ms":   50,
-		"go.events.channel.enable": true,
-		"socket.timeout.ms":        10,
-		"session.timeout.ms":       10})
+func TestStatsEventConsumerChannelOnline(t *testing.T) {
+	if !testconfRead() {
+		t.Skipf("Missing testconf.json")
+	}
+	testConsumerFunc(t, true)
+}
+
+func testConsumerFunc(t *testing.T, online bool) {
+	var conf ConfigMap
+	if online {
+		conf = ConfigMap{
+			"bootstrap.servers":        testconf.Brokers,
+			"statistics.interval.ms":   50,
+			"go.events.channel.enable": true,
+			"group.id":                 testconf.GroupID,
+			"session.timeout.ms":       6000,
+			"api.version.request":      "true",
+			"debug":                    ",",
+			"default.topic.config":     ConfigMap{"auto.offset.reset": "earliest"}}
+		conf.updateFromTestconf()
+	} else {
+		conf = ConfigMap{
+			"group.id":                 "gotest",
+			"statistics.interval.ms":   50,
+			"go.events.channel.enable": true,
+			"socket.timeout.ms":        10,
+			"session.timeout.ms":       10}
+	}
+
+	c, err := NewConsumer(&conf)
 	if err != nil {
 		t.Fatalf("%s", err)
 	}
@@ -116,7 +221,11 @@ func TestStatsEventConsumerChannel(t *testing.T) {
 	statsReceived := make(chan bool)
 	go handleStatsEvent(t, c.Events(), statsReceived)
 
-	err = c.Subscribe("gotest", nil)
+	if online {
+		err = c.Subscribe(testconf.Topic, nil)
+	} else {
+		err = c.Subscribe("gotest", nil)
+	}
 	if err != nil {
 		t.Errorf("Subscribe failed: %s", err)
 	}
@@ -127,5 +236,4 @@ func TestStatsEventConsumerChannel(t *testing.T) {
 	case <-time.After(time.Second * 3):
 		t.Fatalf("Excepted stats but got none")
 	}
-
 }


### PR DESCRIPTION
This PR will expose a `Parse()` function on the `Stats` Event that returns a go struct `ParsedStats` containing all the parsed stats.

It is useful in case where the user does not want to forward/print the entire json string but rather extract certain parts. Before this had to be done by hand.
I think this should be done by the library rather then each app on its own. 

For performance reasons I did not want to parse it by default. Maybe we could introduce a config string (e.g. `go.statistics.parse: true`) for automated parsing.

One question left: Should I handle Unmarshal errors in `event.go:161`? And if so how? This should actually never happen, since it is covert by the tests and should only fail if librdkafka screwed up.
