### PR TITLE
Update the consumer close function with the latest rd_kafka_consumer_close_queue API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ This is a feature release:
 
 ### Fixes
 
- * Fix Rebalance events behavior for static membership (@jliunyu, #757).
+ * Fix Rebalance events behavior for static membership (@jliunyu, #757,
+   #798).
  * Fix consumer close taking 10 seconds when there's no rebalance
    needed (@jliunyu, #757).
 


### PR DESCRIPTION
Author @jliunyu.
Update the consumer close function with the latest rd_kafka_consumer_close_queue API