### PR TITLE
Use same scheme as the HTML document in docs

### DIFF
--- a/mk/doc-gen.py
+++ b/mk/doc-gen.py
@@ -28,10 +28,10 @@ if __name__ == '__main__':
 
     # Use golang.org for external resources (such as CSS and JS)
     for t in soup.find_all(href=re.compile(r'^/')):
-        t['href'] = 'http://golang.org' + t['href']
+        t['href'] = '//golang.org' + t['href']
 
     for t in soup.find_all(src=re.compile(r'^/')):
-        t['src'] = 'http://golang.org' + t['src']
+        t['src'] = '//golang.org' + t['src']
 
     # Write updated HTML to stdout
     print(soup.prettify().encode('utf-8'))


### PR DESCRIPTION
Some browsers may not pull unencrypted resources that are referenced from encrypted pages. Which causes the styling to be broken on https://docs.confluent.io/current/clients/confluent-kafka-go/index.html in Chrome.

https://www.dropbox.com/s/zzcj5axukisyvk6/Screenshot%202018-04-30%2011.01.03.png?dl=0