### PR TITLE
[consumer] Ignore Seek() timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ This is a maintenance release:
    consumer (Consumer `Events()`) are deprecated.
  * Added `IsTimeout()` on Error type. This is a convenience method that checks
    if the error is due to a timeout.
+ * The timeout parameter on `Seek()` is now ignored and an infinite timeout is
+   used, the method will block until the fetcher state is updated (typically
+   within microseconds).
 
 
 ## v1.9.2

--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -308,11 +308,12 @@ func (c *Consumer) StoreMessage(m *Message) (storedOffsets []TopicPartition, err
 
 // Seek seeks the given topic partitions using the offset from the TopicPartition.
 //
-// If timeoutMs is not 0 the call will wait this long for the
-// seek to be performed. If the timeout is reached the internal state
-// will be unknown and this function returns ErrTimedOut.
-// If timeoutMs is 0 it will initiate the seek but return
-// immediately without any error reporting (e.g., async).
+// The ignoredTimeoutMs parameter is ignored. Instead, this method blocks until
+// the fetcher state is updated for the given partition with the new offset.
+// This guarantees that no previously fetched messages for the old offset (or
+// fetch position) will be passed to the application once this call returns.
+// It will still take some time after the method returns until messages are
+// fetched at the new offset.
 //
 // Seek() may only be used for partitions already being consumed
 // (through Assign() or implicitly through a self-rebalanced Subscribe()).
@@ -320,12 +321,12 @@ func (c *Consumer) StoreMessage(m *Message) (storedOffsets []TopicPartition, err
 // a starting offset for each partition.
 //
 // Returns an error on failure or nil otherwise.
-func (c *Consumer) Seek(partition TopicPartition, timeoutMs int) error {
+func (c *Consumer) Seek(partition TopicPartition, ignoredTimeoutMs int) error {
 	rkt := c.handle.getRkt(*partition.Topic)
 	cErr := C.rd_kafka_seek(rkt,
 		C.int32_t(partition.Partition),
 		C.int64_t(partition.Offset),
-		C.int(timeoutMs))
+		C.int(-1))
 	if cErr != C.RD_KAFKA_RESP_ERR_NO_ERROR {
 		return newError(cErr)
 	}

--- a/kafka/consumer_test.go
+++ b/kafka/consumer_test.go
@@ -105,7 +105,9 @@ func TestConsumerAPIs(t *testing.T) {
 		t.Errorf("Assign failed: %s", err)
 	}
 
-	err = c.Seek(TopicPartition{Topic: &topic1, Partition: 2, Offset: -1}, 1000)
+	// We provide a very small timeout for Seek, to test that the timeout is
+	// ignored.
+	err = c.Seek(TopicPartition{Topic: &topic1, Partition: 2, Offset: -1}, 1)
 	if err != nil {
 		t.Errorf("Seek failed: %s", err)
 	}


### PR DESCRIPTION
Seek timeout is ignored and an infinite timeout is used instead. The method will block till fetcher state is updated and the seek is registered.

See #888.