### PR TITLE
Offset metadata

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,5 +1,6 @@
 consumer_channel_example/consumer_channel_example
 consumer_example/consumer_example
+consumer_offset_metadata/consumer_offset_metadata
 producer_channel_example/producer_channel_example
 producer_example/producer_example
 go-kafkacat/go-kafkacat

--- a/examples/README
+++ b/examples/README
@@ -3,6 +3,7 @@ Examples:
 
   consumer_channel_example - Channel based consumer
   consumer_example - Function & callback based consumer
+  consumer_offset_metadata - Commit offset with metadata
 
   producer_channel_example - Channel based producer
   producer_example - Function based producer

--- a/examples/consumer_offset_metadata/consumer_offset_metadata.go
+++ b/examples/consumer_offset_metadata/consumer_offset_metadata.go
@@ -1,0 +1,103 @@
+// Example function-based high-level Apache Kafka consumer
+package main
+
+/**
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// consumer_offset_metadata implements a consumer that commit offset with metadata that represents the state of the partition consumer at that point in time. The
+// metadata string can be used by another consumer to restore that state, so it can resume consumption.
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/confluentinc/confluent-kafka-go/kafka"
+)
+
+func main() {
+
+	if len(os.Args) < 6 {
+		fmt.Fprintf(os.Stderr, "Usage: %s <broker> <group> <topic> <partition> <offset> \"<metadata>\"\n",
+			os.Args[0])
+		os.Exit(1)
+	}
+
+	broker := os.Args[1]
+	group := os.Args[2]
+	topic := os.Args[3]
+	partition, err := strconv.Atoi(os.Args[4])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Invalid partition: %s\n", err)
+		os.Exit(1)
+	}
+	offset, err := strconv.Atoi(os.Args[5])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Invalid offset: %s\n", err)
+		os.Exit(1)
+	}
+
+	metadata := os.Args[6]
+
+	c, err := kafka.NewConsumer(&kafka.ConfigMap{
+		"bootstrap.servers": broker,
+		// Avoid connecting to IPv6 brokers:
+		// This is needed for the ErrAllBrokersDown show-case below
+		// when using localhost brokers on OSX, since the OSX resolver
+		// will return the IPv6 addresses first.
+		// You typically don't need to specify this configuration property.
+		"broker.address.family": "v4",
+		"group.id":              group,
+		"session.timeout.ms":    6000,
+		"enable.auto.commit":    "false",
+		"auto.offset.reset":     "earliest"})
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to create consumer: %s\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Created Consumer %v\n", c)
+
+	_, err = c.CommitOffsets([]kafka.TopicPartition{{
+		Topic:     &topic,
+		Partition: 0,
+		Metadata:  &metadata,
+		Offset:    kafka.Offset(offset),
+	}})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to commit offset: %s\n", err)
+		os.Exit(1)
+	}
+
+	committedOffsets, err := c.Committed([]kafka.TopicPartition{{Topic: &topic, Partition: int32(partition)}}, 100)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to fetch offset: %s\n", err)
+		os.Exit(1)
+	}
+
+	committedOffset := committedOffsets[0]
+
+	fmt.Printf("Committed partition %d offset: %d", committedOffset.Partition, committedOffset.Offset)
+
+	if committedOffset.Metadata != nil {
+		fmt.Printf(" metadata: %s", *committedOffset.Metadata)
+	} else {
+		fmt.Println("\n Looks like we fetch empty metadata. Ensure that librdkafka version > v1.1.0")
+	}
+
+	c.Close()
+}

--- a/examples/consumer_offset_metadata/consumer_offset_metadata.go
+++ b/examples/consumer_offset_metadata/consumer_offset_metadata.go
@@ -1,8 +1,8 @@
-// Example function-based high-level Apache Kafka consumer
+// Example Apache Kafka consumer that commit offset with metadata
 package main
 
 /**
- * Copyright 2016 Confluent Inc.
+ * Copyright 2019 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,9 @@ package main
  * limitations under the License.
  */
 
