### PR TITLE
Deprecate msg.LeaderEpoch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This is a feature release.
  * Fixes a nil pointer bug in the protobuf `Serializer.Serialize()`, caused due to
    an unchecked error (#997, @baganokodo2022).
  * Fixes incorrect protofbuf FileDescriptor references (#989, @Mrmann87).
- * Deprecate m.LeaderEpoch in favor of m.TopicPartition.LeaderEpoch (#).
+ * Deprecate m.LeaderEpoch in favor of m.TopicPartition.LeaderEpoch (#1012).
 
 confluent-kafka-go is based on librdkafka v2.2.0, see the
 [librdkafka v2.2.0 release notes](https://github.com/confluentinc/librdkafka/releases/tag/v2.2.0-RC1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This is a feature release.
  * Fixes a nil pointer bug in the protobuf `Serializer.Serialize()`, caused due to
    an unchecked error (#997, @baganokodo2022).
  * Fixes incorrect protofbuf FileDescriptor references (#989, @Mrmann87).
+ * Deprecate m.LeaderEpoch in favor of m.TopicPartition.LeaderEpoch (#).
 
 confluent-kafka-go is based on librdkafka v2.2.0, see the
 [librdkafka v2.2.0 release notes](https://github.com/confluentinc/librdkafka/releases/tag/v2.2.0-RC1)

--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -365,7 +365,7 @@ func (c *Consumer) StoreMessage(m *Message) (storedOffsets []TopicPartition, err
 		return nil, newErrorFromString(ErrInvalidArg, "Can't store message with offset less than 0")
 	}
 
-	if m.LeaderEpoch != nil && *m.LeaderEpoch < 0 {
+	if m.TopicPartition.LeaderEpoch != nil && *m.TopicPartition.LeaderEpoch < 0 {
 		return nil, newErrorFromString(ErrInvalidArg, "Can't store message with leader epoch less than 0")
 	}
 

--- a/kafka/integration_test.go
+++ b/kafka/integration_test.go
@@ -681,7 +681,7 @@ func (its *IntegrationTestSuite) TestConsumerSeekPartitions() {
 		return
 	}
 
-	if *msg.TopicPartition.LeaderEpoch == 0 {
+	if *msg.TopicPartition.LeaderEpoch != 0 {
 		t.Errorf("Expected leader epoch of read message is %d, got %d",
 			0, *msg.TopicPartition.LeaderEpoch)
 	}

--- a/kafka/kafka.go
+++ b/kafka/kafka.go
@@ -281,7 +281,7 @@ type TopicPartition struct {
 	Offset      Offset
 	Metadata    *string
 	Error       error
-	LeaderEpoch *int32
+	LeaderEpoch *int32 // LeaderEpoch or nil if not available
 }
 
 func (p TopicPartition) String() string {

--- a/kafka/message.go
+++ b/kafka/message.go
@@ -77,7 +77,7 @@ type Message struct {
 	TimestampType  TimestampType
 	Opaque         interface{}
 	Headers        []Header
-	LeaderEpoch    *int32 // LeaderEpoch or nil if not available
+	LeaderEpoch    *int32 // Deprecated: LeaderEpoch or nil if not available. Use m.TopicPartition.LeaderEpoch instead.
 }
 
 // String returns a human readable representation of a Message.
@@ -165,6 +165,7 @@ func (h *handle) setupMessageFromC(msg *Message, cmsg *C.rd_kafka_message_t) {
 	leaderEpoch := int32(C.rd_kafka_message_leader_epoch(cmsg))
 	if leaderEpoch >= 0 {
 		msg.LeaderEpoch = &leaderEpoch
+		msg.TopicPartition.LeaderEpoch = &leaderEpoch
 	}
 }
 


### PR DESCRIPTION
msg.TopicPartition.LeaderEpoch is used when storing offsets, that field now is also used when returning the leader epoch associated to the message, similar to what happens with the offset.