### PR TITLE
#319: Add ClusterID and ControllerID to AdminClient.

### DIFF
--- a/kafka/adminapi.go
+++ b/kafka/adminapi.go
@@ -421,7 +421,7 @@ func (a *AdminClient) cConfigResourceToResult(cRes **C.rd_kafka_ConfigResource_t
 }
 
 
-// Returns the ClusterId as reported in broker metadata.
+// ClusterId returns the cluster ID as reported in broker metadata.
 //
 // Requires broker version >=0.10.0 and api.version.request=true.
 func (a *AdminClient) ClusterID(timeout time.Duration) (clusterID string, err error) {
@@ -437,7 +437,7 @@ func (a *AdminClient) ClusterID(timeout time.Duration) (clusterID string, err er
 	return clusterID, nil
 }
 
-// Returns the current ControllerId as reported in broker metadata.
+// ControllerID returns the current broker ID of the controller as reported in broker metadata.
 //
 // Requires broker version >=0.10.0 and api.version.request=true.
 func (a *AdminClient) ControllerID(timeout time.Duration) (controllerID int32, err error) {

--- a/kafka/adminapi.go
+++ b/kafka/adminapi.go
@@ -425,7 +425,7 @@ func (a *AdminClient) cConfigResourceToResult(cRes **C.rd_kafka_ConfigResource_t
 //
 // Requires broker version >=0.10.0 and api.version.request=true.
 func (a *AdminClient) ClusterID(timeout time.Duration) (clusterID string, err error) {
-	cClusterID := C.rd_kafka_clusterid(a.handle.rk, C.int(timeout.Milliseconds()))
+	cClusterID := C.rd_kafka_clusterid(a.handle.rk, C.int(timeout/time.Millisecond))
 	defer C.free(unsafe.Pointer(cClusterID))
 
 	if cClusterID == nil {
@@ -441,7 +441,7 @@ func (a *AdminClient) ClusterID(timeout time.Duration) (clusterID string, err er
 //
 // Requires broker version >=0.10.0 and api.version.request=true.
 func (a *AdminClient) ControllerID(timeout time.Duration) (controllerID int32, err error) {
-	controllerID = int32(C.rd_kafka_controllerid(a.handle.rk, C.int(timeout.Milliseconds())))
+	controllerID = int32(C.rd_kafka_controllerid(a.handle.rk, C.int(timeout/time.Millisecond)))
 
 	if controllerID < 0 {
 		err = newError(C.RD_KAFKA_RESP_ERR_REQUEST_TIMED_OUT)

--- a/kafka/adminapi.go
+++ b/kafka/adminapi.go
@@ -420,6 +420,37 @@ func (a *AdminClient) cConfigResourceToResult(cRes **C.rd_kafka_ConfigResource_t
 	return result, nil
 }
 
+
+// Returns the ClusterId as reported in broker metadata.
+//
+// Requires broker version >=0.10.0 and api.version.request=true.
+func (a *AdminClient) ClusterID(timeout time.Duration) (clusterID string, err error) {
+	cClusterID := C.rd_kafka_clusterid(a.handle.rk, C.int(timeout.Milliseconds()))
+	defer C.free(unsafe.Pointer(cClusterID))
+
+	if cClusterID == nil {
+		err = newError(C.RD_KAFKA_RESP_ERR_REQUEST_TIMED_OUT)
+		return "", err
+	}
+
+	clusterID = C.GoString(cClusterID)
+	return clusterID, nil
+}
+
+// Returns the current ControllerId as reported in broker metadata.
+//
+// Requires broker version >=0.10.0 and api.version.request=true.
+func (a *AdminClient) ControllerID(timeout time.Duration) (controllerID int32, err error) {
+	controllerID = int32(C.rd_kafka_controllerid(a.handle.rk, C.int(timeout.Milliseconds())))
+
+	if controllerID < 0 {
+		err = newError(C.RD_KAFKA_RESP_ERR_REQUEST_TIMED_OUT)
+		return controllerID, err
+	}
+
+	return controllerID, nil
+}
+
 // CreateTopics creates topics in cluster.
 //
 // The list of TopicSpecification objects define the per-topic partition count, replicas, etc.

--- a/kafka/adminapi.go
+++ b/kafka/adminapi.go
@@ -424,36 +424,63 @@ func (a *AdminClient) cConfigResourceToResult(cRes **C.rd_kafka_ConfigResource_t
 
 // ClusterID returns the cluster ID as reported in broker metadata.
 //
-// Returns an error C.RD_KAFKA_RESP_ERR__TIMED_OUT if the operation times out.
+// If the operation times out, it returns ErrTimedOut.
 //
-// Requires broker version >=0.10.0 and api.version.request=true.
+// Note on cancellation: The underlying C function call currently cannot be cancelled. That means
+// cancelling the context will block until the C function call returns, before returning the
+// cancellation error.
+//
+// Requires broker version >=0.10.0.
 func (a *AdminClient) ClusterID(ctx context.Context) (clusterID string, err error) {
-	cClusterID := C.rd_kafka_clusterid(a.handle.rk, C.int(Timeout(ctx)/time.Millisecond))
+	responseChan := make(chan *C.char, 1)
 
-	if cClusterID == nil {
-		err = newError(C.RD_KAFKA_RESP_ERR__TIMED_OUT)
-		return "", err
+	go func() {
+		responseChan <- C.rd_kafka_clusterid(a.handle.rk, cTimeoutFromContext(ctx))
+	}()
+
+	select {
+	case <-ctx.Done():
+		if cClusterID := <-responseChan; cClusterID != nil {
+			C.rd_kafka_mem_free(a.handle.rk, unsafe.Pointer(cClusterID))
+		}
+		return "", ctx.Err()
+
+	case cClusterID := <-responseChan:
+		if cClusterID == nil {
+			return "", newError(C.RD_KAFKA_RESP_ERR__TIMED_OUT)
+		}
+		defer C.rd_kafka_mem_free(a.handle.rk, unsafe.Pointer(cClusterID))
+		return C.GoString(cClusterID), nil
 	}
-
-	defer C.rd_kafka_mem_free(a.handle.rk, unsafe.Pointer(cClusterID))
-	clusterID = C.GoString(cClusterID)
-	return clusterID, nil
 }
 
 // ControllerID returns the current broker ID of the controller as reported in broker metadata.
 //
-// Returns an error C.RD_KAFKA_RESP_ERR__TIMED_OUT if the operation times out.
+// If the operation times out, it returns ErrTimedOut.
+//
+// Note on cancellation: The underlying C function call currently cannot be cancelled. That means
+// cancelling the context will block until the C function call returns, before returning the
+// cancellation error.
 //
 // Requires broker version >=0.10.0.
 func (a *AdminClient) ControllerID(ctx context.Context) (controllerID int32, err error) {
-	controllerID = int32(C.rd_kafka_controllerid(a.handle.rk, C.int(Timeout(ctx)/time.Millisecond)))
+	responseChan := make(chan int32, 1)
 
-	if controllerID < 0 {
-		err = newError(C.RD_KAFKA_RESP_ERR__TIMED_OUT)
-		return controllerID, err
+	go func() {
+		responseChan <- int32(C.rd_kafka_controllerid(a.handle.rk, cTimeoutFromContext(ctx)))
+	}()
+
+	select {
+	case <-ctx.Done():
+		<-responseChan
+		return 0, ctx.Err()
+
+	case controllerID := <-responseChan:
+		if controllerID < 0 {
+			return controllerID, newError(C.RD_KAFKA_RESP_ERR__TIMED_OUT)
+		}
+		return controllerID, nil
 	}
-
-	return controllerID, nil
 }
 
 // CreateTopics creates topics in cluster.

--- a/kafka/adminapi.go
+++ b/kafka/adminapi.go
@@ -421,7 +421,7 @@ func (a *AdminClient) cConfigResourceToResult(cRes **C.rd_kafka_ConfigResource_t
 }
 
 
-// ClusterId returns the cluster ID as reported in broker metadata.
+// ClusterID returns the cluster ID as reported in broker metadata.
 //
 // Requires broker version >=0.10.0 and api.version.request=true.
 func (a *AdminClient) ClusterID(timeout time.Duration) (clusterID string, err error) {

--- a/kafka/adminapi_test.go
+++ b/kafka/adminapi_test.go
@@ -228,6 +228,26 @@ func testAdminAPIs(what string, a *AdminClient, t *testing.T) {
 	if ctx.Err() != context.DeadlineExceeded {
 		t.Fatalf("Expected DeadlineExceeded, not %v", ctx.Err())
 	}
+
+	ctx, cancel = context.WithTimeout(context.Background(), expDuration)
+	defer cancel()
+	clusterID, err := a.ClusterID(ctx)
+	if err == nil {
+		t.Fatalf("Expected ClusterID to fail, but got result: %v", clusterID)
+	}
+	if ctx.Err() != context.DeadlineExceeded || err != context.DeadlineExceeded {
+		t.Fatalf("Expected DeadlineExceeded, not %v", ctx.Err())
+	}
+
+	ctx, cancel = context.WithTimeout(context.Background(), expDuration)
+	defer cancel()
+	controllerID, err := a.ControllerID(ctx)
+	if err == nil {
+		t.Fatalf("Expected ControllerID to fail, but got result: %v", controllerID)
+	}
+	if ctx.Err() != context.DeadlineExceeded || err != context.DeadlineExceeded {
+		t.Fatalf("Expected DeadlineExceeded, not %v", ctx.Err())
+	}
 }
 
 // TestAdminAPIs dry-tests most Admin APIs, no broker is needed.

--- a/kafka/context.go
+++ b/kafka/context.go
@@ -21,10 +21,11 @@ import (
 	"time"
 )
 
-// Timeout returns the remaining timeout in the given context, or 0 if no deadline/timeout was set.
-func Timeout(ctx context.Context) (timeout time.Duration) {
+// Timeout returns the remaining time after which work done on behalf of this context should be
+// canceled, or ok==false if no deadline/timeout is set.
+func Timeout(ctx context.Context) (timeout time.Duration, ok bool) {
 	if deadline, ok := ctx.Deadline(); ok {
-		return deadline.Sub(time.Now())
+		return deadline.Sub(time.Now()), true
 	}
-	return 0
+	return 0, false
 }

--- a/kafka/context.go
+++ b/kafka/context.go
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka
+
+import (
+	"context"
+	"time"
+)
+
+// Timeout returns the remaining timeout in the given context, or 0 if no deadline/timeout was set.
+func Timeout(ctx context.Context) (timeout time.Duration) {
+	if deadline, ok := ctx.Deadline(); ok {
+		return deadline.Sub(time.Now())
+	}
+	return 0
+}

--- a/kafka/context.go
+++ b/kafka/context.go
@@ -23,7 +23,7 @@ import (
 
 // Timeout returns the remaining time after which work done on behalf of this context should be
 // canceled, or ok==false if no deadline/timeout is set.
-func Timeout(ctx context.Context) (timeout time.Duration, ok bool) {
+func timeout(ctx context.Context) (timeout time.Duration, ok bool) {
 	if deadline, ok := ctx.Deadline(); ok {
 		return deadline.Sub(time.Now()), true
 	}

--- a/kafka/integration_test.go
+++ b/kafka/integration_test.go
@@ -1569,24 +1569,21 @@ func TestAdminClient_ClusterID(t *testing.T) {
 	config := &ConfigMap{"bootstrap.servers": testconf.Brokers}
 	if err := config.updateFromTestconf(); err != nil {
 		t.Fatalf("Failed to update test configuration: %s\n", err)
-		return
 	}
 
 	admin, err := NewAdminClient(config)
 	if err != nil {
 		t.Fatalf("Failed to create Admin client: %s\n", err)
-		return
 	}
 	defer admin.Close()
 
 	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
 	clusterID, err := admin.ClusterID(ctx)
 	if err != nil {
-		t.Errorf("Failed to get ClusterID: %s\n", err)
-		return
+		t.Fatalf("Failed to get ClusterID: %s\n", err)
 	}
 	if clusterID == "" {
-		t.Error("ClusterID is empty.")
+		t.Fatal("ClusterID is empty.")
 	}
 
 	t.Logf("ClusterID: %s\n", clusterID)
@@ -1601,25 +1598,25 @@ func TestAdminClient_ControllerID(t *testing.T) {
 	config := &ConfigMap{"bootstrap.servers": testconf.Brokers}
 	if err := config.updateFromTestconf(); err != nil {
 		t.Fatalf("Failed to update test configuration: %s\n", err)
-		return
 	}
 
-	admin, err := NewAdminClient(config)
+	producer, err := NewProducer(config)
+	if err != nil {
+		t.Fatalf("Failed to create Producer client: %s\n", err)
+	}
+	admin, err := NewAdminClientFromProducer(producer)
 	if err != nil {
 		t.Fatalf("Failed to create Admin client: %s\n", err)
-		return
 	}
 	defer admin.Close()
 
 	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
 	controllerID, err := admin.ControllerID(ctx)
 	if err != nil {
-		t.Errorf("Failed to get ControllerID: %s\n", err)
-		return
+		t.Fatalf("Failed to get ControllerID: %s\n", err)
 	}
 	if controllerID < 0 {
-		t.Errorf("ControllerID is negative: %d\n", controllerID)
-		return
+		t.Fatalf("ControllerID is negative: %d\n", controllerID)
 	}
 
 	t.Logf("ControllerID: %d\n", controllerID)

--- a/kafka/integration_test.go
+++ b/kafka/integration_test.go
@@ -1560,6 +1560,7 @@ func TestAdminGetMetadata(t *testing.T) {
 
 }
 
+// Test AdminClient ClusterID.
 func TestAdminClient_ClusterID(t *testing.T) {
 	if !testconfRead() {
 		t.Skipf("Missing testconf.json")
@@ -1567,26 +1568,31 @@ func TestAdminClient_ClusterID(t *testing.T) {
 
 	config := &ConfigMap{"bootstrap.servers": testconf.Brokers}
 	if err := config.updateFromTestconf(); err != nil {
-		t.Errorf("Failed to update test configuration: %s\n", err)
+		t.Fatalf("Failed to update test configuration: %s\n", err)
 		return
 	}
 
 	admin, err := NewAdminClient(config)
 	if err != nil {
-		t.Errorf("Failed to create Admin client: %s\n", err)
+		t.Fatalf("Failed to create Admin client: %s\n", err)
 		return
 	}
 	defer admin.Close()
 
-	clusterID, err := admin.ClusterID(time.Second)
+	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+	clusterID, err := admin.ClusterID(ctx)
 	if err != nil {
 		t.Errorf("Failed to get ClusterID: %s\n", err)
 		return
+	}
+	if clusterID == "" {
+		t.Error("ClusterID is empty.")
 	}
 
 	t.Logf("ClusterID: %s\n", clusterID)
 }
 
+// Test AdminClient ControllerID.
 func TestAdminClient_ControllerID(t *testing.T) {
 	if !testconfRead() {
 		t.Skipf("Missing testconf.json")
@@ -1594,20 +1600,25 @@ func TestAdminClient_ControllerID(t *testing.T) {
 
 	config := &ConfigMap{"bootstrap.servers": testconf.Brokers}
 	if err := config.updateFromTestconf(); err != nil {
-		t.Errorf("Failed to update test configuration: %s\n", err)
+		t.Fatalf("Failed to update test configuration: %s\n", err)
 		return
 	}
 
 	admin, err := NewAdminClient(config)
 	if err != nil {
-		t.Errorf("Failed to create Admin client: %s\n", err)
+		t.Fatalf("Failed to create Admin client: %s\n", err)
 		return
 	}
 	defer admin.Close()
 
-	controllerID, err := admin.ControllerID(time.Second)
+	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+	controllerID, err := admin.ControllerID(ctx)
 	if err != nil {
 		t.Errorf("Failed to get ControllerID: %s\n", err)
+		return
+	}
+	if controllerID < 0 {
+		t.Errorf("ControllerID is negative: %d\n", controllerID)
 		return
 	}
 

--- a/kafka/integration_test.go
+++ b/kafka/integration_test.go
@@ -1559,3 +1559,57 @@ func TestAdminGetMetadata(t *testing.T) {
 	t.Logf("Meta data for admin client: %v\n", metaData)
 
 }
+
+func TestAdminClient_ClusterID(t *testing.T) {
+	if !testconfRead() {
+		t.Skipf("Missing testconf.json")
+	}
+
+	config := &ConfigMap{"bootstrap.servers": testconf.Brokers}
+	if err := config.updateFromTestconf(); err != nil {
+		t.Errorf("Failed to update test configuration: %s\n", err)
+		return
+	}
+
+	admin, err := NewAdminClient(config)
+	if err != nil {
+		t.Errorf("Failed to create Admin client: %s\n", err)
+		return
+	}
+	defer admin.Close()
+
+	clusterID, err := admin.ClusterID(time.Second)
+	if err != nil {
+		t.Errorf("Failed to get ClusterID: %s\n", err)
+		return
+	}
+
+	t.Logf("ClusterID: %s\n", clusterID)
+}
+
+func TestAdminClient_ControllerID(t *testing.T) {
+	if !testconfRead() {
+		t.Skipf("Missing testconf.json")
+	}
+
+	config := &ConfigMap{"bootstrap.servers": testconf.Brokers}
+	if err := config.updateFromTestconf(); err != nil {
+		t.Errorf("Failed to update test configuration: %s\n", err)
+		return
+	}
+
+	admin, err := NewAdminClient(config)
+	if err != nil {
+		t.Errorf("Failed to create Admin client: %s\n", err)
+		return
+	}
+	defer admin.Close()
+
+	controllerID, err := admin.ControllerID(time.Second)
+	if err != nil {
+		t.Errorf("Failed to get ControllerID: %s\n", err)
+		return
+	}
+
+	t.Logf("ControllerID: %d\n", controllerID)
+}

--- a/kafka/time.go
+++ b/kafka/time.go
@@ -35,7 +35,7 @@ const (
 // cTimeoutInfinite;
 // If there is no time left in this context, it returns cTimeoutNoWait.
 func cTimeoutFromContext(ctx context.Context) C.int {
-	timeout, hasTimeout := Timeout(ctx)
+	timeout, hasTimeout := timeout(ctx)
 	if !hasTimeout {
 		return cTimeoutInfinite
 	}

--- a/kafka/time.go
+++ b/kafka/time.go
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka
+
+import "C"
+
+import (
+	"context"
+	"time"
+)
+
+const (
+	cTimeoutInfinite = C.int(-1) // Blocks indefinitely until completion.
+	cTimeoutNoWait   = C.int(0)  // Returns immediately without blocking.
+)
+
+// cTimeoutFromContext returns the remaining time after which work done on behalf of this context
+// should be canceled, in milliseconds.
+//
+// If no deadline/timeout is set, or if the timeout does not fit in an int32, it returns
+// cTimeoutInfinite;
+// If there is no time left in this context, it returns cTimeoutNoWait.
+func cTimeoutFromContext(ctx context.Context) C.int {
+	timeout, hasTimeout := Timeout(ctx)
+	if !hasTimeout {
+		return cTimeoutInfinite
+	}
+	if timeout <= 0 {
+		return cTimeoutNoWait
+	}
+
+	timeoutMs := int64(timeout / time.Millisecond)
+	if int64(int32(timeoutMs)) < timeoutMs {
+		return cTimeoutInfinite
+	}
+
+	return C.int(timeoutMs)
+}


### PR DESCRIPTION
Issue: https://github.com/confluentinc/confluent-kafka-go/issues/319