### PR TITLE
Added Consumer.OffsetsStore()

### DIFF
--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -194,6 +194,29 @@ func (c *Consumer) CommitOffsets(offsets []TopicPartition) ([]TopicPartition, er
 	return c.commit(offsets)
 }
 
+// OffsetsStore stores the provided list of offsets that will be committed
+// to the offset store according to `auto.commit.interval.ms` or manual
+// offset-less Commit().
+//
+// Returns the stored offsets on success. If at least one offset couldn't be stored,
+// an error and a list of offsets is returned. Each offset can be checked for
+// specific errors via its `.Error` member.
+func (c *Consumer) OffsetsStore(offsets []TopicPartition) (storedOffsets []TopicPartition, err error) {
+	coffsets := newCPartsFromTopicPartitions(offsets)
+	defer C.rd_kafka_topic_partition_list_destroy(coffsets)
+
+	cErr := C.rd_kafka_offsets_store(c.handle.rk, coffsets)
+
+	// coffsets might be annotated with an error
+	storedOffsets = newTopicPartitionsFromCparts(coffsets)
+
+	if cErr != C.RD_KAFKA_RESP_ERR_NO_ERROR {
+		return storedOffsets, newError(cErr)
+	}
+
+	return storedOffsets, nil
+}
+
 // Seek seeks the given topic partitions using the offset from the TopicPartition.
 //
 // If timeoutMs is not 0 the call will wait this long for the

--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -194,14 +194,14 @@ func (c *Consumer) CommitOffsets(offsets []TopicPartition) ([]TopicPartition, er
 	return c.commit(offsets)
 }
 
-// OffsetsStore stores the provided list of offsets that will be committed
+// StoreOffsets stores the provided list of offsets that will be committed
 // to the offset store according to `auto.commit.interval.ms` or manual
 // offset-less Commit().
 //
 // Returns the stored offsets on success. If at least one offset couldn't be stored,
 // an error and a list of offsets is returned. Each offset can be checked for
 // specific errors via its `.Error` member.
-func (c *Consumer) OffsetsStore(offsets []TopicPartition) (storedOffsets []TopicPartition, err error) {
+func (c *Consumer) StoreOffsets(offsets []TopicPartition) (storedOffsets []TopicPartition, err error) {
 	coffsets := newCPartsFromTopicPartitions(offsets)
 	defer C.rd_kafka_topic_partition_list_destroy(coffsets)
 

--- a/kafka/consumer_test.go
+++ b/kafka/consumer_test.go
@@ -65,17 +65,17 @@ func TestConsumerAPIs(t *testing.T) {
 	}
 
 	topic := "gotest"
-	stored, err := c.OffsetsStore([]TopicPartition{{Topic: &topic, Partition: 0, Offset: 1}})
+	stored, err := c.StoreOffsets([]TopicPartition{{Topic: &topic, Partition: 0, Offset: 1}})
 	if err != nil && err.(Error).Code() != ErrUnknownPartition {
-		t.Errorf("OffsetsStore() failed: %s", err)
+		t.Errorf("StoreOffsets() failed: %s", err)
 		toppar := stored[0]
 		if toppar.Error.(Error).Code() == ErrUnknownPartition {
-			t.Errorf("OffsetsStore() TopicPartition error: %s", toppar.Error)
+			t.Errorf("StoreOffsets() TopicPartition error: %s", toppar.Error)
 		}
 	}
-	stored, err = c.OffsetsStore(nil)
+	stored, err = c.StoreOffsets(nil)
 	if err != nil {
-		t.Errorf("OffsetsStore(nil) failed: %s", err)
+		t.Errorf("StoreOffsets(nil) failed: %s", err)
 	}
 
 	topic1 := "gotest1"

--- a/kafka/consumer_test.go
+++ b/kafka/consumer_test.go
@@ -54,6 +54,7 @@ func TestConsumerAPIs(t *testing.T) {
 	if err != nil {
 		t.Errorf("SubscribeTopics failed: %s", err)
 	}
+
 	_, err = c.Commit()
 	if err != nil && err.(Error).Code() != ErrNoOffset {
 		t.Errorf("Commit() failed: %s", err)

--- a/kafka/consumer_test.go
+++ b/kafka/consumer_test.go
@@ -73,9 +73,10 @@ func TestConsumerAPIs(t *testing.T) {
 			t.Errorf("StoreOffsets() TopicPartition error: %s", toppar.Error)
 		}
 	}
-	stored, err = c.StoreOffsets(nil)
+	var empty []TopicPartition
+	stored, err = c.StoreOffsets(empty)
 	if err != nil {
-		t.Errorf("StoreOffsets(nil) failed: %s", err)
+		t.Errorf("StoreOffsets(empty) failed: %s", err)
 	}
 
 	topic1 := "gotest1"

--- a/kafka/consumer_test.go
+++ b/kafka/consumer_test.go
@@ -54,7 +54,6 @@ func TestConsumerAPIs(t *testing.T) {
 	if err != nil {
 		t.Errorf("SubscribeTopics failed: %s", err)
 	}
-
 	_, err = c.Commit()
 	if err != nil && err.(Error).Code() != ErrNoOffset {
 		t.Errorf("Commit() failed: %s", err)
@@ -63,6 +62,20 @@ func TestConsumerAPIs(t *testing.T) {
 	err = c.Unsubscribe()
 	if err != nil {
 		t.Errorf("Unsubscribe failed: %s", err)
+	}
+
+	topic := "gotest"
+	stored, err := c.OffsetsStore([]TopicPartition{{Topic: &topic, Partition: 0, Offset: 1}})
+	if err != nil && err.(Error).Code() != ErrUnknownPartition {
+		t.Errorf("OffsetsStore() failed: %s", err)
+		toppar := stored[0]
+		if toppar.Error.(Error).Code() == ErrUnknownPartition {
+			t.Errorf("OffsetsStore() TopicPartition error: %s", toppar.Error)
+		}
+	}
+	stored, err = c.OffsetsStore(nil)
+	if err != nil {
+		t.Errorf("OffsetsStore(nil) failed: %s", err)
 	}
 
 	topic1 := "gotest1"


### PR DESCRIPTION
Expose librdkafka's `rd_kafka_offsets_store()` introduced in v0.11.0 (not yet released).

Consumer.OffsetsStore() allows manual control over the committed offsets without sacrificing auto-commit functionality.

I am not sure if returning the storedOffsets is the correct thing to do, we could stop returning them to keep the API cleaner, or return a list of the failed TopicPartitions.