### PR TITLE
Update docs for consumer rebalancing offset management

### DIFF
--- a/kafka/api.html
+++ b/kafka/api.html
@@ -118,7 +118,7 @@ as well as set the initial offsets. To do this you need to pass
 `"go.application.rebalance.enable": true` to the `NewConsumer()` call
 mentioned above. You will (eventually) see a `kafka.AssignedPartitions` event
 with the assigned partition set. You can optionally modify the initial
-offsets (they'll default to stored offsets and if there are no previously stored
+offsets (they'll default to committed offsets and if there are no previously committed
 offsets it will fall back to `"auto.offset.reset"`
 which defaults to the `latest` message) and then call `.Assign(partitions)`
 to start consuming. If you don't need to modify the initial offsets you will

--- a/kafka/kafka.go
+++ b/kafka/kafka.go
@@ -44,7 +44,7 @@
 // `"go.application.rebalance.enable": true` to the `NewConsumer()` call
 // mentioned above. You will (eventually) see a `kafka.AssignedPartitions` event
 // with the assigned partition set. You can optionally modify the initial
-// offsets (they'll default to stored offsets and if there are no previously stored
+// offsets (they'll default to committed offsets and if there are no previously committed
 // offsets it will fall back to `"auto.offset.reset"`
 // which defaults to the `latest` message) and then call `.Assign(partitions)`
 // to start consuming. If you don't need to modify the initial offsets you will


### PR DESCRIPTION
The use of `stored offset` for the consumer rebalancing doc is a bit misleading because people might interpret that as referring to the in memory store (which is used for auto commits or offset-less manual commits).