### PR TITLE
Fix so v0.9.2.x library will build

### DIFF
--- a/kafka/config.go
+++ b/kafka/config.go
@@ -128,7 +128,7 @@ func (cConf *rdkConf) set(cKey *C.char, cVal *C.char, cErrstr *C.char, errstrSiz
 }
 
 func (ctopicConf *rdkTopicConf) set(cKey *C.char, cVal *C.char, cErrstr *C.char, errstrSize int) C.rd_kafka_conf_res_t {
-	return C.rd_kafka_topic_conf_set((*C.rd_kafka_conf_t)(ctopicConf), cKey, cVal, cErrstr, C.size_t(errstrSize))
+	return C.rd_kafka_topic_conf_set((*C.rd_kafka_topic_conf_t)(ctopicConf), cKey, cVal, cErrstr, C.size_t(errstrSize))
 }
 
 func configConvertAnyconf(m ConfigMap, anyconf rdkAnyconf) (err error) {


### PR DESCRIPTION
### changes

Our kafka infrastructure is currently on 0.10.1, thus I needed to use the older version of this library.

This changeset fixes a type error so that when you run `go build` using this library on the `0.9.2.x` branch, it actually builds.

### testing

Running `go build` before this patch:

```
➜ dep ensure # to overwrite my local changes
➜ go build
# github.wouldntyouliketoknow.com/eng/kafkacat-go/vendor/github.com/confluentinc/confluent-kafka-go/kafka
vendor/github.com/confluentinc/confluent-kafka-go/kafka/config.go:131: cannot use (*_Ctype_struct_rd_kafka_conf_s)(ctopicConf) (type *_Ctype_struct_rd_kafka_conf_s) as type *_Ctype_struct_rd_kafka_topic_conf_s in argument to func literal
```

After the patch:

```
➜ cat confluent-kafka-go.patch
--- vendor/github.com/confluentinc/confluent-kafka-go/kafka/config.go	2018-08-07 11:30:50.000000000 -0700
+++ vendor/github.com/confluentinc/confluent-kafka-go/kafka/config.go.updated	2018-08-07 11:31:19.000000000 -0700
@@ -128,7 +128,7 @@
 }

 func (ctopicConf *rdkTopicConf) set(cKey *C.char, cVal *C.char, cErrstr *C.char, errstrSize int) C.rd_kafka_conf_res_t {
-	return C.rd_kafka_topic_conf_set((*C.rd_kafka_conf_t)(ctopicConf), cKey, cVal, cErrstr, C.size_t(errstrSize))
+	return C.rd_kafka_topic_conf_set((*C.rd_kafka_topic_conf_t)(ctopicConf), cKey, cVal, cErrstr, C.size_t(errstrSize))
 }

 func configConvertAnyconf(m ConfigMap, anyconf rdkAnyconf) (err error) {
➜ patch -b -p0 < confluent-kafka-go.patch
➜ go build -a
➜ # built successfully
```

