### PR TITLE
Added "go.logs.channel" property for passing an existing channel to log to

### DIFF
--- a/kafka/config.go
+++ b/kafka/config.go
@@ -237,6 +237,32 @@ func (m ConfigMap) extract(key string, defval ConfigValue) (ConfigValue, error) 
 	return v, nil
 }
 
+// extractLogConfig extracts generic go.logs.* configuration properties.
+func (m ConfigMap) extractLogConfig() (logsChanEnable bool, logsChan chan LogEvent, err error) {
+	v, err := m.extract("go.logs.channel.enable", false)
+	if err != nil {
+		return
+	}
+
+	logsChanEnable = v.(bool)
+
+	v, err = m.extract("go.logs.channel", nil)
+	if err != nil {
+		return
+	}
+
+	if v != nil {
+		logsChan = v.(chan LogEvent)
+	}
+
+	if logsChanEnable {
+		// Tell librdkafka to forward logs to the log queue
+		m.Set("log.queue=true")
+	}
+
+	return
+}
+
 func (m ConfigMap) clone() ConfigMap {
 	m2 := make(ConfigMap)
 	for k, v := range m {

--- a/kafka/consumer_test.go
+++ b/kafka/consumer_test.go
@@ -300,12 +300,19 @@ func TestConsumerOAuthBearerConfig(t *testing.T) {
 }
 
 func TestConsumerLog(t *testing.T) {
+	logsChan := make(chan LogEvent, 1000)
+
 	c, err := NewConsumer(&ConfigMap{
 		"debug":                  "all",
 		"go.logs.channel.enable": true,
+		"go.logs.channel":        logsChan,
 		"group.id":               "gotest"})
 	if err != nil {
 		t.Fatalf("%s", err)
+	}
+
+	if c.Logs() != logsChan {
+		t.Fatalf("Expected c.Logs() %v == logsChan %v", c.Logs(), logsChan)
 	}
 
 	expectedLogs := map[struct {
@@ -320,7 +327,7 @@ func TestConsumerLog(t *testing.T) {
 	go func() {
 		for {
 			select {
-			case log, ok := <-c.Logs():
+			case log, ok := <-logsChan:
 				if !ok {
 					return
 				}


### PR DESCRIPTION

.. and some refactoring.
.. and include the client instance name in the LogEvent.
.. and cache the client instance name to avoid CGo call for each stringification.