### PR TITLE
Implement callback for SASL PLAIN credentials

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/confluentinc/confluent-kafka-go
+module github.com/josvisser66/confluent-kafka-go
 
 go 1.13
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/josvisser66/confluent-kafka-go
+module github.com/confluentinc/confluent-kafka-go
 
 go 1.13
 

--- a/kafka/build_darwin_amd64.go
+++ b/kafka/build_darwin_amd64.go
@@ -6,7 +6,7 @@
 package kafka
 
 // #cgo CFLAGS: -DUSE_VENDORED_LIBRDKAFKA -DLIBRDKAFKA_STATICLIB
-// #cgo LDFLAGS: ${SRCDIR}/librdkafka_vendor/librdkafka_darwin_amd64.a  -lm -lsasl2 -ldl -lpthread -framework CoreFoundation -framework SystemConfiguration
+// #cgo LDFLAGS: ${SRCDIR}/librdkafka_vendor/librdkafka_darwin_amd64.a  -lm -lsasl2 -ldl -lpthread -framework CoreFoundation -framework SystemConfiguration -lcurl -lz
 import "C"
 
 // LibrdkafkaLinkInfo explains how librdkafka was linked to the Go client

--- a/kafka/build_darwin_arm64.go
+++ b/kafka/build_darwin_arm64.go
@@ -6,7 +6,7 @@
 package kafka
 
 // #cgo CFLAGS: -DUSE_VENDORED_LIBRDKAFKA -DLIBRDKAFKA_STATICLIB
-// #cgo LDFLAGS: ${SRCDIR}/librdkafka_vendor/librdkafka_darwin_arm64.a  -lm -lsasl2 -ldl -lpthread -framework CoreFoundation -framework SystemConfiguration
+// #cgo LDFLAGS: ${SRCDIR}/librdkafka_vendor/librdkafka_darwin_arm64.a  -lm -lsasl2 -ldl -lpthread -framework CoreFoundation -framework SystemConfiguration -lz -lcurl
 import "C"
 
 // LibrdkafkaLinkInfo explains how librdkafka was linked to the Go client

--- a/kafka/build_glibc_linux.go
+++ b/kafka/build_glibc_linux.go
@@ -6,7 +6,7 @@
 package kafka
 
 // #cgo CFLAGS: -DUSE_VENDORED_LIBRDKAFKA -DLIBRDKAFKA_STATICLIB
-// #cgo LDFLAGS: ${SRCDIR}/librdkafka_vendor/librdkafka_glibc_linux.a  -lm -ldl -lpthread -lrt
+// #cgo LDFLAGS: ${SRCDIR}/librdkafka_vendor/librdkafka_glibc_linux.a  -lm -ldl -lpthread -lrt -lssl -lcrypto -lz
 import "C"
 
 // LibrdkafkaLinkInfo explains how librdkafka was linked to the Go client

--- a/kafka/kafka.go
+++ b/kafka/kafka.go
@@ -254,7 +254,7 @@ package kafka
 import (
 	"fmt"
 	// Make sure librdkafka_vendor/ sub-directory is included in vendor pulls.
-	_ "github.com/confluentinc/confluent-kafka-go/kafka/librdkafka_vendor"
+	_ "github.com/josvisser66/confluent-kafka-go/kafka/librdkafka_vendor"
 	"unsafe"
 )
 

--- a/kafka/kafka.go
+++ b/kafka/kafka.go
@@ -254,7 +254,7 @@ package kafka
 import (
 	"fmt"
 	// Make sure librdkafka_vendor/ sub-directory is included in vendor pulls.
-	_ "github.com/josvisser66/confluent-kafka-go/kafka/librdkafka_vendor"
+	_ "github.com/confluentinc/confluent-kafka-go/kafka/librdkafka_vendor"
 	"unsafe"
 )
 

