### PR TITLE
fix nil pointer error on schemaregistry/serde/protobuf/protobuf.go

### DIFF
--- a/schemaregistry/serde/protobuf/protobuf.go
+++ b/schemaregistry/serde/protobuf/protobuf.go
@@ -193,10 +193,10 @@ func (s *Serializer) Serialize(topic string, msg interface{}) ([]byte, error) {
 
 func (s *Serializer) toProtobufSchema(msg proto.Message) (*desc.FileDescriptor, map[string]string, error) {
 	messageDesc, err := desc.LoadMessageDescriptorForMessage(protoV1.MessageV1(msg))
-	fileDesc := messageDesc.GetFile()
 	if err != nil {
 		return nil, nil, err
 	}
+	fileDesc := messageDesc.GetFile()
 	deps := make(map[string]string)
 	err = s.toDependencies(fileDesc, deps)
 	if err != nil {


### PR DESCRIPTION
an easy fix for potential nil pointer error.
we have hit nil pointer when desc.LoadMessageDescriptorForMessage() returns error. 