### PR TITLE
Update imports in README to use github imports instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ High-level balanced consumer
 ```golang
 import (
 	"fmt"
-	"gopkg.in/confluentinc/confluent-kafka-go.v1/kafka"
+	"github.com/confluentinc/confluent-kafka-go/kafka"
 )
 
 func main() {
@@ -75,7 +75,7 @@ Producer
 ```golang
 import (
 	"fmt"
-	"gopkg.in/confluentinc/confluent-kafka-go.v1/kafka"
+	"github.com/confluentinc/confluent-kafka-go/kafka"
 )
 
 func main() {


### PR DESCRIPTION
Using the examples verbatim from the README as a quick start, you run into this problem https://github.com/confluentinc/confluent-kafka-go/issues/510

Using github imports solves the issue, especially for new users quickly