### PR TITLE
Fix spelling in a couple comments

### DIFF
--- a/kafka/config.go
+++ b/kafka/config.go
@@ -33,7 +33,7 @@ import "C"
 //  bool, int, string, any type with the standard String() interface
 type ConfigValue interface{}
 
-// ConfigMap is a map contaning standard librdkafka configuration properties as documented in:
+// ConfigMap is a map containing standard librdkafka configuration properties as documented in:
 // https://github.com/edenhill/librdkafka/tree/master/CONFIGURATION.md
 //
 // The special property "default.topic.config" (optional) is a ConfigMap

--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -265,7 +265,7 @@ func (c *Consumer) Events() chan Event {
 
 // ReadMessage polls the consumer for a message.
 //
-// This is a conveniance API that wraps Poll() and only returns
+// This is a convenience API that wraps Poll() and only returns
 // messages or errors. All other event types are discarded.
 //
 // The call will block for at most `timeout` waiting for


### PR DESCRIPTION
Learning how to use Go Kafka and noticed spelling mistakes in the comments of `kafka/consumer.go` and `kafka/config.go`