### PR TITLE
Improve user experience when attempting unsupported cross-compilation

### DIFF
--- a/kafka/01nocgo.go
+++ b/kafka/01nocgo.go
@@ -1,0 +1,17 @@
+// +build !cgo
+
+package kafka
+
+///////////////////////////////////////////////////////////////////////////////
+// Cross-compilation is not supported, you must build your Linux application //
+// on a Linux machine or inside a Linux docker container.                    //
+//                                                                           //
+// There is no workaround for building an OSX application on Linux.          //
+//                                                                           //
+//                                                                           //
+// CGO_ENABLED must be enabled, which it is by default unless GOOS is set.   //
+///////////////////////////////////////////////////////////////////////////////
+import (
+	"ConfluentKafkaGo_CANT_BE_CROSS_COMPILED"
+	"ConfluentKafkaGo_REQUIRES_CGO_ENABLED"
+)

--- a/kafka/integration_test.go
+++ b/kafka/integration_test.go
@@ -1550,7 +1550,8 @@ func TestAdminClient_ClusterID(t *testing.T) {
 	}
 	defer admin.Close()
 
-	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
 	clusterID, err := admin.ClusterID(ctx)
 	if err != nil {
 		t.Fatalf("Failed to get ClusterID: %s\n", err)
@@ -1583,7 +1584,8 @@ func TestAdminClient_ControllerID(t *testing.T) {
 	}
 	defer admin.Close()
 
-	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
 	controllerID, err := admin.ControllerID(ctx)
 	if err != nil {
 		t.Fatalf("Failed to get ControllerID: %s\n", err)


### PR DESCRIPTION
This is how it will look to the user:

```bash
$ GOOS=linux go build
../confluent-kafka-go/kafka/01nocgo.go:15:2: cannot find package "ConfluentKafkaGo_CANT_BE_CROSS_COMPILED" in any of:
	/usr/local/bin/go/src/ConfluentKafkaGo_CANT_BE_CROSS_COMPILED (from $GOROOT)
../confluent-kafka-go/kafka/01nocgo.go:16:2: cannot find package "ConfluentKafkaGo_REQUIRES_CGO_ENABLED" in any of:
	/usr/local/bin/go/src/ConfluentKafkaGo_REQUIRES_CGO_ENABLED (from $GOROOT)
```

Which, despite the hack of using dummy imports, provides a far more useful
error message than the current:

```bash
$ GOOS=linux go build
 .....: undefined: "gopkg.in/confluentinc/confluent-kafka-go.v1/kafka".Event
 .....: undefined: "gopkg.in/confluentinc/confluent-kafka-go.v1/kafka".Message
 ....
 ...lots of lines..
```