### PR TITLE
Silence golang static checker

### DIFF
--- a/examples/consumer_example/consumer_example.go
+++ b/examples/consumer_example/consumer_example.go
@@ -65,7 +65,7 @@ func main() {
 
 	run := true
 
-	for run == true {
+	for run {
 		select {
 		case sig := <-sigchan:
 			fmt.Printf("Caught signal %v: terminating\n", sig)


### PR DESCRIPTION
static check complaining that `== true` is superfluous for a boolean var.