### PR TITLE
Expose consumer member ID

### DIFF
--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -910,11 +910,11 @@ func (c *Consumer) handleRebalanceEvent(channel chan Event, rkev *C.rd_kafka_eve
 
 // MemberID returns this client's broker-assigned group member id.
 func(c *Consumer) MemberID() string {
-	cMemberId := C.rd_kafka_memberid(c.handle.rk)
+	cMemberID := C.rd_kafka_memberid(c.handle.rk)
 
-	if cMemberId != nil {
-		defer C.rd_kafka_mem_free(c.handle.rk, unsafe.Pointer(cMemberId))
-		return C.GoString(cMemberId)
+	if cMemberID != nil {
+		defer C.rd_kafka_mem_free(c.handle.rk, unsafe.Pointer(cMemberID))
+		return C.GoString(cMemberID)
 	}
 	return ""
 }


### PR DESCRIPTION
cc @KJTsanaktsidis @Strainy

Introduce `MemberID` method to `Consumer` so that it can be used for observability and debugging purposes.  

Covered by the CLA that signed by Zendesk. 