### PR TITLE
Fix Rebalance events behavior for static membership and fix for consu…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ This is a feature release:
    See [examples/mock_cluster](examples/mock_cluster).
 
 
+### Fixes
+
+ * Fix Rebalance events behavior for static membership (@jliunyu, #757).
+ * Fix consumer close taking 10 seconds when there's no rebalance
+   needed (@jliunyu, #757).
+
 confluent-kafka-go is based on librdkafka FUTUREFIXME, see the
 [librdkafka release notes](https://github.com/edenhill/librdkafka/releases/tag/v1.9.0)
 for a complete list of changes, enhancements, fixes and upgrade considerations.


### PR DESCRIPTION
…mer close takes longer than 10s
```
EAGER rebalance: 6 partition(s) revoked: [testrebalance[0]@unset testrebalance[1]@unset testrebalance[2]@unset testrebalance[3]@unset testrebalance[4]@unset testrebalance[5]@unset]
Ignored OffsetsCommitted (<nil>, [testrebalance[0]@953 testrebalance[1]@900 testrebalance[2]@919 testrebalance[3]@unset testrebalance[4]@857 testrebalance[5]@925]) for consumer rdkafka#consumer-1
rdkafka#consumer-1, EAGER rebalance: 3 new partition(s) assigned: [testrebalance[0]@unset testrebalance[1]@unset testrebalance[2]@unset]
rdkafka#consumer-2, EAGER rebalance: 3 new partition(s) assigned: [testrebalance[3]@unset testrebalance[4]@unset testrebalance[5]@unset]
Message on testrebalance[1]@900:
test
EAGER rebalance: 3 partition(s) revoked: [testrebalance[0]@unset testrebalance[1]@unset testrebalance[2]@unset]
Ignored OffsetsCommitted (<nil>, [testrebalance[0]@unset testrebalance[1]@901 testrebalance[2]@unset]) for consumer rdkafka#consumer-1
EAGER rebalance: 3 partition(s) revoked: [testrebalance[3]@unset testrebalance[4]@unset testrebalance[5]@unset]
rdkafka#consumer-2, EAGER rebalance: 2 new partition(s) assigned: [testrebalance[2]@unset testrebalance[3]@unset]
rdkafka#consumer-1, EAGER rebalance: 2 new partition(s) assigned: [testrebalance[0]@unset testrebalance[1]@unset]
rdkafka#consumer-3, EAGER rebalance: 2 new partition(s) assigned: [testrebalance[4]@unset testrebalance[5]@unset]
rdkafka#consumer-4, EAGER rebalance: 2 new partition(s) assigned: [testrebalance[2]@unset testrebalance[3]@unset]
PASS
ok  	_/Users/jliu/Documents/Code/jliunyu/confluent-kafka-go/kafka	38.019s
```

Manually tested for the `Close`, before this fix, the consumer takes more than 10s, with this fix, closing time: 730.602µs

```
consumer closed. closing time: 730.602µs
PASS
ok  	_/Users/jliu/Documents/Code/jliunyu/confluent-kafka-go/kafka	0.573s
```