### PR TITLE
Fix metadata memory leak

### DIFF
--- a/kafka/metadata.go
+++ b/kafka/metadata.go
@@ -94,6 +94,7 @@ func getMetadata(H Handle, topic *string, allTopics bool, timeoutMs int) (*Metad
 	}
 
 	m := Metadata{}
+	defer C.rd_kafka_metadata_destroy(cMd)
 
 	m.Brokers = make([]BrokerMetadata, cMd.broker_cnt)
 	for i := 0; i < int(cMd.broker_cnt); i++ {


### PR DESCRIPTION
When GetMetadata is called, a C struct is created for holding this data,
but then is never released again after data is copied to a Go struct. This adds a release for that memory

I believe this addresses #210.