### PR TITLE
[consumer] Add SeekPartitions to Consumer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This is a maintenance release:
  * The timeout parameter on `Seek()` is now ignored and an infinite timeout is
    used, the method will block until the fetcher state is updated (typically
    within microseconds).
+ * Added Consumer `SeekPartitions()` method to seek multiple partitions at
+   once and deprecated `Seek()`.
 
 
 ## v1.9.2

--- a/kafka/consumer_test.go
+++ b/kafka/consumer_test.go
@@ -112,6 +112,25 @@ func TestConsumerAPIs(t *testing.T) {
 		t.Errorf("Seek failed: %s", err)
 	}
 
+	// SeekPartitions
+	seekedPartitions, err := c.SeekPartitions([]TopicPartition{})
+	if err == nil {
+		t.Errorf("SeekPartitions(empty) succeeded when it should fail")
+	}
+
+	seekedPartitions, err = c.SeekPartitions([]TopicPartition{
+		{Topic: &topic, Partition: 0, Offset: -1},
+		{Topic: &topic, Partition: 1, Offset: 1},
+	})
+	if err != nil {
+		t.Errorf("SeekPartitions() failed: %s", err)
+	}
+	if len(seekedPartitions) != 2 {
+		t.Errorf(
+			"SeekedPartitions() seekedPartitions length %d should be 2",
+			len(seekedPartitions))
+	}
+
 	// Pause & Resume
 	err = c.Pause([]TopicPartition{{Topic: &topic1, Partition: 2},
 		{Topic: &topic2, Partition: 1}})


### PR DESCRIPTION
Allows seeking multiple partitions.
Deprecates Seek(), which supports seeking single partition.

See #902