### PR TITLE
Bump timeout on go test command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ install:
 script:
   # should be replaced with golangci-lint
   - if [[ -f .do_lint ]]; then golint -set_exit_status ./examples/... ./kafka/... ./kafkatest/... ; fi
-  - for dir in kafka ; do (cd $dir && go test -timeout 60s -v ${BUILD_TYPE} ./...) ; done
+  - for dir in kafka ; do (cd $dir && go test -timeout 180s -v ${BUILD_TYPE} ./...) ; done
   - go-kafkacat --help
   - library-version
   - (library-version | grep "$EXPECT_LINK_INFO") || (echo "Incorrect linkage, expected $EXPECT_LINK_INFO" ; false)


### PR DESCRIPTION
It seems the travis tests are failing because they're timing out. Bumping the timeout to see if that fixes it, or if the timeout is actually the result of some other brokenness.

EDIT: yeah that seems to be all it took. @mhowlett What do you think, should we merge this?