### PR TITLE
Change development version to go1.19

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -11,7 +11,7 @@ global_job_config:
     commands:
       - checkout
 blocks:
-  - name: "Go 1.17 OSX bundled librdkafka"
+  - name: "Go 1.19 OSX bundled librdkafka"
     dependencies: [ ]
     task:
       agent:
@@ -19,7 +19,8 @@ blocks:
           type: s1-prod-macos
       prologue:
         commands:
-          - sem-version go 1.18
+          - sem-version go 1.19
+          - export GOPATH=$(go env GOPATH)
           - export PATH="$PATH:$GOPATH/bin"
           - export PKG_CONFIG_PATH="/usr/local/opt/openssl/lib/pkgconfig:$HOME/confluent-kafka-go/tmp-build/lib/pkgconfig"
           - export LD_LIBRARY_PATH="$HOME/confluent-kafka-go/tmp-build/lib"
@@ -37,7 +38,7 @@ blocks:
             - name: EXPECT_LINK_INFO
               value: dynamic
           commands_file: semaphore_commands.sh
-  - name: "Go 1.17 linux bundled librdkafka"
+  - name: "Go 1.19 linux bundled librdkafka"
     dependencies: [ ]
     task:
       agent:
@@ -45,7 +46,8 @@ blocks:
           type: s1-prod-ubuntu20-04-amd64-2
       prologue:
         commands:
-          - sem-version go 1.17
+          - sem-version go 1.19
+          - export GOPATH=$(go env GOPATH)
           - export PATH="$PATH:$GOPATH/bin"
           - export PKG_CONFIG_PATH="$HOME/confluent-kafka-go/tmp-build/lib/pkgconfig"
           - export LD_LIBRARY_PATH="$HOME/confluent-kafka-go/tmp-build/lib"
@@ -67,7 +69,7 @@ blocks:
             - name: EXPECT_LINK_INFO
               value: dynamic
           commands_file: semaphore_commands.sh
-  - name: "Go 1.17 linux arm64 bundled librdkafka"
+  - name: "Go 1.19 linux arm64 bundled librdkafka"
     dependencies: [ ]
     task:
       agent:
@@ -75,7 +77,8 @@ blocks:
           type: s1-prod-ubuntu20-04-arm64-1
       prologue:
         commands:
-          - sem-version go 1.17
+          - sem-version go 1.19
+          - export GOPATH=$(go env GOPATH)
           - export PATH="$PATH:$GOPATH/bin"
           - export PKG_CONFIG_PATH="$HOME/confluent-kafka-go/tmp-build/lib/pkgconfig"
           - export LD_LIBRARY_PATH="$HOME/confluent-kafka-go/tmp-build/lib"
@@ -97,7 +100,7 @@ blocks:
             - name: EXPECT_LINK_INFO
               value: dynamic
           commands_file: semaphore_commands.sh
-  - name: "Go 1.17 Windows bundled librdkafka"
+  - name: "Go 1.19 Windows bundled librdkafka"
     dependencies: [ ]
     task:
       agent:
@@ -106,10 +109,10 @@ blocks:
       prologue:
         commands:
           # Install Go
-          - cache restore win-go-1.17
+          - cache restore win-go-1.19
           - "& .\\mk\\setup-go.ps1"
-          - cache delete win-go-1.17
-          - cache store win-go-1.17 ($env:USERPROFILE + '\go')
+          - cache delete win-go-1.19
+          - cache store win-go-1.19 ($env:USERPROFILE + '\go')
           - cache restore msys2-x64
           # Set up msys2
           - ".\\mk\\mingw-w64\\setup-msys2.ps1"

--- a/kafka/README.md
+++ b/kafka/README.md
@@ -2,7 +2,7 @@
 
 ## Development process
 
-1. Use go1.18 (and related tooling) for development on confluent-kafka-go.
+1. Use go1.19 (and related tooling) for development on confluent-kafka-go.
 2. Make sure to run `gofmt` and `go vet` on your code.
 3. While there is no hard-limit, try to keep your line length under 80
    characters.

