### PR TITLE
Add support for go.delivery.report.fields

### DIFF
--- a/kafka/message.go
+++ b/kafka/message.go
@@ -135,10 +135,10 @@ func (h *handle) setupMessageFromC(msg *Message, cmsg *C.rd_kafka_message_t) {
 		msg.TopicPartition.Topic = &topic
 	}
 	msg.TopicPartition.Partition = int32(cmsg.partition)
-	if cmsg.payload != nil {
+	if cmsg.payload != nil && h.msgFields.Value {
 		msg.Value = C.GoBytes(unsafe.Pointer(cmsg.payload), C.int(cmsg.len))
 	}
-	if cmsg.key != nil {
+	if cmsg.key != nil && h.msgFields.Key {
 		msg.Key = C.GoBytes(unsafe.Pointer(cmsg.key), C.int(cmsg.key_len))
 	}
 	msg.TopicPartition.Offset = Offset(cmsg.offset)

--- a/kafka/producer.go
+++ b/kafka/producer.go
@@ -423,6 +423,8 @@ func (p *Producer) Purge(flags int) error {
 //                                     Note: timestamps and headers are not supported with this interface.
 //   go.delivery.reports (bool, true) - Forward per-message delivery reports to the
 //                                      Events() channel.
+//   go.delivery.report.fields (string, all) - Comma separated list of fields to enable for delivery reports.
+//                                             Allowed values: all, none (or empty string), key, value
 //   go.events.channel.size (int, 1000000) - Events().
 //   go.produce.channel.size (int, 1000000) - ProduceChannel() buffer size (in number of messages)
 //   go.logs.channel.enable (bool, false) - Forward log to Logs() channel.
@@ -460,6 +462,17 @@ func NewProducer(conf *ConfigMap) (*Producer, error) {
 		return nil, err
 	}
 	p.handle.fwdDr = v.(bool)
+
+	v, err = confCopy.extract("go.delivery.report.fields", "all")
+	if err != nil {
+		return nil, err
+	}
+
+	msgFields, err := newMessageFieldsFrom(v)
+	if err != nil {
+		return nil, err
+	}
+	p.handle.msgFields = msgFields
 
 	v, err = confCopy.extract("go.events.channel.size", 1000000)
 	if err != nil {


### PR DESCRIPTION
@edenhill 
This configuration property will allow users to enable/disable certain fields of the delivery reports to reduce allocations.

Only the key & value are currently supported

Addresses #524