### PR TITLE
Add GetWatermarkOffsets API

### DIFF
--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -482,16 +482,15 @@ func (c *Consumer) GetMetadata(topic *string, allTopics bool, timeoutMs int) (*M
 	return getMetadata(c, topic, allTopics, timeoutMs)
 }
 
-// QueryWatermarkOffsets queries the broker for the low and high offsets for the given topic
-// and partition.
+// QueryWatermarkOffsets queries the broker for the low and high offsets for the given topic and partition.
 func (c *Consumer) QueryWatermarkOffsets(topic string, partition int32, timeoutMs int) (low, high int64, err error) {
 	return queryWatermarkOffsets(c, topic, partition, timeoutMs)
 }
 
 // GetWatermarkOffsets returns the cached low and high offsets for the given topic
 // and partition.  The high offset is populated on every fetch response or via calling QueryWatermarkOffsets.
-// The low offset is populated only when calling QueryWatermarkOffsets.  0 will be returned if
-// there is no cached offset for either value.
+// The low offset is populated every statistics.interval.ms if that value is set.
+// OffsetInvalid will be returned if there is no cached offset for either value.
 func (c *Consumer) GetWatermarkOffsets(topic string, partition int32) (low, high int64, err error) {
 	return getWatermarkOffsets(c, topic, partition)
 }

--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -482,10 +482,18 @@ func (c *Consumer) GetMetadata(topic *string, allTopics bool, timeoutMs int) (*M
 	return getMetadata(c, topic, allTopics, timeoutMs)
 }
 
-// QueryWatermarkOffsets returns the broker's low and high offsets for the given topic
+// QueryWatermarkOffsets queries the broker for the low and high offsets for the given topic
 // and partition.
 func (c *Consumer) QueryWatermarkOffsets(topic string, partition int32, timeoutMs int) (low, high int64, err error) {
 	return queryWatermarkOffsets(c, topic, partition, timeoutMs)
+}
+
+// GetWatermarkOffsets returns the cached low and high offsets for the given topic
+// and partition.  The high offset is populated on every fetch response or via calling QueryWatermarkOffsets.
+// The low offset is populated only when calling QueryWatermarkOffsets.  0 will be returned if
+// there is no cached offset for either value.
+func (c *Consumer) GetWatermarkOffsets(topic string, partition int32) (low, high int64, err error) {
+	return getWatermarkOffsets(c, topic, partition)
 }
 
 // OffsetsForTimes looks up offsets by timestamp for the given partitions.

--- a/kafka/integration_test.go
+++ b/kafka/integration_test.go
@@ -445,9 +445,7 @@ func TestConsumerGetWatermarkOffsets(t *testing.T) {
 		"bootstrap.servers":        testconf.Brokers,
 		"group.id":                 testconf.GroupID,
 		"session.timeout.ms":       6000,
-		"api.version.request":      "true",
 		"enable.auto.commit":       false,
-		"debug":                    ",",
 		"auto.offset.reset":        "earliest",
 	}
 	_ = config.updateFromTestconf()
@@ -475,18 +473,15 @@ func TestConsumerGetWatermarkOffsets(t *testing.T) {
 		}
 	}
 
-	queryLow, queryHigh, err := c.QueryWatermarkOffsets(testconf.Topic, 0, 5*1000)
+	_, queryHigh, err := c.QueryWatermarkOffsets(testconf.Topic, 0, 5*1000)
 	if err != nil {
 		t.Fatalf("Error querying watermark offsets: %s", err)
 	}
 
-	getLow, getHigh, err := c.GetWatermarkOffsets(testconf.Topic, 0)
+	// We are not currently testing the low watermark offset as it only gets set every 10s by the stats timer
+	_, getHigh, err := c.GetWatermarkOffsets(testconf.Topic, 0)
 	if err != nil {
 		t.Fatalf("Error getting watermark offsets: %s", err)
-	}
-
-	if queryLow != getLow {
-		t.Errorf("QueryWatermarkOffsets low[%d] does not equal GetWatermarkOffsets low[%d]", queryLow, getLow)
 	}
 
 	if queryHigh != getHigh {

--- a/kafka/integration_test.go
+++ b/kafka/integration_test.go
@@ -248,7 +248,7 @@ func producerTest(t *testing.T, testname string, testmsgs []*testmsgType, pc pro
 		"queue.buffering.max.messages": len(testmsgs),
 		"api.version.request":          "true",
 		"broker.version.fallback":      "0.9.0.1",
-		"acks": 1}
+		"acks":                         1}
 
 	conf.updateFromTestconf()
 