--- a/kafka/librdkafka_vendor/rdkafka.h
+++ b/kafka/librdkafka_vendor/rdkafka.h
@@ -2127,6 +2127,55 @@ void rd_kafka_conf_set_oauthbearer_token_refresh_cb(
                                          void *opaque));
 
 /**
+ * @brief Set SASL/PLAIN credential callback in provided conf object.
+ *
+ * @param conf the configuration to mutate.
+ * @param plain_creds_cb the callback to set; callback function
+ *  arguments:<br>
+ *   \p rk - Kafka handle<br>
+ *   \p username - Pointer to the receiving area for the SASL username (may be
+ *                 NULL)
+ *   \p username_size - Pointer to the number of bytes available in the
+ *                      receiving area. If this is not enough, set this to
+ *                      the number of bytes required.
+ *   \p password - Pointer to the receiving area for the SASL password (may be
+ *                 NULL)
+ *   \p password_size - Pointer to the number of bytes available in the
+ *                      receiving area. If this is not enough, set this to the
+ *                      number of bytes required,
+ *
+ * Users of the SASL/PLAIN authentication mechanism can opt to set the SASL
+ * username and password statically in the configuration or specify this
+ * callback. If the callback is set, then neither the sasl.username nor the
+ * sasl.password field may be set.
+ *
+ * Whenever the SASL/PLAIN implementation needs the SASL username and/or
+ * password it will call this callback. The callback needs to set the memory
+ * pointed to by *username and *password to the credentials to be used. The
+ * username_size and password_size fields point to integers that indicate how
+ * much memory is available in each of the receiving areas.
+ * If the receiving area cannot hold the username or password the callback
+ * should set these pointers to the number of bytes required (including the
+ * terminating 0x00 byte and return -1, and 0 otherwise.
+ *
+ * The SASL/PLAIN implementation does not cache the provided username and
+ * password. The callback will be called _every_ time the username and/or
+ * password is needed.
+ *
+ * If username or password is NULL that means that we are not interested
+ * in that particular bit of information. Use the if statement in your callback
+ * to detect this condition :-) In that case the pointer to the
+ * provided/required size will be NULL too.
+ */
+RD_EXPORT
+void rd_kafka_conf_set_plain_creds_cb(rd_kafka_conf_t *conf,
+                                      int (*plain_creds_cb)(rd_kafka_t *rk,
+                                                            char *username,
+                                                            size_t *username_size,
+                                                            char *password,
+                                                            size_t *password_size));
+
+/**
  * @brief Enable/disable creation of a queue specific to SASL events
  *        and callbacks.
  *
@@ -2155,7 +2204,6 @@ void rd_kafka_conf_set_oauthbearer_token_refresh_cb(
 
 RD_EXPORT
 void rd_kafka_conf_enable_sasl_queue(rd_kafka_conf_t *conf, int enable);
-
 
 /**
  * @brief Set socket callback.

--- a/kafka/plain_creds_cb.go
+++ b/kafka/plain_creds_cb.go
@@ -1,0 +1,84 @@
+package kafka
+
+import (
+	"C"
+	"errors"
+	"fmt"
+	"sync"
+	"unsafe"
+)
+
+// PlainCredsCallback is the type of the Go function that will be called to obtain the SASL username and password
+// for a Kafka client/
+type PlainCredsCallbackFunc func() (string, string, error)
+
+var (
+	// cbMap maps the address of the Kafka client (*rd_kafka_t) to the callback function. This map is necessary
+	// because all Go Kafka clients use the same C function as the credentials callback. That C function then
+	// passes control to a Go intermediary, which in turn calls the right Go callback by referencing this map.
+	cbMap map[unsafe.Pointer]PlainCredsCallbackFunc
+	mu    sync.RWMutex
+)
+
+func init() {
+	cbMap = make(map[unsafe.Pointer]PlainCredsCallbackFunc)
+}
+
+// insertPlainCredsCallback inserts a Go callback into the disambiguation map (cbMap).
+func insertPlainCredsCallback(rk unsafe.Pointer, fun PlainCredsCallbackFunc) {
+	mu.Lock()
+	defer mu.Unlock()
+	cbMap[rk] = fun
+}
+
+// removePlainCredsCallback removes a Go callback from the disambiguation map. This should be called after
+// destroying a Go Kafka client.
+func removePlainCredsCallback(rk unsafe.Pointer) {
+	mu.Lock()
+	defer mu.Unlock()
+	delete(cbMap, rk)
+}
+
+// extractCallbackFromConfig does the needful to check if the user has set "plain.creds.cb" in the config map.
+// If so, extracts that value and casts it to the correct type and returns it.
+func extractCallbackFromConfigMap(conf *ConfigMap) (PlainCredsCallbackFunc, error) {
+	cb, err := conf.extract("plain.creds.cb", nil)
+	if err != nil {
+		return nil, err
+	}
+	if cb == nil {
+		return nil, nil
+	}
+	// Can't use PlainCredsCallbackFunc here because of the way Go's type system works.
+	if cbFun, ok := cb.(func() (string, string, error)); ok {
+		return cbFun, nil
+	}
+	return nil, errors.New("plain.creds.cb callback function is not of the correct type")
+}
+
+// callPlainCredsCallback is the intermediary between the C function installed as the actual callback and the
+// Go callback registered by the user. This intermediary is called by the C function. It will allocate memory
+// for the username and password that are returned from the Go callback. It is the caller's responsibility
+// (in other word: The C callback's responsibility) to remove those.
+// Note: If the Go callback returns an error this function will return -1 and the actual error is lost.
+//export callPlainCredsCallback
+func callPlainCredsCallback(rk *C.int, username **C.char, password **C.char, errmsg **C.char) {
+	*errmsg = nil
+	mu.RLock()
+	fun := cbMap[unsafe.Pointer(rk)]
+	mu.RUnlock()
+
+	if fun == nil {
+		*errmsg = C.CString(fmt.Sprintf("callPlainCredsCallback called for unknown rk %x", rk))
+		return
+	}
+
+	u, p, err := fun()
+	if err != nil {
+		*errmsg = C.CString(err.Error())
+		return
+	}
+
+	*username = C.CString(u)
+	*password = C.CString(p)
+}

--- a/kafka/plain_creds_cb2.go
+++ b/kafka/plain_creds_cb2.go
@@ -1,0 +1,70 @@
+package kafka
+
+/*
+#include <stdlib.h>
+#include <string.h>
+#include "select_rdkafka.h"
+
+
+// Copies the string in src to dest. If it does not fit, sets *dest_size to the required
+// size and *rc to -1. If dest is NULL this function does nothing.
+static void copy(char *dest, char *src, size_t *dest_size, int *rc) {
+  if (!dest) {
+    return;
+  }
+
+  int src_size = strlen(src) + 1;
+
+  if (src_size > *dest_size) {
+    *dest_size = src_size;
+    *rc = -1;
+  } else {
+    strcpy(dest, src);
+  }
+}
+
+
+// This is the librdkafka SASL/PLAIN credentials callback used for all Go Kafka clients. Since all
+// Go clients use this as their registered callback (using C.rd_kafka_conf_set_plain_creds_cb) this
+// implementation disambiguates between the client by their address and calls the correct Go callback
+// method that was passed in through the "plain.creds.cb" field in the ConfigMap.
+static int plain_creds_cb(rd_kafka_t *rk, char *username, size_t *username_size, char *password, size_t *password_size) {
+  // This function (in Go) calls the right Go callback for this client. The username and password fields are allocated
+  // by the function and need to be freed by the caller (i.c: us).
+  extern void callPlainCredsCallback(int *rk, char **username, char **password, char **errmsg);
+  char *go_username;
+  char *go_password;
+  char *errmsg;
+
+
+  // Calls the Go callback (through this intermediary function).
+  callPlainCredsCallback((int *)rk, &go_username, &go_password, &errmsg);
+
+  if (errmsg) {
+    // TODO: Find a better way to log this error message.
+    fprintf(stderr,"Go callback error: %s\n", errmsg);
+    free(errmsg);
+    return -1;
+  }
+
+ // The return code for this function. 0 means a username and/or password was returned. -1 means that the
+  // username or password did not fit in the buffer provided by the caller. In that case *username_size and/or
+  // *password_size are set to the number of bytes required (including termininating '\0').
+  int rc = 0;
+
+  // If the Go callback succeeded, copies the username and password to the caller
+  // provided areas and frees the buffers allocated by the intermediary.
+  copy(username, go_username, username_size, &rc);
+  free(go_username);
+  copy(password, go_password, password_size, &rc);
+  free(go_password);
+
+  return rc;
+}
+
+// Sets the one-callback-function-to-rule-them-all into the Kafka configuration map.
+void set_plain_creds_cb(rd_kafka_conf_t *conf) {
+  rd_kafka_conf_set_plain_creds_cb(conf, plain_creds_cb);
+}
+*/
+import "C"


