### PR TITLE
 [consumer] Add SeekPartitions to Consumer  

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Confluent's Golang client for Apache Kafka
 
+## vNext
+
+ * Added Consumer `SeekPartitions()` method to seek multiple partitions at
+   once and deprecated `Seek()`.
+
 ## v2.0.2
 
 This is a feature release:

--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -384,6 +384,7 @@ func (c *Consumer) StoreMessage(m *Message) (storedOffsets []TopicPartition, err
 // a starting offset for each partition.
 //
 // Returns an error on failure or nil otherwise.
+// Deprecated: Seek is deprecated in favour of SeekPartitions().
 func (c *Consumer) Seek(partition TopicPartition, ignoredTimeoutMs int) error {
 	err := c.verifyClient()
 	if err != nil {
@@ -398,6 +399,32 @@ func (c *Consumer) Seek(partition TopicPartition, ignoredTimeoutMs int) error {
 		return newError(cErr)
 	}
 	return nil
+}
+
+// SeekPartitions seeks the given topic partitions to the per-partition offset
+// stored in the .Offset field of each partition.
+//
+// The offset may be either absolute (>= 0) or a logical offset (e.g. OffsetEnd).
+//
+// SeekPartitions() may only be used for partitions already being consumed
+// (through Assign() or implicitly through a self-rebalanced Subscribe()).
+// To set the starting offset it is preferred to use Assign() in a
+// kafka.AssignedPartitions handler and provide a starting offset for each
+// partition.
+//
+// Returns an error on failure or nil otherwise. Individual partition errors
+// should be checked in the per-partition .Error field.
+func (c *Consumer) SeekPartitions(partitions []TopicPartition) ([]TopicPartition, error) {
+	cPartitions := newCPartsFromTopicPartitions(partitions)
+	defer C.rd_kafka_topic_partition_list_destroy(cPartitions)
+
+	cErr := C.rd_kafka_seek_partitions(
+		c.handle.rk, cPartitions, -1 /* infinite timeout */)
+	if cErr != nil {
+		return nil, newErrorFromCErrorDestroy(cErr)
+	}
+
+	return newTopicPartitionsFromCparts(cPartitions), nil
 }
 
 // Poll the consumer for messages or events.

--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -415,6 +415,11 @@ func (c *Consumer) Seek(partition TopicPartition, ignoredTimeoutMs int) error {
 // Returns an error on failure or nil otherwise. Individual partition errors
 // should be checked in the per-partition .Error field.
 func (c *Consumer) SeekPartitions(partitions []TopicPartition) ([]TopicPartition, error) {
+	err := c.verifyClient()
+	if err != nil {
+		return nil, err
+	}
+
 	cPartitions := newCPartsFromTopicPartitions(partitions)
 	defer C.rd_kafka_topic_partition_list_destroy(cPartitions)
 

--- a/kafka/consumer_test.go
+++ b/kafka/consumer_test.go
@@ -115,6 +115,25 @@ func testConsumerAPIs(t *testing.T, c *Consumer, errCheck error) {
 		t.Errorf("Seek() should have thrown err : %s, but got %s", errCheck, err)
 	}
 
+	// SeekPartitions
+	seekedPartitions, err := c.SeekPartitions([]TopicPartition{})
+	if err == nil {
+		t.Errorf("SeekPartitions(empty) succeeded when it should fail")
+	}
+
+	seekedPartitions, err = c.SeekPartitions([]TopicPartition{
+		{Topic: &topic, Partition: 0, Offset: -1},
+		{Topic: &topic, Partition: 1, Offset: 1},
+	})
+	if err != nil {
+		t.Errorf("SeekPartitions() failed: %s", err)
+	}
+	if len(seekedPartitions) != 2 {
+		t.Errorf(
+			"SeekedPartitions() seekedPartitions length %d should be 2",
+			len(seekedPartitions))
+	}
+
 	// Pause & Resume
 	err = c.Pause([]TopicPartition{{Topic: &topic1, Partition: 2},
 		{Topic: &topic2, Partition: 1}})

--- a/kafka/consumer_test.go
+++ b/kafka/consumer_test.go
@@ -117,7 +117,7 @@ func testConsumerAPIs(t *testing.T, c *Consumer, errCheck error) {
 
 	// SeekPartitions
 	seekedPartitions, err := c.SeekPartitions([]TopicPartition{})
-	if err == nil {
+	if !c.IsClosed() && err == nil {
 		t.Errorf("SeekPartitions(empty) succeeded when it should fail")
 	}
 
@@ -125,12 +125,12 @@ func testConsumerAPIs(t *testing.T, c *Consumer, errCheck error) {
 		{Topic: &topic, Partition: 0, Offset: -1},
 		{Topic: &topic, Partition: 1, Offset: 1},
 	})
-	if err != nil {
-		t.Errorf("SeekPartitions() failed: %s", err)
+	if err != errCheck {
+		t.Errorf("SeekPartitions() should have thrown err : %s, but got %s", errCheck, err)
 	}
-	if len(seekedPartitions) != 2 {
-		t.Errorf(
-			"SeekedPartitions() seekedPartitions length %d should be 2",
+
+	if !c.IsClosed() && len(seekedPartitions) != 2 {
+		t.Errorf("SeekedPartitions() seekedPartitions length %d should be 2",
 			len(seekedPartitions))
 	}
 

--- a/kafka/integration_test.go
+++ b/kafka/integration_test.go
@@ -1262,6 +1262,81 @@ func TestProducerConsumerHeaders(t *testing.T) {
 	c.Close()
 }
 
+// TestConsumerSeekPartitions tests seeking of partitions using SeekPartitions().
+func TestConsumerSeekPartitions(t *testing.T) {
+	if !testconfRead() {
+		t.Skipf("Missing testconf.json")
+	}
+
+	numMessages := 10 // should be more than or equal to 2.
+
+	// Produce `numMessages` messages to Topic.
+	conf := ConfigMap{"bootstrap.servers": testconf.Brokers}
+	conf.updateFromTestconf()
+
+	producer, err := NewProducer(&conf)
+	if err != nil {
+		t.Fatalf("Failed to create producer: %s", err)
+	}
+
+	for idx := 0; idx < numMessages; idx++ {
+		if err = producer.Produce(&Message{
+			TopicPartition: TopicPartition{Topic: &testconf.Topic, Partition: 0},
+		}, nil); err != nil {
+			t.Fatalf("Failed to produce message: %s", err)
+		}
+	}
+
+	producer.Flush(10 * 1000)
+	producer.Close()
+
+	// Assign partition, seek to `numMessages`/2, and check by reading the message.
+	conf = ConfigMap{
+		"bootstrap.servers": testconf.Brokers,
+		"group.id":          testconf.GroupID,
+		"auto.offset.reset": "end",
+	}
+	conf.updateFromTestconf()
+
+	consumer, err := NewConsumer(&conf)
+	if err != nil {
+		t.Fatalf("Failed to create consumer: %s", err)
+	}
+
+	tps := []TopicPartition{
+		{Topic: &testconf.Topic, Partition: 0},
+	}
+	err = consumer.Assign(tps)
+	if err != nil {
+		t.Fatalf("Failed to assign partition: %s", err)
+	}
+
+	tps[0].Offset = Offset(numMessages / 2)
+	seekedPartitions, err := consumer.SeekPartitions(tps)
+	if err != nil {
+		t.Errorf("SeekPartitions failed: %s", err)
+	}
+	if len(seekedPartitions) != len(tps) {
+		t.Errorf(
+			"SeekPartitions should return result for %d partitions, %d returned",
+			len(tps), len(seekedPartitions))
+	}
+	for _, seekedPartition := range seekedPartitions {
+		if seekedPartition.Error != nil {
+			t.Errorf("Seek error for partition %v", seekedPartition)
+		}
+	}
+
+	msg, err := consumer.ReadMessage(10 * time.Second)
+	if err != nil {
+		t.Fatalf("ReadMessage failed: %s", err)
+	}
+	if msg.TopicPartition.Offset != Offset(numMessages/2) {
+		t.Errorf("Expected offset of read message is %d, got %d",
+			numMessages/2, msg.TopicPartition.Offset)
+	}
+}
+
 func validateTopicResult(t *testing.T, result []TopicResult, expError map[string]Error) {
 	for _, res := range result {
 		exp, ok := expError[res.Topic]


### PR DESCRIPTION
Allows seeking multiple partitions.
Deprecates Seek(), which supports seeking single partition.

See https://github.com/confluentinc/confluent-kafka-go/issues/902

Added for replacing #907 since it's on a fork.