### PR TITLE
Add a cache for schema metadata

### DIFF
--- a/schemaregistry/mock_schemaregistry_client.go
+++ b/schemaregistry/mock_schemaregistry_client.go
@@ -56,6 +56,8 @@ type mockclient struct {
 	url                    *url.URL
 	schemaCache            map[subjectJSON]idCacheEntry
 	schemaCacheLock        sync.RWMutex
+	metadataCache          map[subjectVersion]SchemaMetadata
+	metadataCacheLock      sync.RWMutex
 	idCache                map[subjectID]*SchemaInfo
 	idCacheLock            sync.RWMutex
 	versionCache           map[subjectJSON]versionCacheEntry


### PR DESCRIPTION
This PR includes a cache on schema metadata. I noticed while deserializing Protobuf messages that my clients were pulling messages very slowly. After digging into the problem I noticed that my local Schema Registry was getting hammered, it was due to `GetSchemaMetadata` not including a cache.

Stack trace:
```
runtime/debug.Stack()
        /opt/homebrew/Cellar/go/1.18.4/libexec/src/runtime/debug/stack.go:24 +0x65
runtime/debug.PrintStack()
        /opt/homebrew/Cellar/go/1.18.4/libexec/src/runtime/debug/stack.go:16 +0x19
github.com/confluentinc/confluent-kafka-go/schemaregistry.(*restService).handleRequest(0xc00000f230, 0xc002149a40, {0x15a24c0, 0xc0036e5e00})
        /Users/kamador/src/contentful/vendor/github.com/confluentinc/confluent-kafka-go/schemaregistry/rest_service.go:274 +0xd6
github.com/confluentinc/confluent-kafka-go/schemaregistry.(*client).GetSchemaMetadata(0xc0009946c0, {0xc0008a6690, 0x2b}, 0xc0031bdd60?)
        /Users/kamador/src/contentful/vendor/github.com/confluentinc/confluent-kafka-go/schemaregistry/schemaregistry_client.go:389 +0x185
github.com/confluentinc/confluent-kafka-go/schemaregistry/serde.ResolveReferences({0x1bdfc70, 0xc0009946c0}, {{0xc0030da500, 0x481}, {0xc00072ddb8, 0x8}, {0xc0030b0dc0, 0x2, 0x4}}, 0xc00370dda0)
        /Users/kamador/src/contentful/vendor/github.com/confluentinc/confluent-kafka-go/schemaregistry/serde/serde.go:217 +0x15a
github.com/confluentinc/confluent-kafka-go/schemaregistry/serde/protobuf.(*Deserializer).toFileDesc(0xc00086c580, {{0xc0030da500, 0x481}, {0xc00072ddb8, 0x8}, {0xc0030b0dc0, 0x2, 0x4}})
        /Users/kamador/src/contentful/vendor/github.com/confluentinc/confluent-kafka-go/schemaregistry/serde/protobuf/protobuf.go:407 +0xc6
github.com/confluentinc/confluent-kafka-go/schemaregistry/serde/protobuf.(*Deserializer).Deserialize(0xc00086c580, {0xc0001826e0, 0x19}, {0xc002d9503c, 0x11f, 0x1c4})
        /Users/kamador/src/contentful/vendor/github.com/confluentinc/confluent-kafka-go/schemaregistry/serde/protobuf/protobuf.go:355 +0x14e
```
