### PR TITLE
[consumer] Propagate errors for Pause/Resume APIs

### DIFF
--- a/kafka/consumer_test.go
+++ b/kafka/consumer_test.go
@@ -122,6 +122,27 @@ func TestConsumerAPIs(t *testing.T) {
 		t.Errorf("Resume failed: %s", err)
 	}
 
+	// Pause & Resume - errors
+	tps := []TopicPartition{{Topic: &topic, Partition: 2}, {Topic: &topic2, Partition: 1}}
+	err = c.Pause(tps)
+	if err == nil || !strings.HasPrefix(err.Error(), "1 error(s)") {
+		t.Errorf("Expected an error in Pause given unsubscribed topic, got %s", err)
+
+		if tps[0].Error == nil || tps[1].Error != nil {
+			t.Errorf("Errors not set correctly for Pause, %v", tps)
+		}
+	}
+
+	tps = []TopicPartition{{Topic: &topic, Partition: 2}, {Topic: &topic, Partition: 1}}
+	err = c.Resume(tps)
+	if err == nil || !strings.HasPrefix(err.Error(), "2 error(s)") {
+		t.Errorf("Expected an error in Resume given unsubscribed topic, got %s", err)
+
+		if tps[0].Error == nil || tps[1].Error == nil {
+			t.Errorf("Errors not set correctly for Resume, %v", tps)
+		}
+	}
+
 	err = c.Unassign()
 	if err != nil {
 		t.Errorf("Unassign failed: %s", err)


### PR DESCRIPTION
This propagates the individual errors for each TopicPartition
that is being Paused/Resumed, into the input slice itself.
An non-nil cumulative error is returned in case one or more of
the TopicPartitions has an error.
This approach is different from other such APIs, which return a
new slice of TopicPartitions, but that would break the API.
This method keeps the existing API to not break existing code, but
allows users to access errors which were not being made available
earlier through the input.
Fixes #808 