### PR TITLE
Add IsTimeout method to Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This is a maintenance release:
    will be used for subsequent (new) connections to a broker.
  * Channel based producer (Producer `ProduceChannel()`) and channel based
    consumer (Consumer `Events()`) are deprecated.
+ * Added `IsTimeout()` on Error type. This is a convenience method that checks
+   if the error is due to a timeout.
 
 
 ## v1.9.2

--- a/README.md
+++ b/README.md
@@ -68,10 +68,10 @@ func main() {
 		msg, err := c.ReadMessage(time.Second)
 		if err == nil {
 			fmt.Printf("Message on %s: %s\n", msg.TopicPartition, string(msg.Value))
-		} else if err.(kafka.Error).Code() != kafka.ErrTimedOut {
+		} else if !err.(kafka.Error).IsTimeout() {
 			// The client will automatically try to recover from all errors.
-			// kafka.ErrTimedOut is not considered an error because it is
-			// raised by ReadMessage on timeout.
+			// Timeout is not considered an error because it is raised by
+			// ReadMessage in absence of messages.
 			fmt.Printf("Consumer error: %v (%v)\n", err, msg)
 		}
 	}

--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -367,7 +367,7 @@ func (c *Consumer) Logs() chan LogEvent {
 // a new message or error. `timeout` may be set to -1 for
 // indefinite wait.
 //
-// Timeout is returned as (nil, err) where err is `err.(kafka.Error).Code() == kafka.ErrTimedOut`.
+// Timeout is returned as (nil, err) where `err.(kafka.Error).IsTimeout() == true`.
 //
 // Messages are returned as (msg, nil),
 // while general errors are returned as (nil, err),

--- a/kafka/error.go
+++ b/kafka/error.go
@@ -127,6 +127,12 @@ func (e Error) IsRetriable() bool {
 	return e.retriable
 }
 
+// IsTimeout returns true if the error is a timeout error.
+// A timeout error indicates that the operation timed out locally.
+func (e Error) IsTimeout() bool {
+	return e.code == ErrTimedOut || e.code == ErrTimedOutQueue
+}
+
 // TxnRequiresAbort returns true if the error is an abortable transaction error
 // that requires the application to abort the current transaction with
 // AbortTransaction() and start a new transaction with BeginTransaction()


### PR DESCRIPTION
This convenience method just checks if Error code is ErrTimedOut.

Also modifies the example in README.md.

See https://github.com/confluentinc/confluent-kafka-go/pull/846#discussion_r1030215346 