### PR TITLE
bugfix: update protobuf.Deserializer to use base class implementation of ConfigureDeserializer

### DIFF
--- a/schemaregistry/serde/protobuf/protobuf.go
+++ b/schemaregistry/serde/protobuf/protobuf.go
@@ -139,10 +139,9 @@ func (s *Deserializer) ConfigureDeserializer(client schemaregistry.Client, serde
 	if client == nil {
 		return fmt.Errorf("schema registry client missing")
 	}
-	s.Client = client
-	s.Conf = conf
-	s.SerdeType = serdeType
-	s.SubjectNameStrategy = serde.TopicNameStrategy
+	if err := s.BaseDeserializer.ConfigureDeserializer(client, serdeType, conf); err != nil {
+		return err
+	}
 	s.MessageFactory = s.protoMessageFactory
 	s.ProtoRegistry = new(protoregistry.Types)
 	return nil


### PR DESCRIPTION
Copying the functionality of a base implementation into the extending struct's implementation is a recipe for later bugs when changes are made in the base implementation that don't get copied into the extending implementation.  It is far better to call the base implementation and then just perform actions that are extension-specific in the extending implementation.