### PR TITLE
added copyright to some schema registry files and

### DIFF
--- a/examples/admin_create_acls/admin_create_acls.go
+++ b/examples/admin_create_acls/admin_create_acls.go
@@ -1,6 +1,3 @@
-// Create ACLs
-package main
-
 /**
  * Copyright 2022 Confluent Inc.
  *
@@ -16,6 +13,9 @@ package main
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+// Create ACLs
+package main
 
 import (
 	"context"

--- a/examples/admin_create_topic/admin_create_topic.go
+++ b/examples/admin_create_topic/admin_create_topic.go
@@ -1,6 +1,3 @@
-// Create topic
-package main
-
 /**
  * Copyright 2018 Confluent Inc.
  *
@@ -16,6 +13,9 @@ package main
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+// Create topic
+package main
 
 import (
 	"context"

--- a/examples/admin_delete_acls/admin_delete_acls.go
+++ b/examples/admin_delete_acls/admin_delete_acls.go
@@ -1,6 +1,3 @@
-// Delete ACLs
-package main
-
 /**
  * Copyright 2022 Confluent Inc.
  *
@@ -16,6 +13,9 @@ package main
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+// Delete ACLs
+package main
 
 import (
 	"context"

--- a/examples/admin_delete_topics/admin_delete_topics.go
+++ b/examples/admin_delete_topics/admin_delete_topics.go
@@ -1,6 +1,3 @@
-// Delete topics
-package main
-
 /**
  * Copyright 2018 Confluent Inc.
  *
@@ -16,6 +13,9 @@ package main
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+// Delete topics
+package main
 
 import (
 	"context"

--- a/examples/admin_describe_acls/admin_describe_acls.go
+++ b/examples/admin_describe_acls/admin_describe_acls.go
@@ -1,6 +1,3 @@
-// Describe ACLs
-package main
-
 /**
  * Copyright 2022 Confluent Inc.
  *
@@ -16,6 +13,9 @@ package main
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+// Describe ACLs
+package main
 
 import (
 	"context"

--- a/examples/admin_describe_config/admin_describe_config.go
+++ b/examples/admin_describe_config/admin_describe_config.go
@@ -1,6 +1,3 @@
-// List current configuration for a cluster resource
-package main
-
 /**
  * Copyright 2018 Confluent Inc.
  *
@@ -16,6 +13,9 @@ package main
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+// List current configuration for a cluster resource
+package main
 
 import (
 	"context"

--- a/examples/avro_generic_consumer_example/avro_generic_consumer_example.go
+++ b/examples/avro_generic_consumer_example/avro_generic_consumer_example.go
@@ -1,6 +1,3 @@
-// Example function-based high-level Apache Kafka consumer
-package main
-
 /**
  * Copyright 2022 Confluent Inc.
  *
@@ -16,6 +13,9 @@ package main
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+// Example function-based high-level Apache Kafka consumer
+package main
 
 // consumer_example implements a consumer using the non-channel Poll() API
 // to retrieve messages and events.

--- a/examples/avro_generic_producer_example/avro_generic_producer_example.go
+++ b/examples/avro_generic_producer_example/avro_generic_producer_example.go
@@ -1,6 +1,3 @@
-// Example function-based Apache Kafka producer
-package main
-
 /**
  * Copyright 2022 Confluent Inc.
  *
@@ -16,6 +13,9 @@ package main
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+// Example function-based Apache Kafka producer
+package main
 
 import (
 	"fmt"

--- a/examples/avro_specific_consumer_example/avro_specific_consumer_example.go
+++ b/examples/avro_specific_consumer_example/avro_specific_consumer_example.go
@@ -1,6 +1,3 @@
-// Example function-based high-level Apache Kafka consumer
-package main
-
 /**
  * Copyright 2022 Confluent Inc.
  *
@@ -16,6 +13,9 @@ package main
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+// Example function-based high-level Apache Kafka consumer
+package main
 
 // consumer_example implements a consumer using the non-channel Poll() API
 // to retrieve messages and events.

--- a/examples/confluent_cloud_example/confluent_cloud_example.go
+++ b/examples/confluent_cloud_example/confluent_cloud_example.go
@@ -1,12 +1,3 @@
-// This is a simple example demonstrating how to produce a message to
-// a topic, and then reading it back again using a consumer. The topic
-// belongs to a Apache Kafka cluster from Confluent Cloud. For more
-// information about Confluent Cloud, please visit:
-//
-// https://www.confluent.io/confluent-cloud/
-
-package main
-
 /**
  * Copyright 2018 Confluent Inc.
  *
@@ -22,6 +13,15 @@ package main
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+// This is a simple example demonstrating how to produce a message to
+// a topic, and then reading it back again using a consumer. The topic
+// belongs to a Apache Kafka cluster from Confluent Cloud. For more
+// information about Confluent Cloud, please visit:
+//
+// https://www.confluent.io/confluent-cloud/
+
+package main
 
 import (
 	"context"

--- a/examples/consumer_example/consumer_example.go
+++ b/examples/consumer_example/consumer_example.go
@@ -1,6 +1,3 @@
-// Example function-based high-level Apache Kafka consumer
-package main
-
 /**
  * Copyright 2016 Confluent Inc.
  *
@@ -16,6 +13,9 @@ package main
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+// Example function-based high-level Apache Kafka consumer
+package main
 
 // consumer_example implements a consumer using the non-channel Poll() API
 // to retrieve messages and events.

--- a/examples/consumer_offset_metadata/consumer_offset_metadata.go
+++ b/examples/consumer_offset_metadata/consumer_offset_metadata.go
@@ -1,6 +1,3 @@
-// Example Apache Kafka consumer that commit offset with metadata
-package main
-
 /**
  * Copyright 2019 Confluent Inc.
  *
@@ -16,6 +13,9 @@ package main
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+// Example Apache Kafka consumer that commit offset with metadata
+package main
 
 // consumer_offset_metadata implements a consumer that commit offset with metadata that represents the state
 // of the partition consumer at that point in time. The metadata string can be used by another consumer

--- a/examples/cooperative_consumer_example/cooperative_consumer_example.go
+++ b/examples/cooperative_consumer_example/cooperative_consumer_example.go
@@ -1,8 +1,3 @@
-// Example high-level Apache Kafka consumer using the
-// cooperative incremental rebalancing protocol which allows
-// seamless reassignment of partitions to other group members.
-package main
-
 /**
  * Copyright 2020 Confluent Inc.
  *
@@ -18,6 +13,11 @@ package main
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+// Example high-level Apache Kafka consumer using the
+// cooperative incremental rebalancing protocol which allows
+// seamless reassignment of partitions to other group members.
+package main
 
 import (
 	"fmt"

--- a/examples/go-kafkacat/go-kafkacat.go
+++ b/examples/go-kafkacat/go-kafkacat.go
@@ -1,6 +1,3 @@
-// Example kafkacat clone written in Golang
-package main
-
 /**
  * Copyright 2016 Confluent Inc.
  *
@@ -17,15 +14,19 @@ package main
  * limitations under the License.
  */
 
