### PR TITLE
defer p.Close() in producer, avoid memory leak

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ func main() {
 		panic(err)
 	}
 
+	defer p.Close()
+
 	// Delivery report handler for produced messages
 	go func() {
 		for e := range p.Events() {


### PR DESCRIPTION
Fixed bug memory leak (important bug !)

by closing Producer 