### PR TITLE
mirror consumer.Close()

### DIFF
--- a/kafka/producer.go
+++ b/kafka/producer.go
@@ -346,7 +346,7 @@ func (p *Producer) Flush(timeoutMs int) int {
 
 // Close a Producer instance.
 // The Producer object or its channels are no longer usable after this call.
-func (p *Producer) Close() {
+func (p *Producer) Close() error {
 	// Wait for poller() (signaled by closing pollerTermChan)
 	// and channel_producer() (signaled by closing ProduceChannel)
 	close(p.pollerTermChan)
@@ -358,6 +358,7 @@ func (p *Producer) Close() {
 	p.handle.cleanup()
 
 	C.rd_kafka_destroy(p.handle.rk)
+	return nil
 }
 
 // NewProducer creates a new high-level Producer instance.


### PR DESCRIPTION
not necessarily required and maybe I'm just doing something wrong. Feel free to close.

### changes

Updates `kafka.Producer.Close()` to return an `error` like `kafka.Consumer.Close()` does. This way, I can write something like this:

```go
type ResourceCloser interface {
	Close() error
}

func CloseResourceWithTimeout(r ResourceCloser, name string, t time.Duration) {
	fmt.Fprintf(os.Stderr, "%% Closing %s\n", name)
	closeDone := make(chan struct{})
	go func() {
		r.Close()
		close(closeDone)
	}()
	select {
	case <-closeDone:
		fmt.Fprintf(os.Stderr, "%% Closed %s\n", name)
		break
	case <-time.After(t):
		fmt.Fprintf(os.Stderr, "%% Timed out waiting for %s to close, moving on\n", name)
		break
	}
}

CloseResourceWithTimeout(c, "consumer", 45 * time.Second)
CloseResourceWithTimeout(p, "producer", 45 * time.Second)
```

instead of having to have two identical functions for both `kafka.Consumer` and `kafka.Producer`.

Maybe I'm thinking about this incorrectly / am not understanding the correct way to do this in Go.