### PR TITLE
SASL_SSL why?

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ func main() {
 		"bootstrap.servers": "localhost",
 		"group.id":          "myGroup",
 		"auto.offset.reset": "earliest",
+		"security.protocol": "SASL_SSL",
 	})
 
 	if err != nil {


### PR DESCRIPTION
Invalid value "SASL_SSL" for configuration property "security.protocol"