### PR TITLE
Add frameworks for darwin

### DIFF
--- a/kafka/librdkafka_vendor/bundle-import.sh
+++ b/kafka/librdkafka_vendor/bundle-import.sh
@@ -61,6 +61,13 @@ setup_build() {
 
     echo "Generating $gpath (extra build tag: $build_tag)"
 
+    local ldflags="// #cgo LDFLAGS: \${SRCDIR}/librdkafka_vendor/${dpath} $dynlibs"
+    local framework_darwin=" -framework CoreFoundation -framework SystemConfiguration"
+
+    if [[ $btype == "darwin" ]]; then
+        ldflags+=$framework_darwin
+    fi
+
     cat >$gpath <<EOF
 // +build !dynamic
 $build_tag
@@ -70,7 +77,7 @@ $build_tag
 package kafka
 
 // #cgo CFLAGS: -DUSE_VENDORED_LIBRDKAFKA -DLIBRDKAFKA_STATICLIB
-// #cgo LDFLAGS: \${SRCDIR}/librdkafka_vendor/${dpath} $dynlibs
+${ldflags}
 import "C"
 
 // LibrdkafkaLinkInfo explains how librdkafka was linked to the Go client


### PR DESCRIPTION
After created a static bundle from librdkafka, when running the import.sh script to import the latest bundle, we hit this error and this PR fixed it.
```
[import_v1.9.0-RC2 7f49af6] librdkafka static bundle v1.9.0-RC2
 10 files changed, 1790 insertions(+), 1210 deletions(-)
Updating error codes and docs
~/Documents/Code/forRelease/confluent-kafka-go ~/Documents/Code/forRelease/confluent-kafka-go/kafka/librdkafka_vendor
(cd kafka/go_rdkafka_generr && go install)
# github.com/confluentinc/confluent-kafka-go/kafka
Undefined symbols for architecture x86_64:
  "_CFRelease", referenced from:
      _Curl_resolv in librdkafka_darwin.a(libcurl_la-hostip.o)
  "_SCDynamicStoreCopyProxies", referenced from:
      _Curl_resolv in librdkafka_darwin.a(libcurl_la-hostip.o)
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

With this fix, the generated build_darwin.go

```
// +build !dynamic


// This file was auto-generated by librdkafka_vendor/bundle-import.sh, DO NOT EDIT.

package kafka

// #cgo CFLAGS: -DUSE_VENDORED_LIBRDKAFKA -DLIBRDKAFKA_STATICLIB
// #cgo LDFLAGS: ${SRCDIR}/librdkafka_vendor/librdkafka_darwin.a  -lm -lsasl2 -ldl -lpthread -framework CoreFoundation -framework SystemConfiguration
import "C"

// LibrdkafkaLinkInfo explains how librdkafka was linked to the Go client
const LibrdkafkaLinkInfo = "static darwin from librdkafka-static-bundle-v1.9.0-RC2.tgz"
```

And other files generated using same file are not affected, for example: build_glibc_linux.go

```
// +build !dynamic
// +build !musl

// This file was auto-generated by librdkafka_vendor/bundle-import.sh, DO NOT EDIT.

package kafka

// #cgo CFLAGS: -DUSE_VENDORED_LIBRDKAFKA -DLIBRDKAFKA_STATICLIB
// #cgo LDFLAGS: ${SRCDIR}/librdkafka_vendor/librdkafka_glibc_linux.a  -lm -ldl -lpthread -lrt
import "C"

// LibrdkafkaLinkInfo explains how librdkafka was linked to the Go client
const LibrdkafkaLinkInfo = "static glibc_linux from librdkafka-static-bundle-v1.9.0-RC2.tgz"
```