### PR TITLE
Fix Deserialize (avro_specific) and improve tests for avro_specific/avro_generic

### DIFF
--- a/schemaregistry/serde/avro/avro_specific.go
+++ b/schemaregistry/serde/avro/avro_specific.go
@@ -139,7 +139,11 @@ func (s *SpecificDeserializer) Deserialize(topic string, payload []byte) (interf
 		return nil, err
 	}
 	r := bytes.NewReader(payload[5:])
-	return vm.Eval(r, deser, avroMsg), nil
+
+	if err = vm.Eval(r, deser, avroMsg); err != nil {
+		return nil, err
+	}
+	return avroMsg, nil
 }
 
 // DeserializeInto implements deserialization of specific Avro data to the given object


### PR DESCRIPTION
1. Fixes avro_specific Deserialize method which did not return the
   right thing (it did not return anything useable).
2. Update tests for (1) - add Deserialize to tests which were only
   testing DeserializeInto
3. Add Deserialize to avro_generic tests as well.

Addresses  #843
