### PR TITLE
Better error message

### DIFF
--- a/kafka/producer.go
+++ b/kafka/producer.go
@@ -150,7 +150,7 @@ func (p *Producer) gethandle() *handle {
 
 func (p *Producer) produce(msg *Message, msgFlags int, deliveryChan chan Event) error {
 	if msg == nil || msg.TopicPartition.Topic == nil || len(*msg.TopicPartition.Topic) == 0 {
-		return newErrorFromString(ErrInvalidArg, "")
+		return newErrorFromString(ErrInvalidArg, "nil message or nil/empty topic")
 	}
 
 	crkt := p.handle.getRkt(*msg.TopicPartition.Topic)


### PR DESCRIPTION
Tiniest fix that will save time for someone.

I'm a newbie in Kafka, so I was sure there was something wrong with my Kafka setup, while I was decoding the topic wrong. It results in an empty topic being passed to `Produce()` function. The reason why I spent a few hours trying to understand what was wrong was the error messages saying `Local: Invalid argument or configuration`. I couldn't understand what it means and spent hours figuring out what was wrong. Hope this small change will help.
