### PR TITLE
Added ASF notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,6 @@ for the balanced consumer groups of Apache Kafka 0.9 and above.
 
 See the [API documentation](http://docs.confluent.io/current/clients/confluent-kafka-go/index.html) for more information.
 
-**License**: [Apache License v2.0](http://www.apache.org/licenses/LICENSE-2.0)
-
 
 Examples
 ========
@@ -317,14 +315,20 @@ Cons:
 
 See [examples/producer_example](examples/producer_example)
 
+License
+=======
 
-Tests
-=====
+[Apache License v2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+KAFKA is a registered trademark of The Apache Software Foundation and has been licensed for use
+by confluent-kafka-go. confluent-kafka-go has no affiliation with and is not endorsed by The Apache
+Software Foundation.
+
+Developer Notes
+===============
 
 See [kafka/README](kafka/README.md)
 
-Contributing
-------------
 Contributions to the code, examples, documentation, et.al, are very much appreciated.
 
 Make your changes, run gofmt, tests, etc, push your branch, create a PR, and [sign the CLA](http://clabot.confluent.io/cla).


### PR DESCRIPTION
[as with python] i think it makes sense to put this text after the license.
i think it's a bit too heavy though and low impact to be putting near the top, so i moved the license, and this down the bottom.
although i like the license up the top (it's something to advertise), i don't see any issue in not doing this - people are used to seeking out license, and we don't make it hard to find (there's a LICENSE.txt file).