### PR DESCRIPTION
# Introduction

This PR is the sibling of https://github.com/edenhill/librdkafka/pull/3955 which adds a feature to librdkafka that allows the specification of a callback to obtain the SASL PLAIN credentials.

The Golang implementation works as follows:

```
func credsCallback() (string, string, error) {
        // Magic here.
        return username, password, nil
}

func main() {
        c, err := kafka.NewConsumer(&kafka.ConfigMap{
                "bootstrap.servers": "pkc-XXXXXX.confluent.cloud:9092",
                "group.id":          "myGroup",
                "auto.offset.reset": "earliest",
                "sasl.mechanism":    "PLAIN",
                "security.protocol": "SASL_SSL",
                "plain.creds.cb":    credsCallback,
        })
```

Whenever librdkafka needs the credentials it calls (through some intermediaries) the Golang callback specified in the "plain.creds.cb" key and uses whatever it gets back from there.

# Implementation details

There is some excitement in this PR because of the way the C/Go bridge works and the consequences of that. The PR provides a single callback function for all Golang Kafka clients (in C) which then branches out to the "right" one for this particular Kafka client (using the pointer address of the Kafka client structure as a key in a map). There is a drawback to this approach, which is that we can only update that map when we know that pointer address and this means that there is a short coverage gap where the client could call the callback and not get any results. Testing so far seems to indicate that this is not a big problem.