+// Example kafkacat clone written in Golang
+package main
+
 import (
 	"bufio"
 	"fmt"
-	"github.com/alecthomas/kingpin"
-	"github.com/confluentinc/confluent-kafka-go/kafka"
 	"os"
 	"os/signal"
 	"strings"
 	"syscall"
+
+	"github.com/alecthomas/kingpin"
+	"github.com/confluentinc/confluent-kafka-go/kafka"
 )
 
 var (

--- a/examples/idempotent_producer_example/idempotent_producer_example.go
+++ b/examples/idempotent_producer_example/idempotent_producer_example.go
@@ -1,16 +1,3 @@
-// Idempotent Producer example.
-//
-// The idempotent producer provides strict ordering and
-// exactly-once producing guarantees.
-//
-// From the application developer's perspective, the only difference
-// from a standard producer is the enabling of the feature by setting
-// the `enable.idempotence` configuration property to true, and
-// handling fatal errors (Error.IsFatal()) which are raised when the
-// idempotent guarantees can't be satisfied.
-
-package main
-
 /**
  * Copyright 2019 Confluent Inc.
  *
@@ -26,6 +13,19 @@ package main
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+// Idempotent Producer example.
+//
+// The idempotent producer provides strict ordering and
+// exactly-once producing guarantees.
+//
+// From the application developer's perspective, the only difference
+// from a standard producer is the enabling of the feature by setting
+// the `enable.idempotence` configuration property to true, and
+// handling fatal errors (Error.IsFatal()) which are raised when the
+// idempotent guarantees can't be satisfied.
+
+package main
 
 import (
 	"fmt"

--- a/examples/json_consumer_example/json_consumer_example.go
+++ b/examples/json_consumer_example/json_consumer_example.go
@@ -1,6 +1,3 @@
-// Example function-based high-level Apache Kafka consumer
-package main
-
 /**
  * Copyright 2022 Confluent Inc.
  *
@@ -16,6 +13,9 @@ package main
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+// Example function-based high-level Apache Kafka consumer
+package main
 
 // consumer_example implements a consumer using the non-channel Poll() API
 // to retrieve messages and events.

--- a/examples/json_producer_example/json_producer_example.go
+++ b/examples/json_producer_example/json_producer_example.go
@@ -1,6 +1,3 @@
-// Example function-based Apache Kafka producer
-package main
-
 /**
  * Copyright 2022 Confluent Inc.
  *
@@ -16,6 +13,9 @@ package main
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+// Example function-based Apache Kafka producer
+package main
 
 import (
 	"fmt"

--- a/examples/legacy/consumer_channel_example/consumer_channel_example.go
+++ b/examples/legacy/consumer_channel_example/consumer_channel_example.go
@@ -1,6 +1,3 @@
-// Example channel-based high-level Apache Kafka consumer
-package main
-
 /**
  * Copyright 2016 Confluent Inc.
  *
@@ -16,6 +13,9 @@ package main
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+// Example channel-based high-level Apache Kafka consumer
+package main
 
 import (
 	"fmt"

--- a/examples/legacy/producer_channel_example/producer_channel_example.go
+++ b/examples/legacy/producer_channel_example/producer_channel_example.go
@@ -1,6 +1,3 @@
-// Example channel-based Apache Kafka producer
-package main
-
 /**
  * Copyright 2016 Confluent Inc.
  *
@@ -16,6 +13,9 @@ package main
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+// Example channel-based Apache Kafka producer
+package main
 
 import (
 	"fmt"

--- a/examples/library-version/library-version.go
+++ b/examples/library-version/library-version.go
@@ -21,11 +21,11 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/confluentinc/confluent-kafka-go/kafka"
 )
 
-
-func main () {
+func main() {
 	vnum, vstr := kafka.LibraryVersion()
 	fmt.Printf("LibraryVersion: %s (0x%x)\n", vstr, vnum)
 	fmt.Printf("LinkInfo:       %s\n", kafka.LibrdkafkaLinkInfo)

--- a/examples/mockcluster_example/mockcluster.go
+++ b/examples/mockcluster_example/mockcluster.go
@@ -1,5 +1,3 @@
-package main
-
 /**
  * Copyright 2022 Confluent Inc.
  *
@@ -16,10 +14,13 @@ package main
  * limitations under the License.
  */
 
+package main
+
 import (
 	"fmt"
-	"github.com/confluentinc/confluent-kafka-go/kafka"
 	"os"
+
+	"github.com/confluentinc/confluent-kafka-go/kafka"
 )
 
 func main() {

--- a/examples/oauthbearer_example/oauthbearer_example.go
+++ b/examples/oauthbearer_example/oauthbearer_example.go
@@ -1,6 +1,3 @@
-// Example client with a custom OAUTHBEARER token implementation.
-package main
-
 /**
  * Copyright 2019 Confluent Inc.
  *
@@ -16,6 +13,9 @@ package main
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+// Example client with a custom OAUTHBEARER token implementation.
+package main
 
 import (
 	"encoding/base64"

--- a/examples/producer_custom_channel_example/producer_custom_channel_example.go
+++ b/examples/producer_custom_channel_example/producer_custom_channel_example.go
@@ -1,6 +1,3 @@
-// Example function-based Apache Kafka producer with a custom delivery channel
-package main
-
 /**
  * Copyright 2016 Confluent Inc.
  *
@@ -16,6 +13,9 @@ package main
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+// Example function-based Apache Kafka producer with a custom delivery channel
+package main
 
 import (
 	"fmt"

--- a/examples/producer_example/producer_example.go
+++ b/examples/producer_example/producer_example.go
@@ -1,6 +1,3 @@
-// Example function-based Apache Kafka producer
-package main
-
 /**
  * Copyright 2016 Confluent Inc.
  *
@@ -16,6 +13,9 @@ package main
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+// Example function-based Apache Kafka producer
+package main
 
 import (
 	"fmt"

--- a/examples/protobuf_consumer_example/protobuf_consumer_example.go
+++ b/examples/protobuf_consumer_example/protobuf_consumer_example.go
@@ -1,8 +1,5 @@
-// Example function-based high-level Apache Kafka consumer
-package main
-
 /**
- * Copyright 2016 Confluent Inc.
+ * Copyright 2022 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +13,9 @@ package main
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+// Example function-based high-level Apache Kafka consumer
+package main
 
 // consumer_example implements a consumer using the non-channel Poll() API
 // to retrieve messages and events.

--- a/examples/protobuf_producer_example/protobuf_producer_example.go
+++ b/examples/protobuf_producer_example/protobuf_producer_example.go
@@ -1,8 +1,5 @@
-// Example function-based Apache Kafka producer
-package main
-
 /**
- * Copyright 2016 Confluent Inc.
+ * Copyright 2022 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +13,9 @@ package main
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+// Example function-based Apache Kafka producer
+package main
 
 import (
 	"fmt"

--- a/examples/stats_example/stats_example.go
+++ b/examples/stats_example/stats_example.go
@@ -1,10 +1,3 @@
-// Example of a consumer handling statistics events.
-// The Stats handling code is the same for Consumers and Producers.
-//
-// The definition of the emitted statistics JSON object can be found here:
-// https://github.com/edenhill/librdkafka/blob/master/STATISTICS.md
-package main
-
 /**
  * Copyright 2019 Confluent Inc.
  *
@@ -20,6 +13,13 @@ package main
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+// Example of a consumer handling statistics events.
+// The Stats handling code is the same for Consumers and Producers.
+//
+// The definition of the emitted statistics JSON object can be found here:
+// https://github.com/edenhill/librdkafka/blob/master/STATISTICS.md
+package main
 
 import (
 	"encoding/json"

--- a/kafka/00version.go
+++ b/kafka/00version.go
@@ -1,5 +1,3 @@
-package kafka
-
 /**
  * Copyright 2016-2019 Confluent Inc.
  *
@@ -15,6 +13,8 @@ package kafka
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+package kafka
 
 import (
 	"fmt"

--- a/kafka/adminapi.go
+++ b/kafka/adminapi.go
@@ -1,5 +1,3 @@
-package kafka
-
 /**
  * Copyright 2018 Confluent Inc.
  *
@@ -15,6 +13,8 @@ package kafka
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+package kafka
 
 import (
 	"context"

--- a/kafka/adminoptions.go
+++ b/kafka/adminoptions.go
@@ -1,5 +1,3 @@
-package kafka
-
 /**
  * Copyright 2018 Confluent Inc.
  *
@@ -15,6 +13,8 @@ package kafka
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+package kafka
 
 import (
 	"fmt"

--- a/kafka/config.go
+++ b/kafka/config.go
@@ -1,5 +1,3 @@
-package kafka
-
 /**
  * Copyright 2016 Confluent Inc.
  *
@@ -15,6 +13,8 @@ package kafka
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+package kafka
 
 import (
 	"fmt"

--- a/kafka/config_test.go
+++ b/kafka/config_test.go
@@ -1,5 +1,3 @@
-package kafka
-
 /**
  * Copyright 2016 Confluent Inc.
  *
@@ -15,6 +13,8 @@ package kafka
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+package kafka
 
 import (
 	"fmt"

--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -1,5 +1,3 @@
-package kafka
-
 /**
  * Copyright 2016-2020 Confluent Inc.
  *
@@ -15,6 +13,8 @@ package kafka
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+package kafka
 
 import (
 	"fmt"

--- a/kafka/consumer_performance_test.go
+++ b/kafka/consumer_performance_test.go
@@ -1,5 +1,3 @@
-package kafka
-
 /**
  * Copyright 2016 Confluent Inc.
  *
@@ -15,6 +13,8 @@ package kafka
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+package kafka
 
 import (
 	"fmt"

--- a/kafka/consumer_test.go
+++ b/kafka/consumer_test.go
@@ -1,5 +1,3 @@
-package kafka
-
 /**
  * Copyright 2016 Confluent Inc.
  *
@@ -15,6 +13,8 @@ package kafka
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+package kafka
 
 import (
 	"fmt"

--- a/kafka/context.go
+++ b/kafka/context.go
@@ -1,5 +1,3 @@
-package kafka
-
 /**
  * Copyright 2019 Confluent Inc.
  *
@@ -15,6 +13,8 @@ package kafka
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+package kafka
 
 import (
 	"context"

--- a/kafka/error.go
+++ b/kafka/error.go
@@ -1,5 +1,3 @@
-package kafka
-
 /**
  * Copyright 2016 Confluent Inc.
  *
@@ -15,6 +13,8 @@ package kafka
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+package kafka
 
 // Automatically generate error codes from librdkafka
 // See README for instructions

--- a/kafka/error_gen.go
+++ b/kafka/error_gen.go
@@ -1,5 +1,3 @@
-package kafka
-
 /**
  * Copyright 2020 Confluent Inc.
  *
@@ -15,6 +13,8 @@ package kafka
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+package kafka
 
 // Automatically generate error codes from librdkafka
 // See README for instructions

--- a/kafka/error_test.go
+++ b/kafka/error_test.go
@@ -1,5 +1,3 @@
-package kafka
-
 /**
  * Copyright 2019 Confluent Inc.
  *
@@ -15,6 +13,8 @@ package kafka
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+package kafka
 
 import (
 	"strings"

--- a/kafka/event.go
+++ b/kafka/event.go
@@ -1,5 +1,3 @@
-package kafka
-
 /**
  * Copyright 2016 Confluent Inc.
  *
@@ -15,6 +13,8 @@ package kafka
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+package kafka
 
 import (
 	"fmt"

--- a/kafka/event_test.go
+++ b/kafka/event_test.go
@@ -1,5 +1,3 @@
-package kafka
-
 /**
  * Copyright 2016 Confluent Inc.
  *
@@ -15,6 +13,8 @@ package kafka
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+package kafka
 
 import (
 	"testing"

--- a/kafka/go_rdkafka_generr/go_rdkafka_generr.go
+++ b/kafka/go_rdkafka_generr/go_rdkafka_generr.go
@@ -1,6 +1,3 @@
-// confluent-kafka-go internal tool to generate error constants from librdkafka
-package main
-
 /**
  * Copyright 2016 Confluent Inc.
  *
@@ -17,9 +14,13 @@ package main
  * limitations under the License.
  */
 
+// confluent-kafka-go internal tool to generate error constants from librdkafka
+package main
+
 import (
-	"github.com/confluentinc/confluent-kafka-go/kafka"
 	"os"
+
+	"github.com/confluentinc/confluent-kafka-go/kafka"
 )
 
 func main() {

--- a/kafka/handle.go
+++ b/kafka/handle.go
@@ -1,5 +1,3 @@
-package kafka
-
 /**
  * Copyright 2016 Confluent Inc.
  *
@@ -15,6 +13,8 @@ package kafka
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+package kafka
 
 import (
 	"fmt"

--- a/kafka/header.go
+++ b/kafka/header.go
@@ -1,5 +1,3 @@
-package kafka
-
 /**
  * Copyright 2018 Confluent Inc.
  *
@@ -15,6 +13,8 @@ package kafka
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+package kafka
 
 import (
 	"fmt"

--- a/kafka/header_test.go
+++ b/kafka/header_test.go
@@ -1,5 +1,3 @@
-package kafka
-
 /**
  * Copyright 2016 Confluent Inc.
  *
@@ -15,6 +13,8 @@ package kafka
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+package kafka
 
 import (
 	"testing"

--- a/kafka/integration_test.go
+++ b/kafka/integration_test.go
@@ -1,5 +1,3 @@
-package kafka
-
 /**
  * Copyright 2016 Confluent Inc.
  *
@@ -15,6 +13,8 @@ package kafka
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+package kafka
 
 import (
 	"context"

--- a/kafka/message_test.go
+++ b/kafka/message_test.go
@@ -1,5 +1,3 @@
-package kafka
-
 /**
  * Copyright 2016 Confluent Inc.
  *
@@ -15,6 +13,8 @@ package kafka
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+package kafka
 
 import (
 	"testing"

--- a/kafka/metadata_test.go
+++ b/kafka/metadata_test.go
@@ -1,5 +1,3 @@
-package kafka
-
 /**
  * Copyright 2016 Confluent Inc.
  *
@@ -15,6 +13,8 @@ package kafka
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+package kafka
 
 import (
 	"testing"

--- a/kafka/misc.go
+++ b/kafka/misc.go
@@ -1,5 +1,3 @@
-package kafka
-
 /**
  * Copyright 2016 Confluent Inc.
  *
@@ -15,6 +13,8 @@ package kafka
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+package kafka
 
 import "C"
 

--- a/kafka/mockcluster.go
+++ b/kafka/mockcluster.go
@@ -1,5 +1,3 @@
-package kafka
-
 /**
  * Copyright 2022 Confluent Inc.
  *
@@ -15,6 +13,8 @@ package kafka
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+package kafka
 
 import "unsafe"
 

--- a/kafka/offset.go
+++ b/kafka/offset.go
@@ -1,5 +1,3 @@
-package kafka
-
 /**
  * Copyright 2017 Confluent Inc.
  *
@@ -15,6 +13,8 @@ package kafka
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+package kafka
 
 import (
 	"fmt"

--- a/kafka/producer_performance_test.go
+++ b/kafka/producer_performance_test.go
@@ -1,5 +1,3 @@
-package kafka
-
 /**
  * Copyright 2016 Confluent Inc.
  *
@@ -15,6 +13,8 @@ package kafka
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+package kafka
 
 import (
 	"fmt"

--- a/kafka/producer_test.go
+++ b/kafka/producer_test.go
@@ -1,5 +1,3 @@
-package kafka
-
 /**
  * Copyright 2016 Confluent Inc.
  *
@@ -15,6 +13,8 @@ package kafka
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+package kafka
 
 import (
 	"bytes"

--- a/kafka/testhelpers_test.go
+++ b/kafka/testhelpers_test.go
@@ -1,5 +1,3 @@
-package kafka
-
 /**
  * Copyright 2016 Confluent Inc.
  *
@@ -15,6 +13,8 @@ package kafka
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+package kafka
 
 import (
 	"testing"

--- a/kafka/time.go
+++ b/kafka/time.go
@@ -1,5 +1,3 @@
-package kafka
-
 /**
  * Copyright 2019 Confluent Inc.
  *
@@ -15,6 +13,8 @@ package kafka
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+package kafka
 
 import "C"
 

--- a/kafka/txn_integration_test.go
+++ b/kafka/txn_integration_test.go
@@ -1,5 +1,3 @@
-package kafka
-
 /**
  * Copyright 2020 Confluent Inc.
  *
@@ -15,6 +13,8 @@ package kafka
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+package kafka
 
 // Integration tests for the transactional producer
 

--- a/kafkatest/go_verifiable_consumer/go_verifiable_consumer.go
+++ b/kafkatest/go_verifiable_consumer/go_verifiable_consumer.go
@@ -1,6 +1,3 @@
-// Apache Kafka kafkatest VerifiableConsumer implemented in Go
-package main
-
 /**
  * Copyright 2016 Confluent Inc.
  *
@@ -17,16 +14,20 @@ package main
  * limitations under the License.
  */
 
+// Apache Kafka kafkatest VerifiableConsumer implemented in Go
+package main
+
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/alecthomas/kingpin"
-	"github.com/confluentinc/confluent-kafka-go/kafka"
 	"os"
 	"os/signal"
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/alecthomas/kingpin"
+	"github.com/confluentinc/confluent-kafka-go/kafka"
 )
 
 var (

--- a/kafkatest/go_verifiable_producer/go_verifiable_producer.go
+++ b/kafkatest/go_verifiable_producer/go_verifiable_producer.go
@@ -1,6 +1,3 @@
-// Apache Kafka kafkatest VerifiableProducer implemented in Go
-package main
-
 /**
  * Copyright 2016 Confluent Inc.
  *
@@ -17,16 +14,20 @@ package main
  * limitations under the License.
  */
 
+// Apache Kafka kafkatest VerifiableProducer implemented in Go
+package main
+
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/alecthomas/kingpin"
-	"github.com/confluentinc/confluent-kafka-go/kafka"
 	"os"
 	"os/signal"
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/alecthomas/kingpin"
+	"github.com/confluentinc/confluent-kafka-go/kafka"
 )
 
 var (

--- a/schemaregistry/cache/cache.go
+++ b/schemaregistry/cache/cache.go
@@ -1,17 +1,17 @@
 /**
-* Copyright 2022 Confluent Inc.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package cache

--- a/schemaregistry/cache/lrucache.go
+++ b/schemaregistry/cache/lrucache.go
@@ -1,8 +1,8 @@
 /**
-* Copyright 2022 Confluent Inc.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package cache
 

--- a/schemaregistry/cache/lrucache_test.go
+++ b/schemaregistry/cache/lrucache_test.go
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package cache
 
 import (

--- a/schemaregistry/cache/mapcache.go
+++ b/schemaregistry/cache/mapcache.go
@@ -1,8 +1,8 @@
 /**
-* Copyright 2022 Confluent Inc.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package cache
 

--- a/schemaregistry/config.go
+++ b/schemaregistry/config.go
@@ -1,7 +1,3 @@
-package schemaregistry
-
-import "fmt"
-
 /**
  * Copyright 2022 Confluent Inc.
  *
@@ -17,6 +13,10 @@ import "fmt"
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+package schemaregistry
+
+import "fmt"
 
 // Config is used to pass multiple configuration options to the Schema Registry client.
 type Config struct {

--- a/schemaregistry/config_test.go
+++ b/schemaregistry/config_test.go
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package schemaregistry
 
 import (

--- a/schemaregistry/mock_schemaregistry_client.go
+++ b/schemaregistry/mock_schemaregistry_client.go
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package schemaregistry
 
 import (

--- a/schemaregistry/rest_service.go
+++ b/schemaregistry/rest_service.go
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package schemaregistry
 
 import (

--- a/schemaregistry/schemaregistry_client.go
+++ b/schemaregistry/schemaregistry_client.go
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package schemaregistry
 
 import (

--- a/schemaregistry/schemaregistry_client_test.go
+++ b/schemaregistry/schemaregistry_client_test.go
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package schemaregistry
 
 import (

--- a/schemaregistry/serde/avro/avro.go
+++ b/schemaregistry/serde/avro/avro.go
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package avro
 
 import (

--- a/schemaregistry/serde/avro/avro_generic.go
+++ b/schemaregistry/serde/avro/avro_generic.go
@@ -1,13 +1,30 @@
+/**
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package avro
 
 import (
+	"reflect"
+	"unsafe"
+
 	"github.com/actgardner/gogen-avro/v10/parser"
 	"github.com/actgardner/gogen-avro/v10/schema"
 	"github.com/confluentinc/confluent-kafka-go/schemaregistry"
 	"github.com/confluentinc/confluent-kafka-go/schemaregistry/serde"
 	"github.com/heetch/avro"
-	"reflect"
-	"unsafe"
 )
 
 // GenericSerializer represents a generic Avro serializer

--- a/schemaregistry/serde/avro/avro_generic_test.go
+++ b/schemaregistry/serde/avro/avro_generic_test.go
@@ -1,10 +1,27 @@
+/**
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package avro
 
 import (
+	"testing"
+
 	"github.com/confluentinc/confluent-kafka-go/schemaregistry"
 	"github.com/confluentinc/confluent-kafka-go/schemaregistry/serde"
 	"github.com/confluentinc/confluent-kafka-go/schemaregistry/test"
-	"testing"
 )
 
 func TestGenericAvroSerdeWithSimple(t *testing.T) {

--- a/schemaregistry/serde/avro/avro_specific.go
+++ b/schemaregistry/serde/avro/avro_specific.go
@@ -1,8 +1,26 @@
+/**
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package avro
 
 import (
 	"bytes"
 	"fmt"
+	"io"
+
 	"github.com/actgardner/gogen-avro/v10/compiler"
 	"github.com/actgardner/gogen-avro/v10/parser"
 	"github.com/actgardner/gogen-avro/v10/schema"
@@ -10,7 +28,6 @@ import (
 	"github.com/actgardner/gogen-avro/v10/vm/types"
 	"github.com/confluentinc/confluent-kafka-go/schemaregistry"
 	"github.com/confluentinc/confluent-kafka-go/schemaregistry/serde"
-	"io"
 )
 
 // SpecificSerializer represents a specific Avro serializer

--- a/schemaregistry/serde/avro/avro_specific_test.go
+++ b/schemaregistry/serde/avro/avro_specific_test.go
@@ -1,10 +1,27 @@
+/**
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package avro
 
 import (
+	"testing"
+
 	"github.com/confluentinc/confluent-kafka-go/schemaregistry"
 	"github.com/confluentinc/confluent-kafka-go/schemaregistry/serde"
 	"github.com/confluentinc/confluent-kafka-go/schemaregistry/test"
-	"testing"
 )
 
 func TestSpecificAvroSerdeWithSimple(t *testing.T) {

--- a/schemaregistry/serde/avro/config.go
+++ b/schemaregistry/serde/avro/config.go
@@ -1,7 +1,3 @@
-package avro
-
-import "github.com/confluentinc/confluent-kafka-go/schemaregistry/serde"
-
 /**
  * Copyright 2022 Confluent Inc.
  *
@@ -17,6 +13,10 @@ import "github.com/confluentinc/confluent-kafka-go/schemaregistry/serde"
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+package avro
+
+import "github.com/confluentinc/confluent-kafka-go/schemaregistry/serde"
 
 // SerializerConfig is used to pass multiple configuration options to the serializers.
 type SerializerConfig struct {

--- a/schemaregistry/serde/config.go
+++ b/schemaregistry/serde/config.go
@@ -1,5 +1,3 @@
-package serde
-
 /**
  * Copyright 2022 Confluent Inc.
  *
@@ -15,6 +13,8 @@ package serde
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+package serde
 
 // SerializerConfig is used to pass multiple configuration options to the serializers.
 type SerializerConfig struct {

--- a/schemaregistry/serde/jsonschema/config.go
+++ b/schemaregistry/serde/jsonschema/config.go
@@ -1,7 +1,3 @@
-package jsonschema
-
-import "github.com/confluentinc/confluent-kafka-go/schemaregistry/serde"
-
 /**
  * Copyright 2022 Confluent Inc.
  *
@@ -17,6 +13,10 @@ import "github.com/confluentinc/confluent-kafka-go/schemaregistry/serde"
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+package jsonschema
+
+import "github.com/confluentinc/confluent-kafka-go/schemaregistry/serde"
 
 // SerializerConfig is used to pass multiple configuration options to the serializers.
 type SerializerConfig struct {

--- a/schemaregistry/serde/jsonschema/json_schema.go
+++ b/schemaregistry/serde/jsonschema/json_schema.go
@@ -1,13 +1,30 @@
+/**
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package jsonschema
 
 import (
 	"encoding/json"
+	"io"
+	"strings"
+
 	"github.com/confluentinc/confluent-kafka-go/schemaregistry"
 	"github.com/confluentinc/confluent-kafka-go/schemaregistry/serde"
 	"github.com/invopop/jsonschema"
 	jsonschema2 "github.com/santhosh-tekuri/jsonschema/v5"
-	"io"
-	"strings"
 )
 
 // Serializer represents a JSON Schema serializer

--- a/schemaregistry/serde/jsonschema/json_schema_test.go
+++ b/schemaregistry/serde/jsonschema/json_schema_test.go
@@ -1,10 +1,27 @@
+/**
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package jsonschema
 
 import (
+	"testing"
+
 	"github.com/confluentinc/confluent-kafka-go/schemaregistry"
 	"github.com/confluentinc/confluent-kafka-go/schemaregistry/serde"
 	"github.com/confluentinc/confluent-kafka-go/schemaregistry/test"
-	"testing"
 )
 
 func TestJSONSchemaSerdeWithSimple(t *testing.T) {

--- a/schemaregistry/serde/protobuf/config.go
+++ b/schemaregistry/serde/protobuf/config.go
@@ -1,7 +1,3 @@
-package protobuf
-
-import "github.com/confluentinc/confluent-kafka-go/schemaregistry/serde"
-
 /**
  * Copyright 2022 Confluent Inc.
  *
@@ -17,6 +13,10 @@ import "github.com/confluentinc/confluent-kafka-go/schemaregistry/serde"
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+package protobuf
+
+import "github.com/confluentinc/confluent-kafka-go/schemaregistry/serde"
 
 // SerializerConfig is used to pass multiple configuration options to the serializers.
 type SerializerConfig struct {

--- a/schemaregistry/serde/protobuf/protobuf.go
+++ b/schemaregistry/serde/protobuf/protobuf.go
@@ -1,8 +1,28 @@
+/**
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package protobuf
 
 import (
 	"encoding/binary"
 	"fmt"
+	"io"
+	"log"
+	"strings"
+
 	"github.com/confluentinc/confluent-kafka-go/schemaregistry"
 	"github.com/confluentinc/confluent-kafka-go/schemaregistry/confluent"
 	"github.com/confluentinc/confluent-kafka-go/schemaregistry/confluent/types"
@@ -37,9 +57,6 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"google.golang.org/protobuf/types/known/typepb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
-	"io"
-	"log"
-	"strings"
 )
 
 // Serializer represents a Protobuf serializer

--- a/schemaregistry/serde/protobuf/protobuf_test.go
+++ b/schemaregistry/serde/protobuf/protobuf_test.go
@@ -1,11 +1,28 @@
+/**
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package protobuf
 
 import (
+	"testing"
+
 	"github.com/confluentinc/confluent-kafka-go/schemaregistry"
 	"github.com/confluentinc/confluent-kafka-go/schemaregistry/serde"
 	"github.com/confluentinc/confluent-kafka-go/schemaregistry/test"
 	"google.golang.org/protobuf/proto"
-	"testing"
 )
 
 func TestProtobufSerdeWithSimple(t *testing.T) {

--- a/schemaregistry/serde/serde.go
+++ b/schemaregistry/serde/serde.go
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package serde
 
 import "C"
@@ -5,6 +21,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+
 	"github.com/confluentinc/confluent-kafka-go/schemaregistry"
 )
 

--- a/schemaregistry/serde/testhelpers.go
+++ b/schemaregistry/serde/testhelpers.go
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package serde
 
 import (

--- a/schemaregistry/testhelpers.go
+++ b/schemaregistry/testhelpers.go
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package schemaregistry
 
 import (

--- a/soaktest/datadog.go
+++ b/soaktest/datadog.go
@@ -1,5 +1,3 @@
-package soaktest
-
 /**
  * Copyright 2021 Confluent Inc.
  *
@@ -16,13 +14,16 @@ package soaktest
  * limitations under the License.
  */
 
+package soaktest
+
 import (
-	"github.com/DataDog/datadog-go/statsd"
-	"github.com/shirou/gopsutil/process"
 	"os"
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/DataDog/datadog-go/statsd"
+	"github.com/shirou/gopsutil/process"
 )
 
 const datadogHost = "127.0.0.1:8125"

--- a/soaktest/soakclient/soakclient.go
+++ b/soaktest/soakclient/soakclient.go
@@ -1,5 +1,3 @@
-package main
-
 /**
  * Copyright 2021 Confluent Inc.
  *
@@ -16,16 +14,19 @@ package main
  * limitations under the License.
  */
 
+package main
+
 import (
 	"context"
 	"flag"
 	"fmt"
-	"github.com/confluentinc/confluent-kafka-go/soaktest"
 	"os"
 	"os/signal"
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/confluentinc/confluent-kafka-go/soaktest"
 
 	"github.com/confluentinc/confluent-kafka-go/kafka"
 )

--- a/soaktest/soakclient_transaction/soakclient_transaction.go
+++ b/soaktest/soakclient_transaction/soakclient_transaction.go
@@ -1,5 +1,3 @@
-package main
-
 /**
  * Copyright 2021 Confluent Inc.
  *
@@ -16,16 +14,19 @@ package main
  * limitations under the License.
  */
 
+package main
+
 import (
 	"context"
 	"flag"
 	"fmt"
-	"github.com/confluentinc/confluent-kafka-go/soaktest"
 	"os"
 	"os/signal"
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/confluentinc/confluent-kafka-go/soaktest"
 
 	"github.com/confluentinc/confluent-kafka-go/kafka"
 )


### PR DESCRIPTION
moved copyright position on top of the files
with one newline before package definition to avoid
being interpreted as the package's documentation