### PR TITLE
remove error return for consumer close

### DIFF
--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -415,7 +415,7 @@ func (c *Consumer) ReadMessage(timeout time.Duration) (*Message, error) {
 
 // Close Consumer instance.
 // The object is no longer usable after this call.
-func (c *Consumer) Close() (err error) {
+func (c *Consumer) Close() {
 
 	// Wait for consumerReader() or pollLogEvents to terminate (by closing readerTermChan)
 	close(c.readerTermChan)
@@ -437,8 +437,6 @@ func (c *Consumer) Close() (err error) {
 	c.handle.cleanup()
 
 	C.rd_kafka_destroy(c.handle.rk)
-
-	return nil
 }
 
 // NewConsumer creates a new high-level Consumer instance.

--- a/kafka/consumer_test.go
+++ b/kafka/consumer_test.go
@@ -204,10 +204,7 @@ func TestConsumerAPIs(t *testing.T) {
 		t.Errorf("Committed() failed but returned non-nil Offsets: %s\n", offsets)
 	}
 
-	err = c.Close()
-	if err != nil {
-		t.Errorf("Close failed: %s", err)
-	}
+	c.Close()
 }
 
 func TestConsumerSubscription(t *testing.T) {
@@ -417,9 +414,7 @@ func TestConsumerLog(t *testing.T) {
 
 	<-time.After(time.Second * 3)
 
-	if err := c.Close(); err != nil {
-		t.Fatal("Failed to close consumer.")
-	}
+	c.Close()
 
 	for expectedLog, found := range expectedLogs {
 		if !found {


### PR DESCRIPTION
there is no any errors for `Close` so removing it.

Signed-off-by: clyang82 <chuyang@redhat.com>