### PR TITLE
admin-client: Implement DeleteGroups

### DIFF
--- a/kafka/adminoptions.go
+++ b/kafka/adminoptions.go
@@ -225,6 +225,13 @@ type DeleteTopicsAdminOption interface {
 	apply(cOptions *C.rd_kafka_AdminOptions_t) error
 }
 
+// DeleteGroupsAdminOption - see setters.
+//
+// See SetAdminRequestTimeout, SetAdminOperationTimeout.
+type DeleteGroupsAdminOption interface {
+	apply(cOptions *C.rd_kafka_AdminOptions_t) error
+}
+
 // CreatePartitionsAdminOption - see setters.
 //
 // See SetAdminRequestTimeout, SetAdminOperationTimeout, SetAdminValidateOnly.

--- a/kafka/generated_errors.go
+++ b/kafka/generated_errors.go
@@ -1,6 +1,6 @@
 package kafka
 // Copyright 2016-2022 Confluent Inc.
-// AUTOMATICALLY GENERATED ON 2022-08-01 22:56:19.86222475 +0200 CEST m=+0.000294735 USING librdkafka 1.9.2
+// AUTOMATICALLY GENERATED ON 2022-09-05 11:58:41.026802 +0530 IST m=+0.000584006 USING librdkafka 1.9.2
 
 /*
 #include "select_rdkafka.h"


### PR DESCRIPTION
Fixes #826 

Follow Up
----------

When the `DescribeGroup` apI is available in the Go client, the integration test can be made more concise, without us having to create the second consumer.