-// consumer_offset_metadata implements a consumer that commit offset with metadata that represents the state of the partition consumer at that point in time. The
-// metadata string can be used by another consumer to restore that state, so it can resume consumption.
+// consumer_offset_metadata implements a consumer that commit offset with metadata that represents the state
+// of the partition consumer at that point in time. The metadata string can be used by another consumer
+// to restore that state, so it can resume consumption.
 
 import (
 	"fmt"
@@ -54,16 +55,8 @@ func main() {
 
 	c, err := kafka.NewConsumer(&kafka.ConfigMap{
 		"bootstrap.servers": broker,
-		// Avoid connecting to IPv6 brokers:
-		// This is needed for the ErrAllBrokersDown show-case below
-		// when using localhost brokers on OSX, since the OSX resolver
-		// will return the IPv6 addresses first.
-		// You typically don't need to specify this configuration property.
-		"broker.address.family": "v4",
-		"group.id":              group,
-		"session.timeout.ms":    6000,
-		"enable.auto.commit":    "false",
-		"auto.offset.reset":     "earliest"})
+		"group.id":          group,
+	})
 
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to create consumer: %s\n", err)
@@ -74,7 +67,7 @@ func main() {
 
 	_, err = c.CommitOffsets([]kafka.TopicPartition{{
 		Topic:     &topic,
-		Partition: 0,
+		Partition: int32(partition),
 		Metadata:  &metadata,
 		Offset:    kafka.Offset(offset),
 	}})
@@ -83,7 +76,10 @@ func main() {
 		os.Exit(1)
 	}
 
-	committedOffsets, err := c.Committed([]kafka.TopicPartition{{Topic: &topic, Partition: int32(partition)}}, 100)
+	committedOffsets, err := c.Committed([]kafka.TopicPartition{{
+		Topic:     &topic,
+		Partition: int32(partition),
+	}}, 100)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to fetch offset: %s\n", err)
 		os.Exit(1)

--- a/kafka/kafka.go
+++ b/kafka/kafka.go
@@ -216,21 +216,13 @@ func newCPartsFromTopicPartitions(partitions []TopicPartition) (cparts *C.rd_kaf
 		rktpar.offset = C.int64_t(part.Offset)
 
 		if part.Metadata != nil {
-			cmetadata := convertToCStringNoNull(*part.Metadata)
-			rktpar.metadata = cmetadata
+			cmetadata := C.CString(*part.Metadata)
+			rktpar.metadata = unsafe.Pointer(cmetadata)
 			rktpar.metadata_size = C.size_t(len(*part.Metadata))
 		}
 	}
 
 	return cparts
-}
-
-// Go string to C string without null character.
-func convertToCStringNoNull(s string) unsafe.Pointer {
-	p := C.malloc(C.size_t(uintptr(len(s))))
-	pp := (*[1 << 30]byte)(p)
-	copy(pp[:], s)
-	return p
 }
 
 func setupTopicPartitionFromCrktpar(partition *TopicPartition, crktpar *C.rd_kafka_topic_partition_t) {

--- a/kafka/kafka.go
+++ b/kafka/kafka.go
@@ -167,6 +167,7 @@ type TopicPartition struct {
 	Topic     *string
 	Partition int32
 	Offset    Offset
+	Metadata  *string
 	Error     error
 }
 
@@ -213,9 +214,23 @@ func newCPartsFromTopicPartitions(partitions []TopicPartition) (cparts *C.rd_kaf
 		defer C.free(unsafe.Pointer(ctopic))
 		rktpar := C.rd_kafka_topic_partition_list_add(cparts, ctopic, C.int32_t(part.Partition))
 		rktpar.offset = C.int64_t(part.Offset)
+
+		if part.Metadata != nil {
+			cmetadata := convertToCStringNoNull(*part.Metadata)
+			rktpar.metadata = cmetadata
+			rktpar.metadata_size = C.size_t(len(*part.Metadata))
+		}
 	}
 
 	return cparts
+}
+
+// Go string to C string without null character.
+func convertToCStringNoNull(s string) unsafe.Pointer {
+	p := C.malloc(C.size_t(uintptr(len(s))))
+	pp := (*[1 << 30]byte)(p)
+	copy(pp[:], s)
+	return p
 }
 
 func setupTopicPartitionFromCrktpar(partition *TopicPartition, crktpar *C.rd_kafka_topic_partition_t) {
@@ -224,6 +239,12 @@ func setupTopicPartitionFromCrktpar(partition *TopicPartition, crktpar *C.rd_kaf
 	partition.Topic = &topic
 	partition.Partition = int32(crktpar.partition)
 	partition.Offset = Offset(crktpar.offset)
+	if crktpar.metadata_size > 0 {
+		size := C.int(crktpar.metadata_size)
+		cstr := (*C.char)(unsafe.Pointer(crktpar.metadata))
+		metadata := C.GoStringN(cstr, size)
+		partition.Metadata = &metadata
+	}
 	if crktpar.err != C.RD_KAFKA_RESP_ERR_NO_ERROR {
 		partition.Error = newError(crktpar.err)
 	}


### PR DESCRIPTION
Added ability to commit offset with metadata that represents the state of the partition consumer at that point in time. The metadata string can be used by another consumer to restore that state, so it can resume consumption.