### PR TITLE
fix: initialise schema-registry tlsConf.RootCAs value (invalid memory address or nil pointer)

### DIFF
--- a/schemaregistry/rest_service.go
+++ b/schemaregistry/rest_service.go
@@ -19,6 +19,7 @@ package schemaregistry
 import (
 	"bytes"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -172,10 +173,8 @@ func configureTLS(conf *Config, tlsConf *tls.Config) error {
 		if err != nil {
 			return err
 		}
+		tlsConf.RootCAs = x509.NewCertPool()
 		tlsConf.RootCAs.AppendCertsFromPEM(caCert)
-		if err != nil {
-			return err
-		}
 	}
 
 	tlsConf.BuildNameToCertificate()


### PR DESCRIPTION
```
panic: runtime error: invalid memory address or nil pointer dereference [signal SIGSEGV: segmentation violation code=0x2 addr=0x20 pc=0x100fcd0e0]

goroutine 1 [running]:
crypto/x509.(*CertPool).addCertFunc(...)
	/opt/homebrew/Cellar/go/1.19.1/libexec/src/crypto/x509/cert_pool.go:189
crypto/x509.(*CertPool).AppendCertsFromPEM(0x0, {0x1400047a000?, 0x1400031f998?, 0x100dabf7c?})
	/opt/homebrew/Cellar/go/1.19.1/libexec/src/crypto/x509/cert_pool.go:227 +0x260
github.com/confluentinc/confluent-kafka-go/schemaregistry.configureTLS(0x1400046da01?, 0x140001cd500)
	/Users/ju/github.com/sumup/confluent-kafka-go/schemaregistry/rest_service.go:176 +0x1f0
github.com/confluentinc/confluent-kafka-go/schemaregistry.configureTransport(0x1400031fbf8)
	/Users/ju/github.com/sumup/confluent-kafka-go/schemaregistry/rest_service.go:190 +0x38
github.com/confluentinc/confluent-kafka-go/schemaregistry.newRestService(0x1400031fbf8)
	/Users/ju/github.com/sumup/confluent-kafka-go/schemaregistry/rest_service.go:126 +0x128
github.com/confluentinc/confluent-kafka-go/schemaregistry.NewClient(0x1400031fbf8)
	/Users/ju/github.com/sumup/confluent-kafka-go/schemaregistry/schemaregistry_client.go:229 +0x15c
```