### PR TITLE
Draft for integration tests setup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,9 @@ require (
 	github.com/invopop/jsonschema v0.4.0
 	github.com/jhump/protoreflect v1.12.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.0.0
-	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
-	google.golang.org/genproto v0.0.0-20220503193339-ba3ae3f07e29
+	github.com/stretchr/testify v1.8.0
+	github.com/testcontainers/testcontainers-go v0.14.0
+	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f
+	google.golang.org/genproto v0.0.0-20220617124728-180714bec0ad
 	google.golang.org/protobuf v1.28.0
 )

--- a/kafka/testresources/docker-compose.yaml
+++ b/kafka/testresources/docker-compose.yaml
@@ -1,0 +1,24 @@
+version: '1'
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+  kafka:
+    image: confluentinc/cp-kafka
+    depends_on:
+      - zookeeper
+    ports:
+      - 9092:9092
+    environment:
+      KAFKA_BROKER_ID: 0
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT, PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092, PLAINTEXT_HOST://localhost:9092
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ZOOKEEPER_CONNECTION_TIMEOUT_MS: 18000
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_AUTHORIZER_CLASS_NAME: kafka.security.authorizer.AclAuthorizer
+      KAFKA_SUPER_USERS: "User:ANONYMOUS"


### PR DESCRIPTION
This is a draft PR intended to illustrate the usage of testcontainers and testify in the go integration tests.
For the purposes of this demonstration, only the AdminClient related tests have been changed for the correct setup.

Using a command line flag, it's also possible to make testcontainer usage optional - we can use them in CI but not in our local setup, for example. In this case, I have made the usage of testcontainers false by default.

Any changes to the things that need to be brought up can be made inside the docker compose file -- for now there's only kafka+zookeeper containers.

Also - besides the rough edges in code, I have not added my go.sum updates.

The commands to run it are:
```
# run all admin tests without anything extra, just like the normal setup
go test -run  ^TestAdminClient$
# run with automatic docker container up and down
go test -run  ^TestAdminClient$  -clients.docker true
# run selected test, in this case TestAdminTopics only
go test -run  ^TestAdminClient$  -clients.docker true -testify.m ^TestAdminTopics$
```