### PR TITLE
docs tweaks

### DIFF
--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -361,7 +361,7 @@ func (c *Consumer) Close() (err error) {
 //                                        If set to true the app must handle the AssignedPartitions and
 //                                        RevokedPartitions events and call Assign() and Unassign()
 //                                        respectively.
-//   go.events.channel.enable (bool, false) - Enable the Events() channel. Messages and events will be pushed on the Events() channel and the Poll() interface will be disabled. (Experimental)
+//   go.events.channel.enable (bool, false) - [deprecated] Enable the Events() channel. Messages and events will be pushed on the Events() channel and the Poll() interface will be disabled.
 //   go.events.channel.size (int, 1000) - Events() channel size
 //   go.logs.channel.enable (bool, false) - Forward log to Logs() channel.
 //   go.logs.channel (chan kafka.LogEvent, nil) - Forward logs to application-provided channel instead of Logs(). Requires go.logs.channel.enable=true.
@@ -581,7 +581,7 @@ func (c *Consumer) Committed(partitions []TopicPartition, timeoutMs int) (offset
 // Typical use is to call Assignment() to get the partition list
 // and then pass it to Position() to get the current consume position for
 // each of the assigned partitions.
-// The conusme position is the next message to read from the partition.
+// The consume position is the next message to read from the partition.
 // i.e., the offset of the last message seen by the application + 1.
 func (c *Consumer) Position(partitions []TopicPartition) (offsets []TopicPartition, err error) {
 	cparts := newCPartsFromTopicPartitions(partitions)

--- a/kafka/kafka.go
+++ b/kafka/kafka.go
@@ -20,8 +20,9 @@
 //
 // High-level Consumer
 //
-// * Decide if you want to read messages and events from the `.Events()` channel
-// (set `"go.events.channel.enable": true`) or by calling `.Poll()`.
+// * Decide if you want to read messages and events by calling `.Poll()` or 
+// the deprecated option of using the `.Events()` channel. (If you want to use
+// `.Events()` channel then set `"go.events.channel.enable": true`).
 //
 // * Create a Consumer with `kafka.NewConsumer()` providing at
 // least the `bootstrap.servers` and `group.id` configuration properties.


### PR DESCRIPTION
- Fix typo
- change `experimental` to `deprecated` and move it earlier in the line so it's not lost in the scroll