### PR TITLE
Use librdkafka's new -static pkg-config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,26 +3,32 @@ go:
   - 1.7
   - 1.8
   - 1.9
-env:
-  global:
-    - PKG_CONFIG_PATH="$HOME/gopath/src/github.com/confluentinc/confluent-kafka-go/tmp-build/lib/pkgconfig"
-    - PATH="$PATH:$GOPATH/bin"
-  matrix:
-    - LIBRDKAFKA_VERSION=master
 osx_image: xcode9.2
 os:
   - linux
   - osx
+env:
+  global:
+    - PKG_CONFIG_PATH="$HOME/gopath/src/github.com/confluentinc/confluent-kafka-go/tmp-build/lib/pkgconfig"
+    - LD_LIBRARY_PATH="$HOME/gopath/src/github.com/confluentinc/confluent-kafka-go/tmp-build/lib"
+    - DYLD_LIBRARY_PATH="$HOME/gopath/src/github.com/confluentinc/confluent-kafka-go/tmp-build/lib"
+    - PATH="$PATH:$GOPATH/bin"
+    - LIBRDKAFKA_VERSION=master
+
+# Travis OSX worker has problems running our Go binaries for 1.7 and 1.8,
+# workaround for now is to skip exec for those.
+
 before_install:
   - rm -rf tmp-build
   - bash mk/bootstrap-librdkafka.sh ${LIBRDKAFKA_VERSION} tmp-build
   - go get -u github.com/golang/lint/golint
+  - if [[ $TRAVIS_OS_NAME == osx && $TRAVIS_GO_VERSION =~ ^1\.[78] ]] ; then touch .no_exec ; fi
 
 install:
   - go get -tags static ./...
-  - go install tags static ./...
+  - go install -tags static ./...
 
 script:
   - golint -set_exit_status ./...
-  - go test -timeout 60s -v -tags static ./...
-  - go-kafkacat --help
+  - if [[ ! -f .no_exec ]]; then go test -timeout 60s -v -tags static ./... ; fi
+  - if [[ ! -f .no_exec ]]; then go-kafkacat --help ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
     - PATH="$PATH:$GOPATH/bin"
   matrix:
     - LIBRDKAFKA_VERSION=master
+osx_image: xcode9.2
 os:
   - linux
   - osx
@@ -19,10 +20,9 @@ before_install:
 
 install:
   - go get -tags static ./...
-  - go install -tags static ./...
-  - (cd examples/go-kafkacat && go install -tags static)
+  - go install tags static ./...
 
 script:
   - golint -set_exit_status ./...
-  - go test -v -tags static ./...
+  - go test -timeout 60s -v -tags static ./...
   - go-kafkacat --help

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
   - 1.7
-  - 1.8rc3
+  - 1.8
   - 1.9
 env:
   global:

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Getting Started
 Installing librdkafka
 ---------------------
 
-This client for Go depends on librdkafka v0.11.0 or later, so you either need to install librdkafka through your OS/distributions package manager,
+This client for Go depends on librdkafka v0.11.4 or later, so you either need to install librdkafka through your OS/distributions package manager,
 or download and build it from source.
 
 - For Debian and Ubuntu based distros, install `librdkafka-dev` from the standard

--- a/kafka/00version.go
+++ b/kafka/00version.go
@@ -30,19 +30,19 @@ import (
 //defines and strings in sync.
 //
 
-#define MIN_RD_KAFKA_VERSION 0x0000b0000
+#define MIN_RD_KAFKA_VERSION 0x0000b0400
 
 #ifdef __APPLE__
-#define MIN_VER_ERRSTR "confluent-kafka-go requires librdkafka v0.11.0 or later. Install the latest version of librdkafka from Homebrew by running `brew install librdkafka` or `brew upgrade librdkafka`"
+#define MIN_VER_ERRSTR "confluent-kafka-go requires librdkafka v0.11.4 or later. Install the latest version of librdkafka from Homebrew by running `brew install librdkafka` or `brew upgrade librdkafka`"
 #else
-#define MIN_VER_ERRSTR "confluent-kafka-go requires librdkafka v0.11.0 or later. Install the latest version of librdkafka from the Confluent repositories, see http://docs.confluent.io/current/installation.html"
+#define MIN_VER_ERRSTR "confluent-kafka-go requires librdkafka v0.11.4 or later. Install the latest version of librdkafka from the Confluent repositories, see http://docs.confluent.io/current/installation.html"
 #endif
 
 #if RD_KAFKA_VERSION < MIN_RD_KAFKA_VERSION
 #ifdef __APPLE__
-#error "confluent-kafka-go requires librdkafka v0.11.0 or later. Install the latest version of librdkafka from Homebrew by running `brew install librdkafka` or `brew upgrade librdkafka`"
+#error "confluent-kafka-go requires librdkafka v0.11.4 or later. Install the latest version of librdkafka from Homebrew by running `brew install librdkafka` or `brew upgrade librdkafka`"
 #else
-#error "confluent-kafka-go requires librdkafka v0.11.0 or later. Install the latest version of librdkafka from the Confluent repositories, see http://docs.confluent.io/current/installation.html"
+#error "confluent-kafka-go requires librdkafka v0.11.4 or later. Install the latest version of librdkafka from the Confluent repositories, see http://docs.confluent.io/current/installation.html"
 #endif
 #endif
 */

--- a/kafka/build_dynamic.go
+++ b/kafka/build_dynamic.go
@@ -4,5 +4,4 @@
 package kafka
 
 // #cgo pkg-config: rdkafka
-// #cgo LDFLAGS: -lrdkafka
 import "C"

--- a/kafka/build_static.go
+++ b/kafka/build_static.go
@@ -3,6 +3,5 @@
 
 package kafka
 
-// #cgo pkg-config: --static rdkafka
-// #cgo LDFLAGS: -Wl,-Bstatic -lrdkafka -Wl,-Bdynamic
+// #cgo pkg-config: rdkafka-static
 import "C"

--- a/kafka/build_static_all.go
+++ b/kafka/build_static_all.go
@@ -3,6 +3,6 @@
 
 package kafka
 
-// #cgo pkg-config: --static rdkafka
+// #cgo pkg-config: rdkafka-static
 // #cgo LDFLAGS: -static
 import "C"

--- a/kafka/integration_test.go
+++ b/kafka/integration_test.go
@@ -1027,7 +1027,7 @@ func TestProducerConsumerHeaders(t *testing.T) {
 	}
 
 	var firstOffset Offset = OffsetInvalid
-	for _ = range expMsgHeaders {
+	for range expMsgHeaders {
 		ev := <-drChan
 		m, ok := ev.(*Message)
 		if !ok {


### PR DESCRIPTION
Two reasons:
 * `pkg-config --static ..` doesn't really work well.
 * Go 1.10 added constraints to what compiler.et.al flags that may be passed, `pkg-config --static` was not one of them.