@@ -429,6 +429,68 @@ func TestConsumerQueryWatermarkOffsets(t *testing.T) {
 
 	if newmsgcnt-msgcnt != len(p0TestMsgs) {
 		t.Errorf("Incorrect offsets. Expected message count %d, got %d\n", len(p0TestMsgs), newmsgcnt-msgcnt)
+	}
+
+}
+
+//Test consumer GetWatermarkOffsets API
+func TestConsumerGetWatermarkOffsets(t *testing.T) {
+	if !testconfRead() {
+		t.Skipf("Missing testconf.json")
+	}
+
+	// Create consumer
+	config := &ConfigMap{
+		"go.events.channel.enable": true,
+		"bootstrap.servers":        testconf.Brokers,
+		"group.id":                 testconf.GroupID,
+		"session.timeout.ms":       6000,
+		"api.version.request":      "true",
+		"enable.auto.commit":       false,
+		"debug":                    ",",
+		"auto.offset.reset":        "earliest",
+	}
+	_ = config.updateFromTestconf()
+
+	c, err := NewConsumer(config)
+	if err != nil {
+		t.Fatalf("Unable to create consumer: %s", err)
+	}
+	defer func() { _ = c.Close() }()
+
+	err = c.Subscribe(testconf.Topic, nil)
+
+	// Prime topic with test messages
+	createTestMessages()
+	producerTest(t, "Priming producer", p0TestMsgs, producerCtrl{silent: true},
+		func(p *Producer, m *Message, drChan chan Event) {
+			p.ProduceChannel() <- m
+		})
+
+	// Wait for messages to be received so that we know the watermark offsets have been delivered
+	// with the fetch response
+	for ev := range c.Events() {
+		if _, ok := ev.(*Message); ok {
+			break
+		}
+	}
+
+	queryLow, queryHigh, err := c.QueryWatermarkOffsets(testconf.Topic, 0, 5*1000)
+	if err != nil {
+		t.Fatalf("Error querying watermark offsets: %s", err)
+	}
+
+	getLow, getHigh, err := c.GetWatermarkOffsets(testconf.Topic, 0)
+	if err != nil {
+		t.Fatalf("Error getting watermark offsets: %s", err)
+	}
+
+	if queryLow != getLow {
+		t.Errorf("QueryWatermarkOffsets low[%d] does not equal GetWatermarkOffsets low[%d]", queryLow, getLow)
+	}
+
+	if queryHigh != getHigh {
+		t.Errorf("QueryWatermarkOffsets high[%d] does not equal GetWatermarkOffsets high[%d]", queryHigh, getHigh)
 	}
 
 }

--- a/kafka/metadata.go
+++ b/kafka/metadata.go
@@ -173,12 +173,8 @@ func getWatermarkOffsets(H Handle, topic string, partition int32) (low, high int
 		return 0, 0, newError(e)
 	}
 
-	if cLow != C.RD_KAFKA_OFFSET_INVALID {
-		low = int64(cLow)
-	}
+	low = int64(cLow)
+	high = int64(cHigh)
 
-	if cHigh != C.RD_KAFKA_OFFSET_INVALID {
-		high = int64(cHigh)
-	}
 	return low, high, nil
 }

--- a/kafka/metadata.go
+++ b/kafka/metadata.go
@@ -156,3 +156,29 @@ func queryWatermarkOffsets(H Handle, topic string, partition int32, timeoutMs in
 	high = int64(cHigh)
 	return low, high, nil
 }
+
+// getWatermarkOffsets returns the clients cached low and high offsets for the given topic
+// and partition.
+func getWatermarkOffsets(H Handle, topic string, partition int32) (low, high int64, err error) {
+	h := H.gethandle()
+
+	ctopic := C.CString(topic)
+	defer C.free(unsafe.Pointer(ctopic))
+
+	var cLow, cHigh C.int64_t
+
+	e := C.rd_kafka_get_watermark_offsets(h.rk, ctopic, C.int32_t(partition),
+		&cLow, &cHigh)
+	if e != C.RD_KAFKA_RESP_ERR_NO_ERROR {
+		return 0, 0, newError(e)
+	}
+
+	if cLow != C.RD_KAFKA_OFFSET_INVALID {
+		low = int64(cLow)
+	}
+
+	if cHigh != C.RD_KAFKA_OFFSET_INVALID {
+		high = int64(cHigh)
+	}
+	return low, high, nil
+}


### PR DESCRIPTION
This PR exposes the [`rd_kafka_get_watermark_offsets`](https://github.com/edenhill/librdkafka/blob/8ea4c10549d5fab2d417e46f9a6e89c852c6e7b7/src/rdkafka.h#L2456) API as `GetWatermarkOffsets`

This is similar to `QueryWatermarkOffsets` except that it does not query the broker for the offsets, it will return the values that are internally cached on the client.  For the purposes of calculating the consumer lag, this is sufficient because the "high watermark" is returned with every fetch request so it will be available while consuming.  

Having this API allows consumers to calculate the lag while avoiding the overhead of either querying the broker or generating and parsing the statistics JSON 