### PR TITLE
Close event channel when consumer is closed

### DIFF
--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -269,7 +269,7 @@ func (c *Consumer) Close() (err error) {
 		// Wait for consumerReader() to terminate (by closing readerTermChan)
 		close(c.readerTermChan)
 		c.handle.waitTerminated(1)
-
+		close(c.events)
 	}
 
 	C.rd_kafka_queue_destroy(c.handle.rkq)


### PR DESCRIPTION
This PR let `Consumer` to close `consumer.events` channel when calling `Consumer.Close()`. In this way, we can use the following code to consume data from `Consumer`, and exit automatically when `Consumer.Close()` is called.

```go
for ev := range consumer.Events() {
    // do something here
}
```