### PR TITLE
Rename newGoError to NewError

### DIFF
--- a/kafka/adminapi.go
+++ b/kafka/adminapi.go
@@ -148,7 +148,7 @@ func ResourceTypeFromString(typeString string) (ResourceType, error) {
 	case "BROKER":
 		return ResourceBroker, nil
 	default:
-		return ResourceUnknown, newGoError(ErrInvalidArg)
+		return ResourceUnknown, NewError(ErrInvalidArg, "Unknown resource type", false)
 	}
 }
 

--- a/kafka/error.go
+++ b/kafka/error.go
@@ -40,8 +40,9 @@ func newError(code C.rd_kafka_resp_err_t) (err Error) {
 	return Error{ErrorCode(code), "", false}
 }
 
-func newGoError(code ErrorCode) (err Error) {
-	return Error{code, "", false}
+// NewError creates a new Error.
+func NewError(code ErrorCode, str string, fatal bool) (err Error) {
+	return Error{code, str, fatal}
 }
 
 func newErrorFromString(code ErrorCode, str string) (err Error) {


### PR DESCRIPTION
Makes possible to create `kafka.Error` objects which is useful for unit testing. 

Closes https://github.com/confluentinc/confluent-kafka-go/issues/302