--- a/kafka/adminapi.go
+++ b/kafka/adminapi.go
@@ -1632,9 +1632,9 @@ func (a *AdminClient) cToDeleteACLsResults(cDeleteACLsResResponse **C.rd_kafka_D
 // CreateACLs creates one or more ACL bindings.
 //
 // Parameters:
-//  * `ctx` - context with the maximum amount of time to block, or nil for indefinite.
-//  * `aclBindings` - A slice of ACL binding specifications to create.
-//  * `options` - Create ACLs options
+//   - `ctx` - context with the maximum amount of time to block, or nil for indefinite.
+//   - `aclBindings` - A slice of ACL binding specifications to create.
+//   - `options` - Create ACLs options
 //
 // Returns a slice of CreateACLResult with a ErrNoError ErrorCode when the operation was successful
 // plus an error that is not nil for client level errors
@@ -1701,15 +1701,15 @@ func (a *AdminClient) CreateACLs(ctx context.Context, aclBindings ACLBindings, o
 // DescribeACLs matches ACL bindings by filter.
 //
 // Parameters:
-//  * `ctx` - context with the maximum amount of time to block, or nil for indefinite.
-//  * `aclBindingFilter` - A filter with attributes that must match.
+//   - `ctx` - context with the maximum amount of time to block, or nil for indefinite.
+//   - `aclBindingFilter` - A filter with attributes that must match.
 //     string attributes match exact values or any string if set to empty string.
 //     Enum attributes match exact values or any value if ending with `Any`.
 //     If `ResourcePatternType` is set to `ResourcePatternTypeMatch` returns ACL bindings with:
-//     - `ResourcePatternTypeLiteral` pattern type with resource name equal to the given resource name
-//     - `ResourcePatternTypeLiteral` pattern type with wildcard resource name that matches the given resource name
-//     - `ResourcePatternTypePrefixed` pattern type with resource name that is a prefix of the given resource name
-//  * `options` - Describe ACLs options
+//   - `ResourcePatternTypeLiteral` pattern type with resource name equal to the given resource name
+//   - `ResourcePatternTypeLiteral` pattern type with wildcard resource name that matches the given resource name
+//   - `ResourcePatternTypePrefixed` pattern type with resource name that is a prefix of the given resource name
+//   - `options` - Describe ACLs options
 //
 // Returns a slice of ACLBindings when the operation was successful
 // plus an error that is not `nil` for client level errors
@@ -1757,15 +1757,15 @@ func (a *AdminClient) DescribeACLs(ctx context.Context, aclBindingFilter ACLBind
 // DeleteACLs deletes ACL bindings matching one or more ACL binding filters.
 //
 // Parameters:
-//  * `ctx` - context with the maximum amount of time to block, or nil for indefinite.
-//  * `aclBindingFilters` - a slice of ACL binding filters to match ACLs to delete.
+//   - `ctx` - context with the maximum amount of time to block, or nil for indefinite.
+//   - `aclBindingFilters` - a slice of ACL binding filters to match ACLs to delete.
 //     string attributes match exact values or any string if set to empty string.
 //     Enum attributes match exact values or any value if ending with `Any`.
 //     If `ResourcePatternType` is set to `ResourcePatternTypeMatch` deletes ACL bindings with:
-//     - `ResourcePatternTypeLiteral` pattern type with resource name equal to the given resource name
-//     - `ResourcePatternTypeLiteral` pattern type with wildcard resource name that matches the given resource name
-//     - `ResourcePatternTypePrefixed` pattern type with resource name that is a prefix of the given resource name
-//  * `options` - Delete ACLs options
+//   - `ResourcePatternTypeLiteral` pattern type with resource name equal to the given resource name
+//   - `ResourcePatternTypeLiteral` pattern type with wildcard resource name that matches the given resource name
+//   - `ResourcePatternTypePrefixed` pattern type with resource name that is a prefix of the given resource name
+//   - `options` - Delete ACLs options
 //
 // Returns a slice of ACLBinding for each filter when the operation was successful
 // plus an error that is not `nil` for client level errors
@@ -1855,9 +1855,10 @@ func (a *AdminClient) Close() {
 // ListConsumerGroups lists the consumer groups available in the cluster.
 //
 // Parameters:
-//  * `ctx` - context with the maximum amount of time to block, or nil for
-//    indefinite.
-//  * `options` - ListConsumerGroupsAdminOption options.
+//   - `ctx` - context with the maximum amount of time to block, or nil for
+//     indefinite.
+//   - `options` - ListConsumerGroupsAdminOption options.
+//
 // Returns a ListConsumerGroupsResult, which contains a slice corresponding to
 // each group in the cluster and a slice of errors encountered while listing.
 // Additionally, an error that is not nil for client-level errors is returned.
@@ -1918,10 +1919,10 @@ func (a *AdminClient) ListConsumerGroups(
 // groups list.
 //
 // Parameters:
-//  * `ctx` - context with the maximum amount of time to block, or nil for
-//    indefinite.
-//  * `groups` - Slice of groups to describe. This should not be nil/empty.
-//  * `options` - DescribeConsumerGroupsAdminOption options.
+//   - `ctx` - context with the maximum amount of time to block, or nil for
+//     indefinite.
+//   - `groups` - Slice of groups to describe. This should not be nil/empty.
+//   - `options` - DescribeConsumerGroupsAdminOption options.
 //
 // Returns DescribeConsumerGroupsResult, which contains a slice of
 // ConsumerGroupDescriptions corresponding to the input groups, plus an error
@@ -1991,14 +1992,15 @@ func (a *AdminClient) DescribeConsumerGroups(
 
 // DeleteConsumerGroups deletes a batch of consumer groups.
 // Parameters:
-//  * `ctx` - context with the maximum amount of time to block, or nil for
-//    indefinite.
-//  * `groups` - A slice of groupIDs to delete.
-//  * `options` - DeleteConsumerGroupsAdminOption options.
+//   - `ctx` - context with the maximum amount of time to block, or nil for
+//     indefinite.
+//   - `groups` - A slice of groupIDs to delete.
+//   - `options` - DeleteConsumerGroupsAdminOption options.
 //
 // Returns a DeleteConsumerGroupsResult containing a slice of ConsumerGroupResult, with
-//  group-level errors, (if any) contained inside; and an error that is not nil
-//  for client level errors.
+//
+//	group-level errors, (if any) contained inside; and an error that is not nil
+//	for client level errors.
 func (a *AdminClient) DeleteConsumerGroups(
 	ctx context.Context,
 	groups []string, options ...DeleteConsumerGroupsAdminOption) (result DeleteConsumerGroupsResult, err error) {
@@ -2064,12 +2066,12 @@ func (a *AdminClient) DeleteConsumerGroups(
 // consumer group(s).
 //
 // Parameters:
-//  * `ctx` - context with the maximum amount of time to block, or nil for indefinite.
-//  * `groupsPartitions` - a slice of ConsumerGroupTopicPartitions, each element of which
+//   - `ctx` - context with the maximum amount of time to block, or nil for indefinite.
+//   - `groupsPartitions` - a slice of ConsumerGroupTopicPartitions, each element of which
 //     has the id of a consumer group, and a slice of the TopicPartitions we
 //     need to fetch the offsets for.
 //     Currently, the size of `groupsPartitions` has to be exactly one.
-//  * `options` - ListConsumerGroupOffsetsAdminOption options.
+//   - `options` - ListConsumerGroupOffsetsAdminOption options.
 //
 // Returns a ListConsumerGroupOffsetsResult, containing a slice of
 // ConsumerGroupTopicPartitions corresponding to the input slice, plus an error that is
@@ -2153,13 +2155,13 @@ func (a *AdminClient) ListConsumerGroupOffsets(
 // consumer group(s).
 //
 // Parameters:
-//  * `ctx` - context with the maximum amount of time to block, or nil for
+//   - `ctx` - context with the maximum amount of time to block, or nil for
 //     indefinite.
-//  * `groupsPartitions` - a slice of ConsumerGroupTopicPartitions, each element of
+//   - `groupsPartitions` - a slice of ConsumerGroupTopicPartitions, each element of
 //     which has the id of a consumer group, and a slice of the TopicPartitions
 //     we need to alter the offsets for. Currently, the size of
 //     `groupsPartitions` has to be exactly one.
-//  * `options` - AlterConsumerGroupOffsetsAdminOption options.
+//   - `options` - AlterConsumerGroupOffsetsAdminOption options.
 //
 // Returns a AlterConsumerGroupOffsetsResult, containing a slice of
 // ConsumerGroupTopicPartitions corresponding to the input slice, plus an error

--- a/kafka/build_dynamic.go
+++ b/kafka/build_dynamic.go
@@ -1,3 +1,4 @@
+//go:build dynamic
 // +build dynamic
 
 package kafka

--- a/kafka/config.go
+++ b/kafka/config.go
@@ -30,7 +30,8 @@ import (
 import "C"
 
 // ConfigValue supports the following types:
-//  bool, int, string, any type with the standard String() interface
+//
+//	bool, int, string, any type with the standard String() interface
 type ConfigValue interface{}
 
 // ConfigMap is a map containing standard librdkafka configuration properties as documented in:

--- a/kafka/config_test.go
+++ b/kafka/config_test.go
@@ -32,7 +32,7 @@ func (hp HostPortType) String() string {
 	return fmt.Sprintf("%s:%d", hp.Host, hp.Port)
 }
 
-//Test config map APIs
+// Test config map APIs
 func TestConfigMapAPIs(t *testing.T) {
 	config := &ConfigMap{}
 

--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -335,10 +335,11 @@ func (c *Consumer) Seek(partition TopicPartition, ignoredTimeoutMs int) error {
 
 // Poll the consumer for messages or events.
 //
-// Will block for at most timeoutMs milliseconds
+// # Will block for at most timeoutMs milliseconds
 //
 // The following callbacks may be triggered:
-//   Subscribe()'s rebalanceCb
+//
+//	Subscribe()'s rebalanceCb
 //
 // Returns nil on timeout, else an Event
 func (c *Consumer) Poll(timeoutMs int) (event Event) {
@@ -376,7 +377,6 @@ func (c *Consumer) Logs() chan LogEvent {
 // msg.TopicPartition provides partition-specific information (such as topic, partition and offset).
 //
 // All other event types, such as PartitionEOF, AssignedPartitions, etc, are silently discarded.
-//
 func (c *Consumer) ReadMessage(timeout time.Duration) (*Message, error) {
 
 	var absTimeout time.Time
@@ -450,14 +450,15 @@ func (c *Consumer) Close() (err error) {
 // conf is a *ConfigMap with standard librdkafka configuration properties.
 //
 // Supported special configuration properties:
-//   go.application.rebalance.enable (bool, false) - Forward rebalancing responsibility to application via the Events() channel.
-//                                        If set to true the app must handle the AssignedPartitions and
-//                                        RevokedPartitions events and call Assign() and Unassign()
-//                                        respectively.
-//   go.events.channel.enable (bool, false) - [deprecated] Enable the Events() channel. Messages and events will be pushed on the Events() channel and the Poll() interface will be disabled.
-//   go.events.channel.size (int, 1000) - Events() channel size
-//   go.logs.channel.enable (bool, false) - Forward log to Logs() channel.
-//   go.logs.channel (chan kafka.LogEvent, nil) - Forward logs to application-provided channel instead of Logs(). Requires go.logs.channel.enable=true.
+//
+//	go.application.rebalance.enable (bool, false) - Forward rebalancing responsibility to application via the Events() channel.
+//	                                     If set to true the app must handle the AssignedPartitions and
+//	                                     RevokedPartitions events and call Assign() and Unassign()
+//	                                     respectively.
+//	go.events.channel.enable (bool, false) - [deprecated] Enable the Events() channel. Messages and events will be pushed on the Events() channel and the Poll() interface will be disabled.
+//	go.events.channel.size (int, 1000) - Events() channel size
+//	go.logs.channel.enable (bool, false) - Forward log to Logs() channel.
+//	go.logs.channel (chan kafka.LogEvent, nil) - Forward logs to application-provided channel instead of Logs(). Requires go.logs.channel.enable=true.
 //
 // WARNING: Due to the buffering nature of channels (and queues in general) the
 // use of the events channel risks receiving outdated events and

--- a/kafka/consumer_test.go
+++ b/kafka/consumer_test.go
@@ -531,31 +531,31 @@ func testPoll(c *Consumer, doneChan chan bool, t *testing.T, wg *sync.WaitGroup)
 // TestConsumerCloseForStaticMember verifies the rebalance
 // for static membership.
 // According to KIP-345, the consumer group will not trigger rebalance unless
-// 1) A new member joins
-// 2) A leader rejoins (possibly due to topic assignment change)
-// 3) An existing member offline time is over session timeout
-// 4) Broker receives a leave group request containing alistof
-//    `group.instance.id`s (details later)
+//  1. A new member joins
+//  2. A leader rejoins (possibly due to topic assignment change)
+//  3. An existing member offline time is over session timeout
+//  4. Broker receives a leave group request containing alistof
+//     `group.instance.id`s (details later)
 //
 // This test uses 3 consumers while each consumer joins after the assignment
 // finished for the previous consumers.
 // The expected behavior for these consumers are:
-// 1) First consumer joins, AssignedPartitions happens. Assign all the
-//    partitions to it.
-// 2) Second consumer joins, RevokedPartitions happens from the first consumer,
-//    then AssignedPartitions happens to both consumers.
-// 3) Third consumer joins, RevokedPartitions happens from the previous two
-//    consumers, then AssignedPartitions happens to all the three consumers.
-// 4) Close the second consumer, revoke its assignments will happen, but it
-//    should not notice other consumers.
-// 5) Rejoin the second consumer, rebalance should not happen to all the other
-//    consumers since it's not the leader, AssignedPartitions only happened
-//    to this consumer to assign the partitions.
-// 6) Close the third consumer, revoke its assignments will happen, but it
-//    should not notice other consumers.
-// 7) Close the rejoined consumer, revoke its assignments will happen,
-//    but it should not notice other consumers.
-// 8) Close the first consumer, revoke its assignments will happen.
+//  1. First consumer joins, AssignedPartitions happens. Assign all the
+//     partitions to it.
+//  2. Second consumer joins, RevokedPartitions happens from the first consumer,
+//     then AssignedPartitions happens to both consumers.
+//  3. Third consumer joins, RevokedPartitions happens from the previous two
+//     consumers, then AssignedPartitions happens to all the three consumers.
+//  4. Close the second consumer, revoke its assignments will happen, but it
+//     should not notice other consumers.
+//  5. Rejoin the second consumer, rebalance should not happen to all the other
+//     consumers since it's not the leader, AssignedPartitions only happened
+//     to this consumer to assign the partitions.
+//  6. Close the third consumer, revoke its assignments will happen, but it
+//     should not notice other consumers.
+//  7. Close the rejoined consumer, revoke its assignments will happen,
+//     but it should not notice other consumers.
+//  8. Close the first consumer, revoke its assignments will happen.
 //
 // The total number of AssignedPartitions for the first consumer is 3,
 // and the total number of RevokedPartitions for the first consumer is 3.

--- a/kafka/error_test.go
+++ b/kafka/error_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 )
 
-//TestFatalError tests fatal errors
+// TestFatalError tests fatal errors
 func TestFatalError(t *testing.T) {
 	fatalErr := newErrorFromString(ErrOutOfOrderSequenceNumber, "Testing a fatal error")
 	fatalErr.fatal = true
@@ -37,7 +37,7 @@ func TestFatalError(t *testing.T) {
 	t.Logf("%v", normalErr)
 }
 
-//TestFatalErrorClient tests fatal errors using a client instance
+// TestFatalErrorClient tests fatal errors using a client instance
 func TestFatalErrorClient(t *testing.T) {
 	p, err := NewProducer(&ConfigMap{})
 	if err != nil {

--- a/kafka/integration_test.go
+++ b/kafka/integration_test.go
@@ -456,7 +456,7 @@ func consumerTest(t *testing.T, testname string, assignmentStrategy string, msgc
 
 }
 
-//Test consumer QueryWatermarkOffsets API
+// Test consumer QueryWatermarkOffsets API
 func TestConsumerQueryWatermarkOffsets(t *testing.T) {
 	if !testconfRead() {
 		t.Skipf("Missing testconf.json")
@@ -489,7 +489,7 @@ func TestConsumerQueryWatermarkOffsets(t *testing.T) {
 
 }
 
-//Test consumer GetWatermarkOffsets API
+// Test consumer GetWatermarkOffsets API
 func TestConsumerGetWatermarkOffsets(t *testing.T) {
 	if !testconfRead() {
 		t.Skipf("Missing testconf.json")
@@ -546,7 +546,7 @@ func TestConsumerGetWatermarkOffsets(t *testing.T) {
 
 }
 
-//TestConsumerOffsetsForTimes
+// TestConsumerOffsetsForTimes
 func TestConsumerOffsetsForTimes(t *testing.T) {
 	if !testconfRead() {
 		t.Skipf("Missing testconf.json")
@@ -645,7 +645,7 @@ func TestConsumerGetMetadata(t *testing.T) {
 	t.Logf("Meta data for consumer: %v\n", metaData)
 }
 
-//Test producer QueryWatermarkOffsets API
+// Test producer QueryWatermarkOffsets API
 func TestProducerQueryWatermarkOffsets(t *testing.T) {
 	if !testconfRead() {
 		t.Skipf("Missing testconf.json")
@@ -689,7 +689,7 @@ func TestProducerQueryWatermarkOffsets(t *testing.T) {
 	}
 }
 
-//Test producer GetMetadata API
+// Test producer GetMetadata API
 func TestProducerGetMetadata(t *testing.T) {
 	if !testconfRead() {
 		t.Skipf("Missing testconf.json")
@@ -1422,7 +1422,9 @@ func TestAdminClient_DeleteConsumerGroups(t *testing.T) {
 
 // TestAdminClient_ListAndDescribeConsumerGroups validates the working of the
 // list consumer groups and describe consumer group APIs of the admin client.
-//  We test the following situations:
+//
+//	We test the following situations:
+//
 // 1. One consumer group with one client.
 // 2. One consumer group with two clients.
 // 3. Empty consumer group.
@@ -2016,7 +2018,7 @@ func TestAdminConfig(t *testing.T) {
 
 }
 
-//Test AdminClient GetMetadata API
+// Test AdminClient GetMetadata API
 func TestAdminGetMetadata(t *testing.T) {
 	if !testconfRead() {
 		t.Skipf("Missing testconf.json")

--- a/kafka/kafka.go
+++ b/kafka/kafka.go
@@ -17,8 +17,7 @@
 // Package kafka provides high-level Apache Kafka producer and consumers
 // using bindings on-top of the librdkafka C library.
 //
-//
-// High-level Consumer
+// # High-level Consumer
 //
 // * Decide if you want to read messages and events by calling `.Poll()` or
 // the deprecated option of using the `.Events()` channel. (If you want to use
@@ -61,9 +60,7 @@
 // * When you are done consuming call `.Close()` to commit final offsets
 // and leave the consumer group.
 //
-//
-//
-// Producer
+// # Producer
 //
 // * Create a Producer with `kafka.NewProducer()` providing at least
 // the `bootstrap.servers` configuration properties.
@@ -92,8 +89,7 @@
 //
 // * Finally call `.Close()` to decommission the producer.
 //
-//
-// Transactional producer API
+// # Transactional producer API
 //
 // The transactional producer operates on top of the idempotent producer,
 // and provides full exactly-once semantics (EOS) for Apache Kafka when used
@@ -185,27 +181,27 @@
 // neither the retriable or abortable flags set, as fatal.
 //
 // Error handling example:
-//     retry:
 //
-//        err := producer.CommitTransaction(...)
-//        if err == nil {
-//            return nil
-//        } else if err.(kafka.Error).TxnRequiresAbort() {
-//            do_abort_transaction_and_reset_inputs()
-//        } else if err.(kafka.Error).IsRetriable() {
-//            goto retry
-//        } else { // treat all other errors as fatal errors
-//            panic(err)
-//        }
+//	retry:
 //
+//	   err := producer.CommitTransaction(...)
+//	   if err == nil {
+//	       return nil
+//	   } else if err.(kafka.Error).TxnRequiresAbort() {
+//	       do_abort_transaction_and_reset_inputs()
+//	   } else if err.(kafka.Error).IsRetriable() {
+//	       goto retry
+//	   } else { // treat all other errors as fatal errors
+//	       panic(err)
+//	   }
 //
-// Events
+// # Events
 //
 // Apart from emitting messages and delivery reports the client also communicates
 // with the application through a number of different event types.
 // An application may choose to handle or ignore these events.
 //
-// Consumer events
+// # Consumer events
 //
 // * `*kafka.Message` - a fetched message.
 //
@@ -221,14 +217,12 @@
 //
 // * `OffsetsCommitted` - Offset commit results (when `enable.auto.commit` is enabled).
 //
-//
-// Producer events
+// # Producer events
 //
 // * `*kafka.Message` - delivery report for produced message.
 // Check `.TopicPartition.Error` for delivery result.
 //
-//
-// Generic events for both Consumer and Producer
+// # Generic events for both Consumer and Producer
 //
 // * `KafkaError` - client (error codes are prefixed with _) or broker error.
 // These errors are normally just informational since the
@@ -242,7 +236,6 @@
 // if setting the token failed, which could happen if an extension doesn't meet
 // the required regular expression); invoking SetOAuthBearerTokenFailure() will
 // schedule a new event for 10 seconds later so another retrieval can be attempted.
-//
 //
 // Hint: If your application registers a signal notification
 // (signal.Notify) makes sure the signals channel is buffered to avoid

--- a/kafka/kafka_test.go
+++ b/kafka/kafka_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 )
 
-//Test LibraryVersion()
+// Test LibraryVersion()
 func TestLibraryVersion(t *testing.T) {
 	ver, verstr := LibraryVersion()
 	if ver >= 0x00090200 {
@@ -30,7 +30,7 @@ func TestLibraryVersion(t *testing.T) {
 	}
 }
 
-//Test Offset APIs
+// Test Offset APIs
 func TestOffsetAPIs(t *testing.T) {
 	offsets := []Offset{OffsetBeginning, OffsetEnd, OffsetInvalid, OffsetStored, 1001}
 	for _, offset := range offsets {

--- a/kafka/message.go
+++ b/kafka/message.go
@@ -44,7 +44,6 @@ void setup_rkmessage (rd_kafka_message_t *rkmessage,
 import "C"
 
 // TimestampType is a the Message timestamp type or source
-//
 type TimestampType int
 
 const (

--- a/kafka/message_test.go
+++ b/kafka/message_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 )
 
-//Test TimestampType
+// Test TimestampType
 func TestTimestampType(t *testing.T) {
 	timestampMap := map[TimestampType]string{TimestampCreateTime: "CreateTime",
 		TimestampLogAppendTime: "LogAppendTime",

--- a/kafka/producer.go
+++ b/kafka/producer.go
@@ -422,19 +422,19 @@ func (p *Producer) Purge(flags int) error {
 // conf is a *ConfigMap with standard librdkafka configuration properties.
 //
 // Supported special configuration properties (type, default):
-//   go.batch.producer (bool, false) - EXPERIMENTAL: Enable batch producer (for increased performance).
-//                                     These batches do not relate to Kafka message batches in any way.
-//                                     Note: timestamps and headers are not supported with this interface.
-//   go.delivery.reports (bool, true) - Forward per-message delivery reports to the
-//                                      Events() channel.
-//   go.delivery.report.fields (string, "key,value") - Comma separated list of fields to enable for delivery reports.
-//                                       Allowed values: all, none (or empty string), key, value, headers
-//                                       Warning: There is a performance penalty to include headers in the delivery report.
-//   go.events.channel.size (int, 1000000) - Events().
-//   go.produce.channel.size (int, 1000000) - ProduceChannel() buffer size (in number of messages)
-//   go.logs.channel.enable (bool, false) - Forward log to Logs() channel.
-//   go.logs.channel (chan kafka.LogEvent, nil) - Forward logs to application-provided channel instead of Logs(). Requires go.logs.channel.enable=true.
 //
+//	go.batch.producer (bool, false) - EXPERIMENTAL: Enable batch producer (for increased performance).
+//	                                  These batches do not relate to Kafka message batches in any way.
+//	                                  Note: timestamps and headers are not supported with this interface.
+//	go.delivery.reports (bool, true) - Forward per-message delivery reports to the
+//	                                   Events() channel.
+//	go.delivery.report.fields (string, "key,value") - Comma separated list of fields to enable for delivery reports.
+//	                                    Allowed values: all, none (or empty string), key, value, headers
+//	                                    Warning: There is a performance penalty to include headers in the delivery report.
+//	go.events.channel.size (int, 1000000) - Events().
+//	go.produce.channel.size (int, 1000000) - ProduceChannel() buffer size (in number of messages)
+//	go.logs.channel.enable (bool, false) - Forward log to Logs() channel.
+//	go.logs.channel (chan kafka.LogEvent, nil) - Forward logs to application-provided channel instead of Logs(). Requires go.logs.channel.enable=true.
 func NewProducer(conf *ConfigMap) (*Producer, error) {
 
 	err := versionCheck()
@@ -729,18 +729,18 @@ func (p *Producer) SetOAuthBearerTokenFailure(errstr string) error {
 // Upon successful return from this function the application has to perform at
 // least one of the following operations within `transaction.timeout.ms` to
 // avoid timing out the transaction on the broker:
-//  * `Produce()` (et.al)
-//  * `SendOffsetsToTransaction()`
-//  * `CommitTransaction()`
-//  * `AbortTransaction()`
+//   - `Produce()` (et.al)
+//   - `SendOffsetsToTransaction()`
+//   - `CommitTransaction()`
+//   - `AbortTransaction()`
 //
 // Parameters:
-//  * `ctx` - The maximum time to block, or nil for indefinite.
-//            On timeout the operation may continue in the background,
-//            depending on state, and it is okay to call `InitTransactions()`
-//            again.
-//            Providing a nil context or a context without a deadline uses
-//            the timeout 2*transaction.timeout.ms.
+//   - `ctx` - The maximum time to block, or nil for indefinite.
+//     On timeout the operation may continue in the background,
+//     depending on state, and it is okay to call `InitTransactions()`
+//     again.
+//     Providing a nil context or a context without a deadline uses
+//     the timeout 2*transaction.timeout.ms.
 //
 // Returns nil on success or an error on failure.
 // Check whether the returned error object permits retrying
@@ -801,13 +801,13 @@ func (p *Producer) BeginTransaction() error {
 // to committing the transaction with `CommitTransaction()`.
 //
 // Parameters:
-//  * `ctx` - The maximum amount of time to block, or nil for indefinite.
-//  * `offsets` - List of offsets to commit to the consumer group upon
-//                successful commit of the transaction. Offsets should be
-//                the next message to consume, e.g., last processed message + 1.
-//  * `consumerMetadata` - The current consumer group metadata as returned by
-//                `consumer.GetConsumerGroupMetadata()` on the consumer
-//                instance the provided offsets were consumed from.
+//   - `ctx` - The maximum amount of time to block, or nil for indefinite.
+//   - `offsets` - List of offsets to commit to the consumer group upon
+//     successful commit of the transaction. Offsets should be
+//     the next message to consume, e.g., last processed message + 1.
+//   - `consumerMetadata` - The current consumer group metadata as returned by
+//     `consumer.GetConsumerGroupMetadata()` on the consumer
+//     instance the provided offsets were consumed from.
 //
 // Note: The consumer must disable auto commits (set `enable.auto.commit` to false on the consumer).
 //
@@ -858,7 +858,7 @@ func (p *Producer) SendOffsetsToTransaction(ctx context.Context, offsets []Topic
 // transaction with `BeginTransaction()`.
 //
 // Parameters:
-//  * `ctx` - The maximum amount of time to block, or nil for indefinite.
+//   - `ctx` - The maximum amount of time to block, or nil for indefinite.
 //
 // Note: This function will block until all outstanding messages are
 // delivered and the transaction commit request has been successfully
@@ -896,7 +896,7 @@ func (p *Producer) CommitTransaction(ctx context.Context) error {
 // `ErrPurgeInflight` or `ErrPurgeQueue`.
 //
 // Parameters:
-//  * `ctx` - The maximum amount of time to block, or nil for indefinite.
+//   - `ctx` - The maximum amount of time to block, or nil for indefinite.
 //
 // Note: This function will block until all outstanding messages are purged
 // and the transaction abort request has been successfully

--- a/schemaregistry/cache/lrucache.go
+++ b/schemaregistry/cache/lrucache.go
@@ -36,7 +36,7 @@ type LRUCache struct {
 // NewLRUCache creates a new Least Recently Used (LRU) Cache
 //
 // Parameters:
-//  * `capacity` - a positive integer indicating the max capacity of this cache
+//   - `capacity` - a positive integer indicating the max capacity of this cache
 //
 // Returns the new allocated LRU Cache and an error
 func NewLRUCache(capacity int) (c *LRUCache, err error) {
@@ -59,7 +59,7 @@ func NewLRUCache(capacity int) (c *LRUCache, err error) {
 // Get returns the cache value associated with key
 //
 // Parameters:
-//  * `key` - the key to retrieve
+//   - `key` - the key to retrieve
 //
 // Returns the value associated with key and a bool that is `false`
 // if the key was not found
@@ -84,8 +84,8 @@ func (c *LRUCache) Get(key interface{}) (value interface{}, ok bool) {
 // Put puts a value in cache associated with key
 //
 // Parameters:
-//  * `key` - the key to put
-//  * `value` - the value to put
+//   - `key` - the key to put
+//   - `value` - the value to put
 func (c *LRUCache) Put(key interface{}, value interface{}) {
 	c.cacheLock.Lock()
 	_, ok := c.entries[key]
@@ -114,7 +114,7 @@ func (c *LRUCache) Put(key interface{}, value interface{}) {
 // Delete deletes the cache entry associated with key
 //
 // Parameters:
-//  * `key` - the key to delete
+//   - `key` - the key to delete
 func (c *LRUCache) Delete(key interface{}) {
 	c.cacheLock.RLock()
 	_, ok := c.entries[key]

--- a/schemaregistry/cache/mapcache.go
+++ b/schemaregistry/cache/mapcache.go
@@ -31,7 +31,7 @@ func NewMapCache() *MapCache {
 // Get returns the cache value associated with key
 //
 // Parameters:
-//  * `key` - the key to retrieve
+//   - `key` - the key to retrieve
 //
 // Returns the value associated with key and a bool that is `false`
 // if the key was not found
@@ -43,8 +43,8 @@ func (c *MapCache) Get(key interface{}) (value interface{}, ok bool) {
 // Put puts a value in cache associated with key
 //
 // Parameters:
-//  * `key` - the key to put
-//  * `value` - the value to put
+//   - `key` - the key to put
+//   - `value` - the value to put
 func (c *MapCache) Put(key interface{}, value interface{}) {
 	c.entries[key] = value
 }
@@ -52,7 +52,7 @@ func (c *MapCache) Put(key interface{}, value interface{}) {
 // Delete deletes the cache entry associated with key
 //
 // Parameters:
-//  * `key` - the key to delete
+//   - `key` - the key to delete
 func (c *MapCache) Delete(key interface{}) {
 	delete(c.entries, key)
 }

--- a/schemaregistry/test/nested.pb.go
+++ b/schemaregistry/test/nested.pb.go
@@ -342,7 +342,6 @@ func (*ComplexType_OneId) isComplexType_SomeVal() {}
 
 func (*ComplexType_OtherId) isComplexType_SomeVal() {}
 
-//
 // Complex message using nested protos and repeated fields
 type NestedMessage struct {
 	state         protoimpl.MessageState


### PR DESCRIPTION
Go 1.18 is no longer supported officially from today. (See https://go.dev/dl/)
Go 1.19 needs to be set as the development version.

1. Change the kafka/README.md
2. Run gofmt on all the code, since go1.19 makes several changes in gofmt, and doing it at once prevents it from happening in a piecemeal fashion later on.