### PR TITLE
Default parameters for AdminClient#createTopic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Confluent's Golang client for Apache Kafka
 
+## v1.7.0
+
+### Fixes
+
+* AdminClient.CreateTopics() previously did not accept default value(-1) of
+  ReplicationFactor without specifying an explicit ReplicaAssignment, this is
+  now fixed.
+
+
+
 ## v1.6.1
 
 v1.6.1 is a feature release:

--- a/kafka/adminapi.go
+++ b/kafka/adminapi.go
@@ -514,10 +514,6 @@ func (a *AdminClient) CreateTopics(ctx context.Context, topics []TopicSpecificat
 				return nil, newErrorFromString(ErrInvalidArg,
 					"TopicSpecification.ReplicaAssignment must contain exactly TopicSpecification.NumPartitions partitions")
 			}
-
-		} else if cReplicationFactor == -1 {
-			return nil, newErrorFromString(ErrInvalidArg,
-				"TopicSpecification.ReplicationFactor or TopicSpecification.ReplicaAssignment must be specified")
 		}
 
 		cTopics[i] = C.rd_kafka_NewTopic_new(


### PR DESCRIPTION
This is the fix for https://github.com/confluentinc/confluent-kafka-go/issues/616

librdkafka supports AdminClient.CreateTopics(...) with default value(-1) of NumPartitions and ReplicationFactor, but currently it's not possible to pass a value of -1 or 0 for ReplicationFactor to CreateTopics without specifying an explicit ReplicaAssignment.