### PR TITLE
Producer: fixed events to be sent even when no error

### DIFF
--- a/kafka/producer.go
+++ b/kafka/producer.go
@@ -557,8 +557,8 @@ func channelProducer(p *Producer) {
 		err := p.produce(m, C.RD_KAFKA_MSG_F_BLOCK, nil)
 		if err != nil {
 			m.TopicPartition.Error = err
-			p.events <- m
 		}
+		p.events <- m
 	}
 }
 
@@ -603,11 +603,11 @@ func channelBatchProducer(p *Producer) {
 
 		for topic, buffered2 := range buffered {
 			err := p.produceBatch(topic, buffered2, C.RD_KAFKA_MSG_F_BLOCK)
-			if err != nil {
-				for _, m = range buffered2 {
+			for _, m = range buffered2 {
+				if err != nil {
 					m.TopicPartition.Error = err
-					p.events <- m
 				}
+				p.events <- m
 			}
 		}
 


### PR DESCRIPTION
Hi,

It looks like actually, message events are sent only when an error occurred on the broker.

This PR simply allows to send them in call cases (which I think should be the case).

Could you please confirm?

Thank you