### PR TITLE
Add dummy Go file to librdkafka sub dir so it is not pruned during vendor import (#450)

### DIFF
--- a/kafka/kafka.go
+++ b/kafka/kafka.go
@@ -252,6 +252,7 @@ package kafka
 
 import (
 	"fmt"
+	// Make sure librdkafka/ sub-directory is included in vendor pulls.
 	_ "github.com/confluentinc/confluent-kafka-go/kafka/librdkafka"
 	"unsafe"
 )

--- a/kafka/kafka.go
+++ b/kafka/kafka.go
@@ -252,6 +252,7 @@ package kafka
 
 import (
 	"fmt"
+	_ "github.com/confluentinc/confluent-kafka-go/kafka/librdkafka"
 	"unsafe"
 )
 

--- a/kafka/librdkafka/librdkafka.go
+++ b/kafka/librdkafka/librdkafka.go
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package librdkafka
+
+// Need to export something so the file is not empty.
+var LibrdkafkaGoSubdir = true

--- a/kafka/librdkafka/librdkafka.go
+++ b/kafka/librdkafka/librdkafka.go
@@ -16,5 +16,6 @@
 
 package librdkafka
 
-// Need to export something so the file is not empty.
+// LibrdkafkaGoSubdir is a dummy variable needed to export something so the
+// file is not empty.
 var LibrdkafkaGoSubdir = true


### PR DESCRIPTION
Prior to this the librdkafka/ sub-directory (which contains headers and prebuilt librdkafka libs) would be pruned by `go mod vendor`.

Not sure how this will work with gopkg.in (since the package path wont match), but people should be using go modules.