### PR TITLE
Add service.yml for adding new project to semaphore CI

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -1,0 +1,12 @@
+name: confluent-kafka-go
+lang: go
+lang_version: 1.18
+# Add the following 2 lines if you want the automatically generated .semaphore files
+git:
+  enable: true
+github:
+  enable: true
+  repo_name: confluentinc/confluent-kafka-go # for example, confluentinc/cc-new-service
+semaphore:
+  enable: true
+

--- a/service.yml
+++ b/service.yml
@@ -8,4 +8,3 @@ github:
   repo_name: confluentinc/confluent-kafka-go
 semaphore:
   enable: true
-

--- a/service.yml
+++ b/service.yml
@@ -1,12 +1,11 @@
 name: confluent-kafka-go
 lang: go
 lang_version: 1.18
-# Add the following 2 lines if you want the automatically generated .semaphore files
 git:
   enable: true
 github:
   enable: true
-  repo_name: confluentinc/confluent-kafka-go # for example, confluentinc/cc-new-service
+  repo_name: confluentinc/confluent-kafka-go
 semaphore:
   enable: true
 


### PR DESCRIPTION
For semaphore CI migration, we need to first add new project to semaphore  CI.