### PR TITLE
Update go version and add developer instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This is a maintenance release:
  * The timeout parameter on `Seek()` is now ignored and an infinite timeout is
    used, the method will block until the fetcher state is updated (typically
    within microseconds).
+ * The minimum version of Go supported has been changed from 1.11 to 1.14.
 
 
 ## v1.9.2

--- a/README.md
+++ b/README.md
@@ -133,12 +133,12 @@ for use with [Confluent Cloud](https://www.confluent.io/confluent-cloud/).
 Getting Started
 ===============
 
-Supports Go 1.11+ and librdkafka 1.9.0+.
+Supports Go 1.14+ and librdkafka 1.9.0+.
 
 Using Go Modules
 ----------------
 
-Starting with Go 1.13, you can use [Go Modules](https://blog.golang.org/using-go-modules) to install
+You can use [Go Modules](https://blog.golang.org/using-go-modules) to install
 confluent-kafka-go.
 
 Import the `kafka` package from GitHub in your code:

--- a/kafka/README.md
+++ b/kafka/README.md
@@ -1,13 +1,21 @@
 # Information for confluent-kafka-go developers
 
-Whenever librdkafka error codes are updated make sure to run generate
+## Development process
+
+1. Use go1.18 (and related tooling) for development on confluent-kafka-go.
+2. Make sure to run `gofmt` and `go vet` on your code.
+3. While there is no hard-limit, try to keep your line length under 80
+   characters.
+3. [Test](#testing) your changes and create a PR.
+
+
+NOTE: Whenever librdkafka error codes are updated make sure to run generate
 before building:
 
 ```
   $ make -f mk/Makefile generr
   $ go build ./...
 ```
-
 
 
 


### PR DESCRIPTION
The go version is updated because 1.11 has been long out of support, and parts of the code are already using features only available in 1.13+. 

The oldest version of go officially supported (by the golang team) is 1.18, but that is a bit too aggressive for us, and so we go for 1.14. 

And as for preferring go1.18 for development, it's because go1.19 has a bunch of changes in gofmt etc, and the release has been out only recently. So we will stick to 1.18 till it's out of support, and then make the changes to all files with the new gofmt.