### PR TITLE
Correct InitTransactions() method comment

### DIFF
--- a/kafka/producer.go
+++ b/kafka/producer.go
@@ -722,14 +722,6 @@ func (p *Producer) SetOAuthBearerTokenFailure(errstr string) error {
 // will acquire the internal producer id and epoch, used in all future
 // transactional messages issued by this producer instance.
 //
-// Upon successful return from this function the application has to perform at
-// least one of the following operations within `transaction.timeout.ms` to
-// avoid timing out the transaction on the broker:
-//  * `Produce()` (et.al)
-//  * `SendOffsetsToTransaction()`
-//  * `CommitTransaction()`
-//  * `AbortTransaction()`
-//
 // Parameters:
 //  * `ctx` - The maximum time to block, or nil for indefinite.
 //            On timeout the operation may continue in the background,


### PR DESCRIPTION
Remove the following comment lines, since these only apply once BeginTransaction() has been called:
// Upon successful return from this function the application has to perform at
// least one of the following operations within `transaction.timeout.ms` to
// avoid timing out the transaction on the broker:
//  * `Produce()` (et.al)
//  * `SendOffsetsToTransaction()`
//  * `CommitTransaction()`
//  * `AbortTransaction()`
