### PR TITLE
fix unsafe.Pointer use to be compatible with cgo rules

### DIFF
--- a/kafka/producer.go
+++ b/kafka/producer.go
@@ -57,6 +57,8 @@ rd_kafka_resp_err_t do_produce (rd_kafka_t *rk,
 */
 import "C"
 
+var emptyByteSlice = []byte{0}
+
 // Producer implements a High-level Apache Kafka Producer instance
 type Producer struct {
 	events         chan Event
@@ -84,28 +86,15 @@ func (p *Producer) produce(msg *Message, msgFlags int, deliveryChan chan Event) 
 
 	crkt := p.handle.getRkt(*msg.TopicPartition.Topic)
 
-	var valp *byte
-	var keyp *byte
-	var empty byte
-	valLen := 0
-	keyLen := 0
-
-	if msg.Value != nil {
-		valLen = len(msg.Value)
-		// allow sending 0-length messages (as opposed to null messages)
-		if valLen > 0 {
-			valp = &msg.Value[0]
-		} else {
-			valp = &empty
-		}
+	valLen := len(msg.Value)
+	keyLen := len(msg.Key)
+	val := emptyByteSlice
+	if valLen > 0 {
+		val = msg.Value
 	}
-	if msg.Key != nil {
-		keyLen = len(msg.Key)
-		if keyLen > 0 {
-			keyp = &msg.Key[0]
-		} else {
-			keyp = &empty
-		}
+	key := emptyByteSlice
+	if keyLen > 0 {
+		key = msg.Key
 	}
 
 	var cgoid int
@@ -128,8 +117,8 @@ func (p *Producer) produce(msg *Message, msgFlags int, deliveryChan chan Event) 
 	cErr := C.do_produce(p.handle.rk, crkt,
 		C.int32_t(msg.TopicPartition.Partition),
 		C.int(msgFlags)|C.RD_KAFKA_MSG_F_COPY,
-		unsafe.Pointer(valp), C.size_t(valLen),
-		unsafe.Pointer(keyp), C.size_t(keyLen),
+		unsafe.Pointer(&val[0]), C.size_t(valLen),
+		unsafe.Pointer(&key[0]), C.size_t(keyLen),
 		C.int64_t(timestamp),
 		(C.uintptr_t)(cgoid))
 	if cErr != C.RD_KAFKA_RESP_ERR_NO_ERROR {


### PR DESCRIPTION
According to https://github.com/golang/go/issues/14210 it's necessary to take the address of a byte slice in the same expression as the cgo function invocation.

IE do this:

    C.f(unsafe.Pointer(&dst[0]))

And not this:

    tmp := unsafe.Pointer(&dst[0])
    C.f(tmp)

This PR will fix https://github.com/confluentinc/confluent-kafka-go/issues/24 without resorting to `CBytes`, and therefore avoiding a copy.