### PR TITLE
Initialize Root CA pool before calling AppendCertsFromPEM when setting up SR rest

### DIFF
--- a/schemaregistry/rest_service.go
+++ b/schemaregistry/rest_service.go
@@ -19,6 +19,7 @@ package schemaregistry
 import (
 	"bytes"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -172,6 +173,7 @@ func configureTLS(conf *Config, tlsConf *tls.Config) error {
 		if err != nil {
 			return err
 		}
+		tlsConf.RootCAs = x509.NewCertPool()
 		tlsConf.RootCAs.AppendCertsFromPEM(caCert)
 		if err != nil {
 			return err


### PR DESCRIPTION
This is required as per:
https://pkg.go.dev/crypto/x509#CertPool.AppendCertsFromPEM

This is a fix for this issue:
https://github.com/confluentinc/confluent-kafka-go/issues/876