### PR TITLE
[DP-9090]add run_semaphore_public

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -8,3 +8,4 @@ github:
   repo_name: confluentinc/confluent-kafka-go
 semaphore:
   enable: true
+  run_semaphore_public: true


### PR DESCRIPTION
A new parameter "run_semaphore_public" is added into manifest and is used to whitelist project that are public on github but could run semaphore plugin.
For new project, if we want to avoid this kind of error and change the manifest manually, one possible solution is to add a new parameter of "run_semaphore_public" in Jenkins so that this parameter will be passed in to projects.json, which will add this parameter to manifest by default.