### PR TITLE
Fix Rebalance events behavior when config go.application.rebalance.enable to true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Confluent's Golang client for Apache Kafka
 
+## v1.8.0
+
+v1.8.0 is a maintenance release with the following fixes and enhancements:
+
+### Fixes
+
+* Fix Rebalance events behavior when config go.application.rebalance.enable to true.
+
+confluent-kafka-go is based on librdkafka v1.8.0, see the
+[librdkafka release notes](https://github.com/edenhill/librdkafka/releases/tag/v1.8.0)
+for a complete list of changes, enhancements, fixes and upgrade considerations.
+
+
 ## v1.7.0
 
 confluent-kafka-go is based on librdkafka v1.7.0, see the

--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -905,5 +905,5 @@ func (c *Consumer) handleRebalanceEvent(channel chan Event, rkev *C.rd_kafka_eve
 		c.events <- newError(cErr)
 	}
 
-	return nil
+	return ev
 }


### PR DESCRIPTION
The behaviour of "go.application.rebalance.enable": true appears to have changed with v1.6.1, with neither kafka.AssignedPartitions or kafka.RevokedPartitions being returned by Poll().

```
Local Test:
jliu@C02DM32YMD6T kafka % go test -run TestConsumerRebalanceEvents
Consumer closed
Consumer closed
COOPERATIVE rebalance: 4 new partition(s) assigned: [testConsumerRebalanceEvents[0]@unset testConsumerRebalanceEvents[1]@unset testConsumerRebalanceEvents[2]@unset testConsumerRebalanceEvents[3]@unset]
COOPERATIVE rebalance: 4 partition(s) revoked: [testConsumerRebalanceEvents[0]@unset testConsumerRebalanceEvents[1]@unset testConsumerRebalanceEvents[2]@unset testConsumerRebalanceEvents[3]@unset]
Consumer closed
EAGER rebalance: 4 new partition(s) assigned: [testConsumerRebalanceEvents[0]@unset testConsumerRebalanceEvents[1]@unset testConsumerRebalanceEvents[2]@unset testConsumerRebalanceEvents[3]@unset]
EAGER rebalance: 4 partition(s) revoked: [testConsumerRebalanceEvents[0]@unset testConsumerRebalanceEvents[1]@unset testConsumerRebalanceEvents[2]@unset testConsumerRebalanceEvents[3]@unset]
Consumer closed
PASS
ok  	_/Users/jliu/Documents/Code/jliunyu/confluent-kafka-go/kafka	0.198s
```