### PR TITLE
Support log exporting from librdkafka

### DIFF
--- a/kafka/consumer_test.go
+++ b/kafka/consumer_test.go
@@ -297,3 +297,31 @@ func TestConsumerOAuthBearerConfig(t *testing.T) {
 
 	c.Close()
 }
+
+func TestConsumerLog(t *testing.T) {
+	c, err := NewConsumer(&ConfigMap{
+		"debug":          "all",
+		"go.logs.channel.enable": true,
+		"group.id":       "gotest"})
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+
+	var count int
+	go func() {
+		for {
+			select {
+			case log, ok := <-c.Logs():
+				if !ok {
+					return
+				}
+				t.Logf("%s", log)
+				count++
+			}
+		}
+	}()
+
+	<-time.After(time.Second * 3)
+	c.Close()
+	t.Logf("Got %d logs from log channel", count)
+}

--- a/kafka/event.go
+++ b/kafka/event.go
@@ -19,6 +19,7 @@ package kafka
 import (
 	"fmt"
 	"os"
+	"time"
 	"unsafe"
 )
 
@@ -143,6 +144,48 @@ type OAuthBearerTokenRefresh struct {
 
 func (o OAuthBearerTokenRefresh) String() string {
 	return "OAuthBearerTokenRefresh"
+}
+
+func (h *handle) logPoll(channel chan Event, timeoutMs int, termChan chan bool, termBack chan string, name string) {
+	defer func() {
+		termBack <- "logPoll"
+	}()
+	for {
+		var evtype C.rd_kafka_event_type_t
+		var rkev *C.rd_kafka_event_t
+		var retval Event
+		retval = nil
+		rkev = C.rd_kafka_queue_poll(h.logq, C.int(timeoutMs))
+		if rkev != nil {
+			evtype = C.rd_kafka_event_type(rkev)
+			if evtype == C.RD_KAFKA_EVENT_LOG {
+				var facLog C.fetched_log_t
+				if C.rd_kafka_event_log(rkev, &(facLog.fac), &(facLog.str), &(facLog.level)) == 0 {
+					retval = LogEvent{
+						Name:      name,
+						Fac:       C.GoString(facLog.fac),
+						Str:       C.GoString(facLog.str),
+						Level:     int(facLog.level),
+						Timestamp: time.Now(),
+					}
+				}
+			}
+			C.rd_kafka_event_destroy(rkev)
+		}
+
+		if channel != nil && retval != nil {
+			select {
+			case channel <- retval:
+			case <-termChan:
+				return
+			}
+		} else {
+			select {
+			case <-termChan:
+				return
+			}
+		}
+	}
 }
 
 // eventPoll polls an event from the handler's C rd_kafka_queue_t,

--- a/kafka/glue_rdkafka.h
+++ b/kafka/glue_rdkafka.h
@@ -44,3 +44,9 @@ typedef struct fetched_c_msg {
   tmphdr_t *tmphdrs;
   size_t    tmphdrsCnt;
 } fetched_c_msg_t;
+
+typedef struct fetched_log {
+  const char *fac;
+  const char *str;
+  int level;
+} fetched_log_t;

--- a/kafka/handle.go
+++ b/kafka/handle.go
@@ -83,6 +83,10 @@ type handle struct {
 	rk  *C.rd_kafka_t
 	rkq *C.rd_kafka_queue_t
 
+	// Being Forwarded queue, init via rd_kafka_queue_new and rd_kafka_set_log_queue.
+	// Extract log from event via rd_kafka_event_log
+	logq *C.rd_kafka_queue_t
+
 	// Termination of background go-routines
 	terminatedChan chan string // string is go-routine name
 
@@ -136,6 +140,12 @@ func (h *handle) cleanup() {
 	if h.rkq != nil {
 		C.rd_kafka_queue_destroy(h.rkq)
 	}
+}
+
+func (h *handle) setupLogQueue() {
+	h.logq = C.rd_kafka_queue_new(h.rk)
+	/* let librdkafka forwarding log to internal log queue instead of print to stderr */
+	C.rd_kafka_set_log_queue(h.rk, h.logq)
 }
 
 // waitTerminated waits termination of background go-routines.

--- a/kafka/log.go
+++ b/kafka/log.go
@@ -1,0 +1,19 @@
+package kafka
+
+import (
+	"fmt"
+	"time"
+)
+
+// LogEvent represent the log from librdkafka internal log queue
+type LogEvent struct {
+	Name      string
+	Fac       string
+	Str       string
+	Level     int
+	Timestamp time.Time
+}
+
+func (le LogEvent) String() string {
+	return fmt.Sprintf("[%v][%s][%d][%s] %s", le.Timestamp.Format(time.RFC3339), le.Fac, le.Level, le.Name, le.Str)
+}


### PR DESCRIPTION
1. rd_kafka_queue_new when new a producer or consumer
2. set log.queue=true to tell librdkafka to forward log to internal log queue instead of print to stderr
3. forward the internal log queue from librdkafka to the new queue via rd_kafka_set_log_queue
4. a seperate goroutine to poll the new log queue