### PR TITLE
Simplify for loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ func main() {
 
 	c.SubscribeTopics([]string{"myTopic", "^aRegex.*[Tt]opic"}, nil)
 
-	for true {
+	for {
 		msg, err := c.ReadMessage(-1)
 		if err == nil {
 			fmt.Printf("Message on %s: %s\n", msg.TopicPartition, string(msg.Value))


### PR DESCRIPTION
In Golang `for {` would loop forever and is effectively the same as `for true {`.