### PR TITLE
Added convenience method StoreMessage that calls StoreOffsets

### DIFF
--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -292,6 +292,17 @@ func (c *Consumer) StoreOffsets(offsets []TopicPartition) (storedOffsets []Topic
 	return storedOffsets, nil
 }
 
+// StoreMessage stores offset based on the provided message.
+// This is a convenience method that uses StoreOffsets to do the actual work
+func (c *Consumer) StoreMessage(m *Message) (storedOffsets []TopicPartition, err error) {
+	if m.TopicPartition.Error != nil {
+		return nil, newErrorFromString(ErrInvalidArg, "Can't store errored message")
+	}
+	offsets := []TopicPartition{m.TopicPartition}
+	offsets[0].Offset++
+	return c.StoreOffsets(offsets)
+}
+
 // Seek seeks the given topic partitions using the offset from the TopicPartition.
 //
 // If timeoutMs is not 0 the call will wait this long for the

--- a/kafka/consumer_test.go
+++ b/kafka/consumer_test.go
@@ -85,6 +85,16 @@ func TestConsumerAPIs(t *testing.T) {
 		t.Errorf("StoreOffsets(empty) failed: %s", err)
 	}
 
+	// test StoreMessage doesn't fail either
+	stored, err = c.StoreMessage(&Message{TopicPartition: TopicPartition{Topic: &topic, Partition: 0, Offset: 1}})
+	if err != nil && err.(Error).Code() != ErrUnknownPartition {
+		t.Errorf("StoreMessage() failed: %s", err)
+		toppar := stored[0]
+		if toppar.Error != nil && toppar.Error.(Error).Code() == ErrUnknownPartition {
+			t.Errorf("StoreMessage() TopicPartition error: %s", toppar.Error)
+		}
+	}
+
 	topic1 := "gotest1"
 	topic2 := "gotest2"
 	err = c.Assign([]TopicPartition{{Topic: &topic1, Partition: 2},


### PR DESCRIPTION
If you have "enable.auto.commit" set to true, but "enable.auto.offset.store" set to false then you need to call  StoreOffsets after the consumer processing has completed, but at this stage you only have the message that was fetched, not the offsets.
This means that you end up writing code like this all over the place:
`if m.TopicPartition.Error != nil {
		return nil, newErrorFromString(ErrInvalidArg, "Can't store errored message")
	}
	offsets := []TopicPartition{m.TopicPartition}
	offsets[0].Offset++
	return c.StoreOffsets(offsets)`

This PR adds a convenience method StoreMessage that does this for you. This is similar to the CommitMessage method in that it simply gets the offset to store from the message.