### PR TITLE
Implement OAuthBearer mechanism for creating Kafka Producer by communicating with SPIRE agent

### DIFF
--- a/examples/spire_producer.example/spire_producer.example.go
+++ b/examples/spire_producer.example/spire_producer.example.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/spiffe/go-spiffe/v2/svid/jwtsvid"
+	"github.com/spiffe/go-spiffe/v2/workloadapi"
+	"os"
+	"os/signal"
+	"regexp"
+	"syscall"
+	"time"
+
+	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
+	_ "github.com/spiffe/go-spiffe/v2/spiffeid"
+	_ "github.com/spiffe/go-spiffe/v2/svid/jwtsvid"
+)
+
+var (
+	// Regex for sasl.oauthbearer.config, which constrains it to be
+	// 1 or more name=value pairs with optional ignored whitespace
+	oauthbearerConfigRegex = regexp.MustCompile("^(\\s*(\\w+)\\s*=\\s*(\\w+))+\\s*$")
+	// Regex used to extract name=value pairs from sasl.oauthbearer.config
+	oauthbearerNameEqualsValueRegex = regexp.MustCompile("(\\w+)\\s*=\\s*(\\w+)")
+)
+
+const (
+	principalClaimNameKey = "principalClaimName"
+	principalKey          = "principal"
+	joseHeaderEncoded     = "eyJhbGciOiJub25lIn0" // {"alg":"none"}
+)
+
+type tokenAuth struct {
+	audience    []string
+	tokenSource *workloadapi.JWTSource
+}
+
+// handleJWTTokenRefreshEvent retrieves JWT from the SPIRE workload API and
+// sets the token on the client for use in any future authentication attempt.
+// It must be invoked whenever kafka.OAuthBearerTokenRefresh appears on the client's event channel,
+// which will occur whenever the client requires a token (i.e. when it first starts and when the
+// previously-received token is 80% of the way to its expiration time).
+func handleJWTTokenRefreshEvent(ctx context.Context, client kafka.Handle, principal, socketPath string, audience []string) {
+	fmt.Fprintf(os.Stderr, "Token refresh\n")
+	oauthBearerToken, retrieveErr := retrieveJWTToken(ctx, principal, socketPath, audience)
+	if retrieveErr != nil {
+		fmt.Fprintf(os.Stderr, "%% Token retrieval error: %v\n", retrieveErr)
+		client.SetOAuthBearerTokenFailure(retrieveErr.Error())
+	} else {
+		setTokenError := client.SetOAuthBearerToken(oauthBearerToken)
+		if setTokenError != nil {
+			fmt.Fprintf(os.Stderr, "%% Error setting token and extensions: %v\n", setTokenError)
+			client.SetOAuthBearerTokenFailure(setTokenError.Error())
+		}
+	}
+}
+
+func retrieveJWTToken(ctx context.Context, principal, socketPath string, audience []string) (kafka.OAuthBearerToken, error) {
+	jwtSource, err := workloadapi.NewJWTSource(
+		ctx,
+		workloadapi.WithClientOptions(workloadapi.WithAddr(socketPath)),
+	)
+	if err != nil {
+		return kafka.OAuthBearerToken{}, fmt.Errorf("unable to create JWTSource: %w", err)
+	}
+
+	defer jwtSource.Close()
+
+	params := jwtsvid.Params{
+		// initialize the fields of Params here
+		Audience: audience[0],
+		// Other fields...
+	}
+
+	jwtSVID, err := jwtSource.FetchJWTSVID(ctx, params)
+	if err != nil {
+		return kafka.OAuthBearerToken{}, fmt.Errorf("unable to fetch JWT SVID: %w", err)
+	}
+
+	oauthBearerToken := kafka.OAuthBearerToken{
+		TokenValue: jwtSVID.Marshal(),
+		Expiration: jwtSVID.Expiry,
+		Principal:  principal,
+		Extensions: map[string]string{},
+	}
+
+	return oauthBearerToken, nil
+}
+
+func main() {
+
+	if len(os.Args) != 5 {
+		fmt.Fprintf(os.Stderr, "Usage: %s <bootstrap-servers> <topic> <principal> <socketPath>\n", os.Args[0])
+		os.Exit(1)
+	}
+
+	bootstrapServers := os.Args[1]
+	topic := os.Args[2]
+	principal := os.Args[3]
+	socketPath := os.Args[4]
+	audience := []string{"audience1", "audience2"} // Audience should be defined properly
+
+	// You'll probably need to modify this configuration to
+	// match your environment.
+	config := kafka.ConfigMap{
+		"bootstrap.servers": bootstrapServers,
+		"security.protocol": "SASL_PLAINTEXT",
+		"sasl.mechanisms":   "OAUTHBEARER",
+		"sasl.oauthbearer.config": map[string]string{
+			"principal": principal,
+		},
+	}
+
+	p, err := kafka.NewProducer(&config)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to create producer: %s\n", err)
+		os.Exit(1)
+	}
+
+	// Token refresh events are posted on the Events channel, instructing
+	// the application to refresh its token.
+	ctx := context.Background()
+	go func(eventsChan chan kafka.Event) {
+		for ev := range eventsChan {
+			_, ok := ev.(kafka.OAuthBearerTokenRefresh)
+			if !ok {
+				// Ignore other event types
+				continue
+			}
+
+			handleJWTTokenRefreshEvent(ctx, p, principal, socketPath, audience)
+		}
+	}(p.Events())
+
+	run := true
+	signalChannel := make(chan os.Signal, 1)
+	signal.Notify(signalChannel, syscall.SIGINT, syscall.SIGTERM)
+
+	msgcnt := 0
+	for run {
+		select {
+		case sig := <-signalChannel:
+			fmt.Printf("Caught signal %v: terminating\n", sig)
+			run = false
+		default:
+			value := fmt.Sprintf("Producer example, message #%d", msgcnt)
+			err = p.Produce(&kafka.Message{
+				TopicPartition: kafka.TopicPartition{Topic: &topic, Partition: kafka.PartitionAny},
+				Value:          []byte(value),
+				Headers:        []kafka.Header{{Key: "myTestHeader", Value: []byte("header values are binary")}},
+			}, nil)
+
+			if err != nil {
+				if err.(kafka.Error).Code() == kafka.ErrQueueFull {
+					// Producer queue is full, wait 1s for messages
+					// to be delivered then try again.
+					time.Sleep(time.Second)
+					continue
+				}
+				fmt.Printf("Failed to produce message: %v\n", err)
+			} else {
+				fmt.Printf("Produced message: %s\n", value)
+			}
+
+			time.Sleep(1 * time.Second)
+			msgcnt++
+		}
+	}
+
+	p.Close()
+}

--- a/examples/spire_producer.example/workloadapi/addr.go
+++ b/examples/spire_producer.example/workloadapi/addr.go
@@ -1,0 +1,69 @@
+package workloadapi
+
+import (
+	"errors"
+	"net"
+	"net/url"
+	"os"
+)
+
+const (
+	// SocketEnv is the environment variable holding the default Workload API
+	// address.
+	SocketEnv = "SPIFFE_ENDPOINT_SOCKET"
+)
+
+func GetDefaultAddress() (string, bool) {
+	return os.LookupEnv(SocketEnv)
+}
+
+// ValidateAddress validates that the provided address
+// can be parsed to a gRPC target string for dialing
+// a Workload API endpoint exposed as either a Unix
+// Domain Socket or TCP socket.
+func ValidateAddress(addr string) error {
+	_, err := parseTargetFromStringAddr(addr)
+	return err
+}
+
+// parseTargetFromStringAddr parses the endpoint address and returns a gRPC target
+// string for dialing.
+func parseTargetFromStringAddr(addr string) (string, error) {
+	u, err := url.Parse(addr)
+	if err != nil {
+		return "", errors.New("workload endpoint socket is not a valid URI: " + err.Error())
+	}
+	return parseTargetFromURLAddr(u)
+}
+
+func parseTargetFromURLAddr(u *url.URL) (string, error) {
+	if u.Scheme == "tcp" {
+		switch {
+		case u.Opaque != "":
+			return "", errors.New("workload endpoint tcp socket URI must not be opaque")
+		case u.User != nil:
+			return "", errors.New("workload endpoint tcp socket URI must not include user info")
+		case u.Host == "":
+			return "", errors.New("workload endpoint tcp socket URI must include a host")
+		case u.Path != "":
+			return "", errors.New("workload endpoint tcp socket URI must not include a path")
+		case u.RawQuery != "":
+			return "", errors.New("workload endpoint tcp socket URI must not include query values")
+		case u.Fragment != "":
+			return "", errors.New("workload endpoint tcp socket URI must not include a fragment")
+		}
+
+		ip := net.ParseIP(u.Hostname())
+		if ip == nil {
+			return "", errors.New("workload endpoint tcp socket URI host component must be an IP:port")
+		}
+		port := u.Port()
+		if port == "" {
+			return "", errors.New("workload endpoint tcp socket URI host component must include a port")
+		}
+
+		return net.JoinHostPort(ip.String(), port), nil
+	}
+
+	return parseTargetFromURLAddrOS(u)
+}

--- a/examples/spire_producer.example/workloadapi/addr_posix.go
+++ b/examples/spire_producer.example/workloadapi/addr_posix.go
@@ -1,0 +1,34 @@
+//go:build !windows
+// +build !windows
+
+package workloadapi
+
+import (
+	"errors"
+	"net/url"
+)
+
+var (
+	ErrInvalidEndpointScheme = errors.New("workload endpoint socket URI must have a \"tcp\" or \"unix\" scheme")
+)
+
+func parseTargetFromURLAddrOS(u *url.URL) (string, error) {
+	switch u.Scheme {
+	case "unix":
+		switch {
+		case u.Opaque != "":
+			return "", errors.New("workload endpoint unix socket URI must not be opaque")
+		case u.User != nil:
+			return "", errors.New("workload endpoint unix socket URI must not include user info")
+		case u.Host == "" && u.Path == "":
+			return "", errors.New("workload endpoint unix socket URI must include a path")
+		case u.RawQuery != "":
+			return "", errors.New("workload endpoint unix socket URI must not include query values")
+		case u.Fragment != "":
+			return "", errors.New("workload endpoint unix socket URI must not include a fragment")
+		}
+		return u.String(), nil
+	default:
+		return "", ErrInvalidEndpointScheme
+	}
+}

--- a/examples/spire_producer.example/workloadapi/addr_windows.go
+++ b/examples/spire_producer.example/workloadapi/addr_windows.go
@@ -1,0 +1,33 @@
+//go:build windows
+// +build windows
+
+package workloadapi
+
+import (
+	"errors"
+	"net/url"
+)
+
+var (
+	ErrInvalidEndpointScheme = errors.New("workload endpoint socket URI must have a \"tcp\" or \"npipe\" scheme")
+)
+
+func parseTargetFromURLAddrOS(u *url.URL) (string, error) {
+	switch u.Scheme {
+	case "npipe":
+		switch {
+		case u.Opaque == "" && u.Host != "":
+			return "", errors.New("workload endpoint named pipe URI must be opaque")
+		case u.Opaque == "":
+			return "", errors.New("workload endpoint named pipe URI must include an opaque part")
+		case u.RawQuery != "":
+			return "", errors.New("workload endpoint named pipe URI must not include query values")
+		case u.Fragment != "":
+			return "", errors.New("workload endpoint named pipe URI must not include a fragment")
+		}
+
+		return namedPipeTarget(u.Opaque), nil
+	default:
+		return "", ErrInvalidEndpointScheme
+	}
+}

--- a/examples/spire_producer.example/workloadapi/backoff.go
+++ b/examples/spire_producer.example/workloadapi/backoff.go
@@ -1,0 +1,34 @@
+package workloadapi
+
+import (
+	"math"
+	"time"
+)
+
+// backoff defines an linear backoff policy.
+type backoff struct {
+	InitialDelay time.Duration
+	MaxDelay     time.Duration
+	n            int
+}
+
+func newBackoff() *backoff {
+	return &backoff{
+		InitialDelay: time.Second,
+		MaxDelay:     30 * time.Second,
+		n:            0,
+	}
+}
+
+// Duration returns the next wait period for the backoff. Not goroutine-safe.
+func (b *backoff) Duration() time.Duration {
+	backoff := float64(b.n) + 1
+	d := math.Min(b.InitialDelay.Seconds()*backoff, b.MaxDelay.Seconds())
+	b.n++
+	return time.Duration(d) * time.Second
+}
+
+// Reset resets the backoff's state.
+func (b *backoff) Reset() {
+	b.n = 0
+}

--- a/examples/spire_producer.example/workloadapi/bundlesource.go
+++ b/examples/spire_producer.example/workloadapi/bundlesource.go
@@ -1,0 +1,188 @@
+package workloadapi
+
+import (
+	"context"
+	"crypto"
+	"crypto/x509"
+	"sync"
+
+	"github.com/spiffe/go-spiffe/v2/bundle/jwtbundle"
+	"github.com/spiffe/go-spiffe/v2/bundle/spiffebundle"
+	"github.com/spiffe/go-spiffe/v2/bundle/x509bundle"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/zeebo/errs"
+)
+
+var bundlesourceErr = errs.Class("bundlesource")
+
+// BundleSource is a source of SPIFFE bundles maintained via the Workload API.
+type BundleSource struct {
+	watcher *watcher
+
+	mtx             sync.RWMutex
+	x509Authorities map[spiffeid.TrustDomain][]*x509.Certificate
+	jwtAuthorities  map[spiffeid.TrustDomain]map[string]crypto.PublicKey
+
+	closeMtx sync.RWMutex
+	closed   bool
+}
+
+// NewBundleSource creates a new BundleSource. It blocks until the initial
+// update has been received from the Workload API. The source should be closed
+// when no longer in use to free underlying resources.
+func NewBundleSource(ctx context.Context, options ...BundleSourceOption) (_ *BundleSource, err error) {
+	config := &bundleSourceConfig{}
+	for _, option := range options {
+		option.configureBundleSource(config)
+	}
+
+	s := &BundleSource{
+		x509Authorities: make(map[spiffeid.TrustDomain][]*x509.Certificate),
+		jwtAuthorities:  make(map[spiffeid.TrustDomain]map[string]crypto.PublicKey),
+	}
+
+	s.watcher, err = newWatcher(ctx, config.watcher, s.setX509Context, s.setJWTBundles)
+	if err != nil {
+		return nil, err
+	}
+
+	return s, nil
+}
+
+// Close closes the source, dropping the connection to the Workload API.
+// Other source methods will return an error after Close has been called.
+// The underlying Workload API client will also be closed if it is owned by
+// the BundleSource (i.e. not provided via the WithClient option).
+func (s *BundleSource) Close() error {
+	s.closeMtx.Lock()
+	s.closed = true
+	s.closeMtx.Unlock()
+
+	return s.watcher.Close()
+}
+
+// GetBundleForTrustDomain returns the SPIFFE bundle for the given trust
+// domain. It implements the spiffebundle.Source interface.
+func (s *BundleSource) GetBundleForTrustDomain(trustDomain spiffeid.TrustDomain) (*spiffebundle.Bundle, error) {
+	if err := s.checkClosed(); err != nil {
+		return nil, err
+	}
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+
+	x509Authorities, hasX509Authorities := s.x509Authorities[trustDomain]
+	jwtAuthorities, hasJWTAuthorities := s.jwtAuthorities[trustDomain]
+	if !hasX509Authorities && !hasJWTAuthorities {
+		return nil, bundlesourceErr.New("no SPIFFE bundle for trust domain %q", trustDomain)
+	}
+	bundle := spiffebundle.New(trustDomain)
+	if hasX509Authorities {
+		bundle.SetX509Authorities(x509Authorities)
+	}
+	if hasJWTAuthorities {
+		bundle.SetJWTAuthorities(jwtAuthorities)
+	}
+	return bundle, nil
+}
+
+// GetX509BundleForTrustDomain returns the X.509 bundle for the given trust
+// domain. It implements the x509bundle.Source interface.
+func (s *BundleSource) GetX509BundleForTrustDomain(trustDomain spiffeid.TrustDomain) (*x509bundle.Bundle, error) {
+	if err := s.checkClosed(); err != nil {
+		return nil, err
+	}
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+
+	x509Authorities, hasX509Authorities := s.x509Authorities[trustDomain]
+	if !hasX509Authorities {
+		return nil, bundlesourceErr.New("no X.509 bundle for trust domain %q", trustDomain)
+	}
+	return x509bundle.FromX509Authorities(trustDomain, x509Authorities), nil
+}
+
+// GetJWTBundleForTrustDomain returns the JWT bundle for the given trust
+// domain. It implements the jwtbundle.Source interface.
+func (s *BundleSource) GetJWTBundleForTrustDomain(trustDomain spiffeid.TrustDomain) (*jwtbundle.Bundle, error) {
+	if err := s.checkClosed(); err != nil {
+		return nil, err
+	}
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+
+	jwtAuthorities, hasJWTAuthorities := s.jwtAuthorities[trustDomain]
+	if !hasJWTAuthorities {
+		return nil, bundlesourceErr.New("no JWT bundle for trust domain %q", trustDomain)
+	}
+	return jwtbundle.FromJWTAuthorities(trustDomain, jwtAuthorities), nil
+}
+
+// WaitUntilUpdated waits until the source is updated or the context is done,
+// in which case ctx.Err() is returned.
+func (s *BundleSource) WaitUntilUpdated(ctx context.Context) error {
+	return s.watcher.WaitUntilUpdated(ctx)
+}
+
+// Updated returns a channel that is sent on whenever the source is updated.
+func (s *BundleSource) Updated() <-chan struct{} {
+	return s.watcher.Updated()
+}
+
+func (s *BundleSource) setX509Context(x509Context *X509Context) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	newBundles := x509Context.Bundles.Bundles()
+
+	// Add/replace the X.509 authorities from the X.509 context. Track the trust
+	// domains represented in the new X.509 context so we can determine which
+	// existing trust domains are no longer represented.
+	trustDomains := make(map[spiffeid.TrustDomain]struct{}, len(newBundles))
+	for _, newBundle := range newBundles {
+		trustDomains[newBundle.TrustDomain()] = struct{}{}
+		s.x509Authorities[newBundle.TrustDomain()] = newBundle.X509Authorities()
+	}
+
+	// Remove the X.509 authority entries for trust domains no longer
+	// represented in the X.509 context.
+	for existingTD := range s.x509Authorities {
+		if _, ok := trustDomains[existingTD]; ok {
+			continue
+		}
+		delete(s.x509Authorities, existingTD)
+	}
+}
+
+func (s *BundleSource) setJWTBundles(bundles *jwtbundle.Set) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	newBundles := bundles.Bundles()
+
+	// Add/replace the JWT authorities from the JWT bundles. Track the trust
+	// domains represented in the new JWT bundles so we can determine which
+	// existing trust domains are no longer represented.
+	trustDomains := make(map[spiffeid.TrustDomain]struct{}, len(newBundles))
+	for _, newBundle := range newBundles {
+		trustDomains[newBundle.TrustDomain()] = struct{}{}
+		s.jwtAuthorities[newBundle.TrustDomain()] = newBundle.JWTAuthorities()
+	}
+
+	// Remove the JWT authority entries for trust domains no longer represented
+	// in the JWT bundles.
+	for existingTD := range s.jwtAuthorities {
+		if _, ok := trustDomains[existingTD]; ok {
+			continue
+		}
+		delete(s.jwtAuthorities, existingTD)
+	}
+}
+
+func (s *BundleSource) checkClosed() error {
+	s.closeMtx.RLock()
+	defer s.closeMtx.RUnlock()
+	if s.closed {
+		return bundlesourceErr.New("source is closed")
+	}
+	return nil
+}

--- a/examples/spire_producer.example/workloadapi/client.go
+++ b/examples/spire_producer.example/workloadapi/client.go
@@ -1,0 +1,549 @@
+package workloadapi
+
+import (
+	"context"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/spiffe/go-spiffe/v2/bundle/jwtbundle"
+	"github.com/spiffe/go-spiffe/v2/bundle/x509bundle"
+	"github.com/spiffe/go-spiffe/v2/logger"
+	"github.com/spiffe/go-spiffe/v2/proto/spiffe/workload"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/spiffe/go-spiffe/v2/svid/jwtsvid"
+	"github.com/spiffe/go-spiffe/v2/svid/x509svid"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+// Client is a Workload API client.
+type Client struct {
+	conn     *grpc.ClientConn
+	wlClient workload.SpiffeWorkloadAPIClient
+	config   clientConfig
+}
+
+// New dials the Workload API and returns a client. The client should be closed
+// when no longer in use to free underlying resources.
+func New(ctx context.Context, options ...ClientOption) (*Client, error) {
+	c := &Client{
+		config: defaultClientConfig(),
+	}
+	for _, opt := range options {
+		opt.configureClient(&c.config)
+	}
+
+	err := c.setAddress()
+	if err != nil {
+		return nil, err
+	}
+
+	c.conn, err = c.newConn(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	c.wlClient = workload.NewSpiffeWorkloadAPIClient(c.conn)
+	return c, nil
+}
+
+// Close closes the client.
+func (c *Client) Close() error {
+	return c.conn.Close()
+}
+
+// FetchX509SVID fetches the default X509-SVID, i.e. the first in the list
+// returned by the Workload API.
+func (c *Client) FetchX509SVID(ctx context.Context) (*x509svid.SVID, error) {
+	ctx, cancel := context.WithCancel(withHeader(ctx))
+	defer cancel()
+
+	stream, err := c.wlClient.FetchX509SVID(ctx, &workload.X509SVIDRequest{})
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := stream.Recv()
+	if err != nil {
+		return nil, err
+	}
+
+	svids, err := parseX509SVIDs(resp, true)
+	if err != nil {
+		return nil, err
+	}
+
+	return svids[0], nil
+}
+
+// FetchX509SVIDs fetches all X509-SVIDs.
+func (c *Client) FetchX509SVIDs(ctx context.Context) ([]*x509svid.SVID, error) {
+	ctx, cancel := context.WithCancel(withHeader(ctx))
+	defer cancel()
+
+	stream, err := c.wlClient.FetchX509SVID(ctx, &workload.X509SVIDRequest{})
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := stream.Recv()
+	if err != nil {
+		return nil, err
+	}
+
+	return parseX509SVIDs(resp, false)
+}
+
+// FetchX509Bundles fetches the X.509 bundles.
+func (c *Client) FetchX509Bundles(ctx context.Context) (*x509bundle.Set, error) {
+	ctx, cancel := context.WithCancel(withHeader(ctx))
+	defer cancel()
+
+	stream, err := c.wlClient.FetchX509Bundles(ctx, &workload.X509BundlesRequest{})
+	if err != nil {
+		return nil, err
+	}
+	resp, err := stream.Recv()
+	if err != nil {
+		return nil, err
+	}
+
+	return parseX509BundlesResponse(resp)
+}
+
+// WatchX509Bundles watches for changes to the X.509 bundles. The watcher receives
+// the updated X.509 bundles.
+func (c *Client) WatchX509Bundles(ctx context.Context, watcher X509BundleWatcher) error {
+	backoff := newBackoff()
+	for {
+		err := c.watchX509Bundles(ctx, watcher, backoff)
+		watcher.OnX509BundlesWatchError(err)
+		err = c.handleWatchError(ctx, err, backoff)
+		if err != nil {
+			return err
+		}
+	}
+}
+
+// FetchX509Context fetches the X.509 context, which contains both X509-SVIDs
+// and X.509 bundles.
+func (c *Client) FetchX509Context(ctx context.Context) (*X509Context, error) {
+	ctx, cancel := context.WithCancel(withHeader(ctx))
+	defer cancel()
+
+	stream, err := c.wlClient.FetchX509SVID(ctx, &workload.X509SVIDRequest{})
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := stream.Recv()
+	if err != nil {
+		return nil, err
+	}
+
+	return parseX509Context(resp)
+}
+
+// WatchX509Context watches for updates to the X.509 context. The watcher
+// receives the updated X.509 context.
+func (c *Client) WatchX509Context(ctx context.Context, watcher X509ContextWatcher) error {
+	backoff := newBackoff()
+	for {
+		err := c.watchX509Context(ctx, watcher, backoff)
+		watcher.OnX509ContextWatchError(err)
+		err = c.handleWatchError(ctx, err, backoff)
+		if err != nil {
+			return err
+		}
+	}
+}
+
+// FetchJWTSVID fetches a JWT-SVID.
+func (c *Client) FetchJWTSVID(ctx context.Context, params jwtsvid.Params) (*jwtsvid.SVID, error) {
+	ctx, cancel := context.WithCancel(withHeader(ctx))
+	defer cancel()
+
+	audience := append([]string{params.Audience}, params.ExtraAudiences...)
+	resp, err := c.wlClient.FetchJWTSVID(ctx, &workload.JWTSVIDRequest{
+		SpiffeId: params.Subject.String(),
+		Audience: audience,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	svids, err := parseJWTSVIDs(resp, audience, true)
+	if err != nil {
+		return nil, err
+	}
+
+	return svids[0], nil
+}
+
+// FetchJWTSVIDs fetches all JWT-SVIDs.
+func (c *Client) FetchJWTSVIDs(ctx context.Context, params jwtsvid.Params) ([]*jwtsvid.SVID, error) {
+	ctx, cancel := context.WithCancel(withHeader(ctx))
+	defer cancel()
+
+	audience := append([]string{params.Audience}, params.ExtraAudiences...)
+	resp, err := c.wlClient.FetchJWTSVID(ctx, &workload.JWTSVIDRequest{
+		SpiffeId: params.Subject.String(),
+		Audience: audience,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return parseJWTSVIDs(resp, audience, false)
+}
+
+// FetchJWTBundles fetches the JWT bundles for JWT-SVID validation, keyed
+// by a SPIFFE ID of the trust domain to which they belong.
+func (c *Client) FetchJWTBundles(ctx context.Context) (*jwtbundle.Set, error) {
+	ctx, cancel := context.WithCancel(withHeader(ctx))
+	defer cancel()
+
+	stream, err := c.wlClient.FetchJWTBundles(ctx, &workload.JWTBundlesRequest{})
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := stream.Recv()
+	if err != nil {
+		return nil, err
+	}
+
+	return parseJWTSVIDBundles(resp)
+}
+
+// WatchJWTBundles watches for changes to the JWT bundles. The watcher receives
+// the updated JWT bundles.
+func (c *Client) WatchJWTBundles(ctx context.Context, watcher JWTBundleWatcher) error {
+	backoff := newBackoff()
+	for {
+		err := c.watchJWTBundles(ctx, watcher, backoff)
+		watcher.OnJWTBundlesWatchError(err)
+		err = c.handleWatchError(ctx, err, backoff)
+		if err != nil {
+			return err
+		}
+	}
+}
+
+// ValidateJWTSVID validates the JWT-SVID token. The parsed and validated
+// JWT-SVID is returned.
+func (c *Client) ValidateJWTSVID(ctx context.Context, token, audience string) (*jwtsvid.SVID, error) {
+	ctx, cancel := context.WithCancel(withHeader(ctx))
+	defer cancel()
+
+	_, err := c.wlClient.ValidateJWTSVID(ctx, &workload.ValidateJWTSVIDRequest{
+		Svid:     token,
+		Audience: audience,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return jwtsvid.ParseInsecure(token, []string{audience})
+}
+
+func (c *Client) newConn(ctx context.Context) (*grpc.ClientConn, error) {
+	c.config.dialOptions = append(c.config.dialOptions, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	c.appendDialOptionsOS()
+	return grpc.DialContext(ctx, c.config.address, c.config.dialOptions...)
+}
+
+func (c *Client) handleWatchError(ctx context.Context, err error, backoff *backoff) error {
+	code := status.Code(err)
+	if code == codes.Canceled {
+		return err
+	}
+
+	if code == codes.InvalidArgument {
+		c.config.log.Errorf("Canceling watch: %v", err)
+		return err
+	}
+
+	c.config.log.Errorf("Failed to watch the Workload API: %v", err)
+	retryAfter := backoff.Duration()
+	c.config.log.Debugf("Retrying watch in %s", retryAfter)
+	select {
+	case <-time.After(retryAfter):
+		return nil
+
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (c *Client) watchX509Context(ctx context.Context, watcher X509ContextWatcher, backoff *backoff) error {
+	ctx, cancel := context.WithCancel(withHeader(ctx))
+	defer cancel()
+
+	c.config.log.Debugf("Watching X.509 contexts")
+	stream, err := c.wlClient.FetchX509SVID(ctx, &workload.X509SVIDRequest{})
+	if err != nil {
+		return err
+	}
+
+	for {
+		resp, err := stream.Recv()
+		if err != nil {
+			return err
+		}
+
+		backoff.Reset()
+		x509Context, err := parseX509Context(resp)
+		if err != nil {
+			c.config.log.Errorf("Failed to parse X509-SVID response: %v", err)
+			watcher.OnX509ContextWatchError(err)
+			continue
+		}
+		watcher.OnX509ContextUpdate(x509Context)
+	}
+}
+
+func (c *Client) watchJWTBundles(ctx context.Context, watcher JWTBundleWatcher, backoff *backoff) error {
+	ctx, cancel := context.WithCancel(withHeader(ctx))
+	defer cancel()
+
+	c.config.log.Debugf("Watching JWT bundles")
+	stream, err := c.wlClient.FetchJWTBundles(ctx, &workload.JWTBundlesRequest{})
+	if err != nil {
+		return err
+	}
+
+	for {
+		resp, err := stream.Recv()
+		if err != nil {
+			return err
+		}
+
+		backoff.Reset()
+		jwtbundleSet, err := parseJWTSVIDBundles(resp)
+		if err != nil {
+			c.config.log.Errorf("Failed to parse JWT bundle response: %v", err)
+			watcher.OnJWTBundlesWatchError(err)
+			continue
+		}
+		watcher.OnJWTBundlesUpdate(jwtbundleSet)
+	}
+}
+
+func (c *Client) watchX509Bundles(ctx context.Context, watcher X509BundleWatcher, backoff *backoff) error {
+	ctx, cancel := context.WithCancel(withHeader(ctx))
+	defer cancel()
+
+	c.config.log.Debugf("Watching X.509 bundles")
+	stream, err := c.wlClient.FetchX509Bundles(ctx, &workload.X509BundlesRequest{})
+	if err != nil {
+		return err
+	}
+
+	for {
+		resp, err := stream.Recv()
+		if err != nil {
+			return err
+		}
+
+		backoff.Reset()
+		x509bundleSet, err := parseX509BundlesResponse(resp)
+		if err != nil {
+			c.config.log.Errorf("Failed to parse X.509 bundle response: %v", err)
+			watcher.OnX509BundlesWatchError(err)
+			continue
+		}
+		watcher.OnX509BundlesUpdate(x509bundleSet)
+	}
+}
+
+// X509ContextWatcher receives X509Context updates from the Workload API.
+type X509ContextWatcher interface {
+	// OnX509ContextUpdate is called with the latest X.509 context retrieved
+	// from the Workload API.
+	OnX509ContextUpdate(*X509Context)
+
+	// OnX509ContextWatchError is called when there is a problem establishing
+	// or maintaining connectivity with the Workload API.
+	OnX509ContextWatchError(error)
+}
+
+// JWTBundleWatcher receives JWT bundle updates from the Workload API.
+type JWTBundleWatcher interface {
+	// OnJWTBundlesUpdate is called with the latest JWT bundle set retrieved
+	// from the Workload API.
+	OnJWTBundlesUpdate(*jwtbundle.Set)
+
+	// OnJWTBundlesWatchError is called when there is a problem establishing
+	// or maintaining connectivity with the Workload API.
+	OnJWTBundlesWatchError(error)
+}
+
+// X509BundleWatcher receives X.509 bundle updates from the Workload API.
+type X509BundleWatcher interface {
+	// OnX509BundlesUpdate is called with the latest X.509 bundle set retrieved
+	// from the Workload API.
+	OnX509BundlesUpdate(*x509bundle.Set)
+
+	// OnX509BundlesWatchError is called when there is a problem establishing
+	// or maintaining connectivity with the Workload API.
+	OnX509BundlesWatchError(error)
+}
+
+func withHeader(ctx context.Context) context.Context {
+	header := metadata.Pairs("workload.spiffe.io", "true")
+	return metadata.NewOutgoingContext(ctx, header)
+}
+
+func defaultClientConfig() clientConfig {
+	return clientConfig{
+		log: logger.Null,
+	}
+}
+
+func parseX509Context(resp *workload.X509SVIDResponse) (*X509Context, error) {
+	svids, err := parseX509SVIDs(resp, false)
+	if err != nil {
+		return nil, err
+	}
+
+	bundles, err := parseX509Bundles(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &X509Context{
+		SVIDs:   svids,
+		Bundles: bundles,
+	}, nil
+}
+
+// parseX509SVIDs parses one or all of the SVIDs in the response. If firstOnly
+// is true, then only the first SVID in the response is parsed and returned.
+// Otherwise all SVIDs are parsed and returned.
+func parseX509SVIDs(resp *workload.X509SVIDResponse, firstOnly bool) ([]*x509svid.SVID, error) {
+	n := len(resp.Svids)
+	if n == 0 {
+		return nil, errors.New("no SVIDs in response")
+	}
+	if firstOnly {
+		n = 1
+	}
+
+	svids := make([]*x509svid.SVID, 0, n)
+	for i := 0; i < n; i++ {
+		svid := resp.Svids[i]
+		s, err := x509svid.ParseRaw(svid.X509Svid, svid.X509SvidKey)
+		if err != nil {
+			return nil, err
+		}
+		svids = append(svids, s)
+	}
+
+	return svids, nil
+}
+
+func parseX509Bundles(resp *workload.X509SVIDResponse) (*x509bundle.Set, error) {
+	bundles := []*x509bundle.Bundle{}
+	for _, svid := range resp.Svids {
+		b, err := parseX509Bundle(svid.SpiffeId, svid.Bundle)
+		if err != nil {
+			return nil, err
+		}
+		bundles = append(bundles, b)
+	}
+
+	for tdID, bundle := range resp.FederatedBundles {
+		b, err := parseX509Bundle(tdID, bundle)
+		if err != nil {
+			return nil, err
+		}
+		bundles = append(bundles, b)
+	}
+
+	return x509bundle.NewSet(bundles...), nil
+}
+
+func parseX509Bundle(spiffeID string, bundle []byte) (*x509bundle.Bundle, error) {
+	td, err := spiffeid.TrustDomainFromString(spiffeID)
+	if err != nil {
+		return nil, err
+	}
+	certs, err := x509.ParseCertificates(bundle)
+	if err != nil {
+		return nil, err
+	}
+	if len(certs) == 0 {
+		return nil, fmt.Errorf("empty X.509 bundle for trust domain %q", td)
+	}
+	return x509bundle.FromX509Authorities(td, certs), nil
+}
+
+func parseX509BundlesResponse(resp *workload.X509BundlesResponse) (*x509bundle.Set, error) {
+	bundles := []*x509bundle.Bundle{}
+
+	for tdID, b := range resp.Bundles {
+		td, err := spiffeid.TrustDomainFromString(tdID)
+		if err != nil {
+			return nil, err
+		}
+
+		b, err := x509bundle.ParseRaw(td, b)
+		if err != nil {
+			return nil, err
+		}
+		bundles = append(bundles, b)
+	}
+
+	return x509bundle.NewSet(bundles...), nil
+}
+
+// parseJWTSVIDs parses one or all of the SVIDs in the response. If firstOnly
+// is true, then only the first SVID in the response is parsed and returned.
+// Otherwise all SVIDs are parsed and returned.
+func parseJWTSVIDs(resp *workload.JWTSVIDResponse, audience []string, firstOnly bool) ([]*jwtsvid.SVID, error) {
+	n := len(resp.Svids)
+	if n == 0 {
+		return nil, errors.New("there were no SVIDs in the response")
+	}
+	if firstOnly {
+		n = 1
+	}
+
+	svids := make([]*jwtsvid.SVID, 0, n)
+	for i := 0; i < n; i++ {
+		svid := resp.Svids[i]
+		s, err := jwtsvid.ParseInsecure(svid.Svid, audience)
+		if err != nil {
+			return nil, err
+		}
+		svids = append(svids, s)
+	}
+
+	return svids, nil
+}
+
+func parseJWTSVIDBundles(resp *workload.JWTBundlesResponse) (*jwtbundle.Set, error) {
+	bundles := []*jwtbundle.Bundle{}
+
+	for tdID, b := range resp.Bundles {
+		td, err := spiffeid.TrustDomainFromString(tdID)
+		if err != nil {
+			return nil, err
+		}
+
+		b, err := jwtbundle.Parse(td, b)
+		if err != nil {
+			return nil, err
+		}
+		bundles = append(bundles, b)
+	}
+
+	return jwtbundle.NewSet(bundles...), nil
+}

--- a/examples/spire_producer.example/workloadapi/client_posix.go
+++ b/examples/spire_producer.example/workloadapi/client_posix.go
@@ -1,0 +1,29 @@
+//go:build !windows
+// +build !windows
+
+package workloadapi
+
+import "errors"
+
+// appendDialOptionsOS appends OS specific dial options
+func (c *Client) appendDialOptionsOS() {
+	// No options to add in this platform
+}
+func (c *Client) setAddress() error {
+	if c.config.namedPipeName != "" {
+		// Purely defensive. This should never happen.
+		return errors.New("named pipes not supported in this platform")
+	}
+
+	if c.config.address == "" {
+		var ok bool
+		c.config.address, ok = GetDefaultAddress()
+		if !ok {
+			return errors.New("workload endpoint socket address is not configured")
+		}
+	}
+
+	var err error
+	c.config.address, err = parseTargetFromStringAddr(c.config.address)
+	return err
+}

--- a/examples/spire_producer.example/workloadapi/client_windows.go
+++ b/examples/spire_producer.example/workloadapi/client_windows.go
@@ -1,0 +1,57 @@
+//go:build windows
+// +build windows
+
+package workloadapi
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+
+	"github.com/Microsoft/go-winio"
+	"google.golang.org/grpc"
+)
+
+// appendDialOptionsOS appends OS specific dial options
+func (c *Client) appendDialOptionsOS() {
+	if c.config.namedPipeName != "" {
+		// Use the dialer to connect to named pipes only if a named pipe
+		// is defined (i.e. WithNamedPipeName is used).
+		c.config.dialOptions = append(c.config.dialOptions, grpc.WithContextDialer(winio.DialPipeContext))
+	}
+}
+
+func (c *Client) setAddress() error {
+	var err error
+	if c.config.namedPipeName != "" {
+		if c.config.address != "" {
+			return errors.New("only one of WithAddr or WithNamedPipeName options can be used, not both")
+		}
+		c.config.address = namedPipeTarget(c.config.namedPipeName)
+		return nil
+	}
+
+	if c.config.address == "" {
+		var ok bool
+		c.config.address, ok = GetDefaultAddress()
+		if !ok {
+			return errors.New("workload endpoint socket address is not configured")
+		}
+	}
+
+	if strings.HasPrefix(c.config.address, "npipe:") {
+		// Use the dialer to connect to named pipes only if the gRPC target
+		// string has the "npipe" scheme
+		c.config.dialOptions = append(c.config.dialOptions, grpc.WithContextDialer(winio.DialPipeContext))
+	}
+
+	c.config.address, err = parseTargetFromStringAddr(c.config.address)
+	return err
+}
+
+// namedPipeTarget returns a target string suitable for
+// dialing the endpoint address based on the provided
+// pipe name.
+func namedPipeTarget(pipeName string) string {
+	return `\\.\` + filepath.Join("pipe", pipeName)
+}

--- a/examples/spire_producer.example/workloadapi/convenience.go
+++ b/examples/spire_producer.example/workloadapi/convenience.go
@@ -1,0 +1,124 @@
+package workloadapi
+
+import (
+	"context"
+
+	"github.com/spiffe/go-spiffe/v2/bundle/jwtbundle"
+	"github.com/spiffe/go-spiffe/v2/bundle/x509bundle"
+	"github.com/spiffe/go-spiffe/v2/svid/jwtsvid"
+	"github.com/spiffe/go-spiffe/v2/svid/x509svid"
+)
+
+// FetchX509SVID fetches the default X509-SVID, i.e. the first in the list
+// returned by the Workload API.
+func FetchX509SVID(ctx context.Context, options ...ClientOption) (*x509svid.SVID, error) {
+	c, err := New(ctx, options...)
+	if err != nil {
+		return nil, err
+	}
+	defer c.Close()
+	return c.FetchX509SVID(ctx)
+}
+
+// FetchX509SVIDs fetches all X509-SVIDs.
+func FetchX509SVIDs(ctx context.Context, options ...ClientOption) ([]*x509svid.SVID, error) {
+	c, err := New(ctx, options...)
+	if err != nil {
+		return nil, err
+	}
+	defer c.Close()
+	return c.FetchX509SVIDs(ctx)
+}
+
+// FetchX509Bundle fetches the X.509 bundles.
+func FetchX509Bundles(ctx context.Context, options ...ClientOption) (*x509bundle.Set, error) {
+	c, err := New(ctx, options...)
+	if err != nil {
+		return nil, err
+	}
+	defer c.Close()
+	return c.FetchX509Bundles(ctx)
+}
+
+// FetchX509Context fetches the X.509 context, which contains both X509-SVIDs
+// and X.509 bundles.
+func FetchX509Context(ctx context.Context, options ...ClientOption) (*X509Context, error) {
+	c, err := New(ctx, options...)
+	if err != nil {
+		return nil, err
+	}
+	defer c.Close()
+	return c.FetchX509Context(ctx)
+}
+
+// WatchX509Context watches for updates to the X.509 context.
+func WatchX509Context(ctx context.Context, watcher X509ContextWatcher, options ...ClientOption) error {
+	c, err := New(ctx, options...)
+	if err != nil {
+		return err
+	}
+	defer c.Close()
+	return c.WatchX509Context(ctx, watcher)
+}
+
+// FetchJWTSVID fetches a JWT-SVID.
+func FetchJWTSVID(ctx context.Context, params jwtsvid.Params, options ...ClientOption) (*jwtsvid.SVID, error) {
+	c, err := New(ctx, options...)
+	if err != nil {
+		return nil, err
+	}
+	defer c.Close()
+	return c.FetchJWTSVID(ctx, params)
+}
+
+// FetchJWTSVID fetches all JWT-SVIDs.
+func FetchJWTSVIDs(ctx context.Context, params jwtsvid.Params, options ...ClientOption) ([]*jwtsvid.SVID, error) {
+	c, err := New(ctx, options...)
+	if err != nil {
+		return nil, err
+	}
+	defer c.Close()
+	return c.FetchJWTSVIDs(ctx, params)
+}
+
+// FetchJWTBundles fetches the JWT bundles for JWT-SVID validation, keyed
+// by a SPIFFE ID of the trust domain to which they belong.
+func FetchJWTBundles(ctx context.Context, options ...ClientOption) (*jwtbundle.Set, error) {
+	c, err := New(ctx, options...)
+	if err != nil {
+		return nil, err
+	}
+	defer c.Close()
+	return c.FetchJWTBundles(ctx)
+}
+
+// WatchJWTBundles watches for changes to the JWT bundles.
+func WatchJWTBundles(ctx context.Context, watcher JWTBundleWatcher, options ...ClientOption) error {
+	c, err := New(ctx, options...)
+	if err != nil {
+		return err
+	}
+	defer c.Close()
+	return c.WatchJWTBundles(ctx, watcher)
+}
+
+// WatchX509Bundles watches for changes to the X.509 bundles.
+func WatchX509Bundles(ctx context.Context, watcher X509BundleWatcher, options ...ClientOption) error {
+	c, err := New(ctx, options...)
+	if err != nil {
+		return err
+	}
+	defer c.Close()
+	return c.WatchX509Bundles(ctx, watcher)
+}
+
+// ValidateJWTSVID validates the JWT-SVID token. The parsed and validated
+// JWT-SVID is returned.
+func ValidateJWTSVID(ctx context.Context, token, audience string, options ...ClientOption) (*jwtsvid.SVID, error) {
+	c, err := New(ctx, options...)
+	if err != nil {
+		return nil, err
+	}
+	defer c.Close()
+	return c.ValidateJWTSVID(ctx, token, audience)
+}

--- a/examples/spire_producer.example/workloadapi/jwtsource.go
+++ b/examples/spire_producer.example/workloadapi/jwtsource.go
@@ -1,0 +1,109 @@
+package workloadapi
+
+import (
+	"context"
+	"sync"
+
+	"github.com/spiffe/go-spiffe/v2/bundle/jwtbundle"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/spiffe/go-spiffe/v2/svid/jwtsvid"
+	"github.com/zeebo/errs"
+)
+
+var jwtsourceErr = errs.Class("jwtsource")
+
+// JWTSource is a source of JWT-SVID and JWT bundles maintained via the
+// Workload API.
+type JWTSource struct {
+	watcher *watcher
+
+	mtx     sync.RWMutex
+	bundles *jwtbundle.Set
+
+	closeMtx sync.RWMutex
+	closed   bool
+}
+
+// NewJWTSource creates a new JWTSource. It blocks until the initial update
+// has been received from the Workload API. The source should be closed when
+// no longer in use to free underlying resources.
+func NewJWTSource(ctx context.Context, options ...JWTSourceOption) (_ *JWTSource, err error) {
+	config := &jwtSourceConfig{}
+	for _, option := range options {
+		option.configureJWTSource(config)
+	}
+
+	s := &JWTSource{}
+
+	s.watcher, err = newWatcher(ctx, config.watcher, nil, s.setJWTBundles)
+	if err != nil {
+		return nil, err
+	}
+
+	return s, nil
+}
+
+// Close closes the source, dropping the connection to the Workload API.
+// Other source methods will return an error after Close has been called.
+// The underlying Workload API client will also be closed if it is owned by
+// the JWTSource (i.e. not provided via the WithClient option).
+func (s *JWTSource) Close() error {
+	s.closeMtx.Lock()
+	s.closed = true
+	s.closeMtx.Unlock()
+
+	return s.watcher.Close()
+}
+
+// FetchJWTSVID fetches a JWT-SVID from the source with the given parameters.
+// It implements the jwtsvid.Source interface.
+func (s *JWTSource) FetchJWTSVID(ctx context.Context, params jwtsvid.Params) (*jwtsvid.SVID, error) {
+	if err := s.checkClosed(); err != nil {
+		return nil, err
+	}
+	return s.watcher.client.FetchJWTSVID(ctx, params)
+}
+
+// FetchJWTSVIDs fetches all JWT-SVIDs from the source with the given parameters.
+// It implements the jwtsvid.Source interface.
+func (s *JWTSource) FetchJWTSVIDs(ctx context.Context, params jwtsvid.Params) ([]*jwtsvid.SVID, error) {
+	if err := s.checkClosed(); err != nil {
+		return nil, err
+	}
+	return s.watcher.client.FetchJWTSVIDs(ctx, params)
+}
+
+// GetJWTBundleForTrustDomain returns the JWT bundle for the given trust
+// domain. It implements the jwtbundle.Source interface.
+func (s *JWTSource) GetJWTBundleForTrustDomain(trustDomain spiffeid.TrustDomain) (*jwtbundle.Bundle, error) {
+	if err := s.checkClosed(); err != nil {
+		return nil, err
+	}
+	return s.bundles.GetJWTBundleForTrustDomain(trustDomain)
+}
+
+// WaitUntilUpdated waits until the source is updated or the context is done,
+// in which case ctx.Err() is returned.
+func (s *JWTSource) WaitUntilUpdated(ctx context.Context) error {
+	return s.watcher.WaitUntilUpdated(ctx)
+}
+
+// Updated returns a channel that is sent on whenever the source is updated.
+func (s *JWTSource) Updated() <-chan struct{} {
+	return s.watcher.Updated()
+}
+
+func (s *JWTSource) setJWTBundles(bundles *jwtbundle.Set) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	s.bundles = bundles
+}
+
+func (s *JWTSource) checkClosed() error {
+	s.closeMtx.RLock()
+	defer s.closeMtx.RUnlock()
+	if s.closed {
+		return jwtsourceErr.New("source is closed")
+	}
+	return nil
+}

--- a/examples/spire_producer.example/workloadapi/option.go
+++ b/examples/spire_producer.example/workloadapi/option.go
@@ -1,0 +1,147 @@
+package workloadapi
+
+import (
+	"github.com/spiffe/go-spiffe/v2/logger"
+	"github.com/spiffe/go-spiffe/v2/svid/x509svid"
+	"google.golang.org/grpc"
+)
+
+// ClientOption is an option used when creating a new Client.
+type ClientOption interface {
+	configureClient(*clientConfig)
+}
+
+// WithAddr provides an address for the Workload API. The value of the
+// SPIFFE_ENDPOINT_SOCKET environment variable will be used if the option
+// is unused.
+func WithAddr(addr string) ClientOption {
+	return clientOption(func(c *clientConfig) {
+		c.address = addr
+	})
+}
+
+// WithDialOptions provides extra GRPC dialing options when dialing the
+// Workload API.
+func WithDialOptions(options ...grpc.DialOption) ClientOption {
+	return clientOption(func(c *clientConfig) {
+		c.dialOptions = append(c.dialOptions, options...)
+	})
+}
+
+// WithLogger provides a logger to the Client.
+func WithLogger(logger logger.Logger) ClientOption {
+	return clientOption(func(c *clientConfig) {
+		c.log = logger
+	})
+}
+
+// SourceOption are options that are shared among all option types.
+type SourceOption interface {
+	configureX509Source(*x509SourceConfig)
+	configureJWTSource(*jwtSourceConfig)
+	configureBundleSource(*bundleSourceConfig)
+}
+
+// WithClient provides a Client for the source to use. If unset, a new Client
+// will be created.
+func WithClient(client *Client) SourceOption {
+	return withClient{client: client}
+}
+
+// WithClientOptions controls the options used to create a new Client for the
+// source. This option will be ignored if WithClient is used.
+func WithClientOptions(options ...ClientOption) SourceOption {
+	return withClientOptions{options: options}
+}
+
+// X509SourceOption is an option for the X509Source. A SourceOption is also an
+// X509SourceOption.
+type X509SourceOption interface {
+	configureX509Source(*x509SourceConfig)
+}
+
+// WithDefaultX509SVIDPicker provides a function that is used to determine the
+// default X509-SVID when more than one is provided by the Workload API. By
+// default, the first X509-SVID in the list returned by the Workload API is
+// used.
+func WithDefaultX509SVIDPicker(picker func([]*x509svid.SVID) *x509svid.SVID) X509SourceOption {
+	return withDefaultX509SVIDPicker{picker: picker}
+}
+
+// JWTSourceOption is an option for the JWTSource. A SourceOption is also a
+// JWTSourceOption.
+type JWTSourceOption interface {
+	configureJWTSource(*jwtSourceConfig)
+}
+
+// BundleSourceOption is an option for the BundleSource. A SourceOption is also
+// a BundleSourceOption.
+type BundleSourceOption interface {
+	configureBundleSource(*bundleSourceConfig)
+}
+
+type clientConfig struct {
+	address       string
+	namedPipeName string
+	dialOptions   []grpc.DialOption
+	log           logger.Logger
+}
+
+type clientOption func(*clientConfig)
+
+func (fn clientOption) configureClient(config *clientConfig) {
+	fn(config)
+}
+
+type x509SourceConfig struct {
+	watcher watcherConfig
+	picker  func([]*x509svid.SVID) *x509svid.SVID
+}
+
+type jwtSourceConfig struct {
+	watcher watcherConfig
+}
+
+type bundleSourceConfig struct {
+	watcher watcherConfig
+}
+
+type withClient struct {
+	client *Client
+}
+
+func (o withClient) configureX509Source(config *x509SourceConfig) {
+	config.watcher.client = o.client
+}
+
+func (o withClient) configureJWTSource(config *jwtSourceConfig) {
+	config.watcher.client = o.client
+}
+
+func (o withClient) configureBundleSource(config *bundleSourceConfig) {
+	config.watcher.client = o.client
+}
+
+type withClientOptions struct {
+	options []ClientOption
+}
+
+func (o withClientOptions) configureX509Source(config *x509SourceConfig) {
+	config.watcher.clientOptions = o.options
+}
+
+func (o withClientOptions) configureJWTSource(config *jwtSourceConfig) {
+	config.watcher.clientOptions = o.options
+}
+
+func (o withClientOptions) configureBundleSource(config *bundleSourceConfig) {
+	config.watcher.clientOptions = o.options
+}
+
+type withDefaultX509SVIDPicker struct {
+	picker func([]*x509svid.SVID) *x509svid.SVID
+}
+
+func (o withDefaultX509SVIDPicker) configureX509Source(config *x509SourceConfig) {
+	config.picker = o.picker
+}

--- a/examples/spire_producer.example/workloadapi/option_windows.go
+++ b/examples/spire_producer.example/workloadapi/option_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+// +build windows
+
+package workloadapi
+
+// WithNamedPipeName provides a Pipe Name for the Workload API
+// endpoint in the form \\.\pipe\<pipeName>.
+func WithNamedPipeName(pipeName string) ClientOption {
+	return clientOption(func(c *clientConfig) {
+		c.namedPipeName = pipeName
+	})
+}

--- a/examples/spire_producer.example/workloadapi/watcher.go
+++ b/examples/spire_producer.example/workloadapi/watcher.go
@@ -1,0 +1,191 @@
+package workloadapi
+
+import (
+	"context"
+	"sync"
+
+	"github.com/spiffe/go-spiffe/v2/bundle/jwtbundle"
+	"github.com/spiffe/go-spiffe/v2/svid/jwtsvid"
+	"github.com/zeebo/errs"
+)
+
+type sourceClient interface {
+	WatchX509Context(context.Context, X509ContextWatcher) error
+	WatchJWTBundles(context.Context, JWTBundleWatcher) error
+	FetchJWTSVID(context.Context, jwtsvid.Params) (*jwtsvid.SVID, error)
+	FetchJWTSVIDs(context.Context, jwtsvid.Params) ([]*jwtsvid.SVID, error)
+	Close() error
+}
+
+type watcherConfig struct {
+	client        sourceClient
+	clientOptions []ClientOption
+}
+
+type watcher struct {
+	updatedCh chan struct{}
+
+	client     sourceClient
+	ownsClient bool
+
+	cancel func()
+	wg     sync.WaitGroup
+
+	closeMtx sync.Mutex
+	closed   bool
+	closeErr error
+
+	x509ContextFn      func(*X509Context)
+	x509ContextSet     chan struct{}
+	x509ContextSetOnce sync.Once
+
+	jwtBundlesFn      func(*jwtbundle.Set)
+	jwtBundlesSet     chan struct{}
+	jwtBundlesSetOnce sync.Once
+}
+
+func newWatcher(ctx context.Context, config watcherConfig, x509ContextFn func(*X509Context), jwtBundlesFn func(*jwtbundle.Set)) (_ *watcher, err error) {
+	w := &watcher{
+		updatedCh:      make(chan struct{}, 1),
+		client:         config.client,
+		cancel:         func() {},
+		x509ContextFn:  x509ContextFn,
+		x509ContextSet: make(chan struct{}),
+		jwtBundlesFn:   jwtBundlesFn,
+		jwtBundlesSet:  make(chan struct{}),
+	}
+
+	// If this function fails, we need to clean up the source.
+	defer func() {
+		if err != nil {
+			err = errs.Combine(err, w.Close())
+		}
+	}()
+
+	// Initialize a new client unless one is provided by the options
+	if w.client == nil {
+		client, err := New(ctx, config.clientOptions...)
+		if err != nil {
+			return nil, err
+		}
+		w.client = client
+		w.ownsClient = true
+	}
+
+	errCh := make(chan error, 2)
+	waitFor := func(has <-chan struct{}) error {
+		select {
+		case <-has:
+			return nil
+		case err := <-errCh:
+			return err
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	// Kick up a background goroutine that watches the Workload API for
+	// updates.
+	var watchCtx context.Context
+	watchCtx, w.cancel = context.WithCancel(context.Background())
+
+	if w.x509ContextFn != nil {
+		w.wg.Add(1)
+		go func() {
+			defer w.wg.Done()
+			errCh <- w.client.WatchX509Context(watchCtx, w)
+		}()
+		if err := waitFor(w.x509ContextSet); err != nil {
+			return nil, err
+		}
+	}
+
+	if w.jwtBundlesFn != nil {
+		w.wg.Add(1)
+		go func() {
+			defer w.wg.Done()
+			errCh <- w.client.WatchJWTBundles(watchCtx, w)
+		}()
+		if err := waitFor(w.jwtBundlesSet); err != nil {
+			return nil, err
+		}
+	}
+
+	// Drain the update channel since this function blocks until an update and
+	// don't want callers to think there was an update on the source right
+	// after it was initialized. If we ever allow the watcher to be initialzed
+	// without waiting, this reset should be removed.
+	w.drainUpdated()
+
+	return w, nil
+}
+
+// Close closes the watcher, dropping the connection to the Workload API.
+func (w *watcher) Close() error {
+	w.closeMtx.Lock()
+	defer w.closeMtx.Unlock()
+
+	if !w.closed {
+		w.cancel()
+		w.wg.Wait()
+
+		// Close() can be called by New() to close a partially intialized source.
+		// Only close the client if it has been set and the source owns it.
+		if w.client != nil && w.ownsClient {
+			w.closeErr = w.client.Close()
+		}
+		w.closed = true
+	}
+	return w.closeErr
+}
+
+func (w *watcher) OnX509ContextUpdate(x509Context *X509Context) {
+	w.x509ContextFn(x509Context)
+	w.x509ContextSetOnce.Do(func() {
+		close(w.x509ContextSet)
+	})
+	w.triggerUpdated()
+}
+
+func (w *watcher) OnX509ContextWatchError(err error) {
+	// The watcher doesn't do anything special with the error. If logging is
+	// desired, it should be provided to the Workload API client.
+}
+
+func (w *watcher) OnJWTBundlesUpdate(jwtBundles *jwtbundle.Set) {
+	w.jwtBundlesFn(jwtBundles)
+	w.jwtBundlesSetOnce.Do(func() {
+		close(w.jwtBundlesSet)
+	})
+	w.triggerUpdated()
+}
+
+func (w *watcher) OnJWTBundlesWatchError(error) {
+	// The watcher doesn't do anything special with the error. If logging is
+	// desired, it should be provided to the Workload API client.
+}
+
+func (w *watcher) WaitUntilUpdated(ctx context.Context) error {
+	select {
+	case <-w.updatedCh:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (w *watcher) Updated() <-chan struct{} {
+	return w.updatedCh
+}
+
+func (w *watcher) drainUpdated() {
+	select {
+	case <-w.updatedCh:
+	default:
+	}
+}
+
+func (w *watcher) triggerUpdated() {
+	w.drainUpdated()
+	w.updatedCh <- struct{}{}
+}

--- a/examples/spire_producer.example/workloadapi/x509context.go
+++ b/examples/spire_producer.example/workloadapi/x509context.go
@@ -1,0 +1,23 @@
+package workloadapi
+
+import (
+	"github.com/spiffe/go-spiffe/v2/bundle/x509bundle"
+	"github.com/spiffe/go-spiffe/v2/svid/x509svid"
+)
+
+// X509Context conveys X.509 materials from the Workload API.
+type X509Context struct {
+	// SVIDs is a list of workload X509-SVIDs.
+	SVIDs []*x509svid.SVID
+
+	// Bundles is a set of X.509 bundles.
+	Bundles *x509bundle.Set
+}
+
+// Default returns the default X509-SVID (the first in the list).
+//
+// See the SPIFFE Workload API standard Section 5.3.
+// (https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE_Workload_API.md#53-default-identity)
+func (x *X509Context) DefaultSVID() *x509svid.SVID {
+	return x.SVIDs[0]
+}

--- a/examples/spire_producer.example/workloadapi/x509source.go
+++ b/examples/spire_producer.example/workloadapi/x509source.go
@@ -1,0 +1,124 @@
+package workloadapi
+
+import (
+	"context"
+	"sync"
+
+	"github.com/spiffe/go-spiffe/v2/bundle/x509bundle"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/spiffe/go-spiffe/v2/svid/x509svid"
+	"github.com/zeebo/errs"
+)
+
+var x509sourceErr = errs.Class("x509source")
+
+// X509Source is a source of X509-SVIDs and X.509 bundles maintained via the
+// Workload API.
+type X509Source struct {
+	watcher *watcher
+	picker  func([]*x509svid.SVID) *x509svid.SVID
+
+	mtx     sync.RWMutex
+	svid    *x509svid.SVID
+	bundles *x509bundle.Set
+
+	closeMtx sync.RWMutex
+	closed   bool
+}
+
+// NewX509Source creates a new X509Source. It blocks until the initial update
+// has been received from the Workload API. The source should be closed when
+// no longer in use to free underlying resources.
+func NewX509Source(ctx context.Context, options ...X509SourceOption) (_ *X509Source, err error) {
+	config := &x509SourceConfig{}
+	for _, option := range options {
+		option.configureX509Source(config)
+	}
+
+	s := &X509Source{
+		picker: config.picker,
+	}
+
+	s.watcher, err = newWatcher(ctx, config.watcher, s.setX509Context, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s, nil
+}
+
+// Close closes the source, dropping the connection to the Workload API.
+// Other source methods will return an error after Close has been called.
+// The underlying Workload API client will also be closed if it is owned by
+// the X509Source (i.e. not provided via the WithClient option).
+func (s *X509Source) Close() (err error) {
+	s.closeMtx.Lock()
+	s.closed = true
+	s.closeMtx.Unlock()
+
+	return s.watcher.Close()
+}
+
+// GetX509SVID returns an X509-SVID from the source. It implements the
+// x509svid.Source interface.
+func (s *X509Source) GetX509SVID() (*x509svid.SVID, error) {
+	if err := s.checkClosed(); err != nil {
+		return nil, err
+	}
+
+	s.mtx.RLock()
+	svid := s.svid
+	s.mtx.RUnlock()
+
+	if svid == nil {
+		// This is a defensive check and should be unreachable since the source
+		// waits for the initial Workload API update before returning from
+		// New().
+		return nil, x509sourceErr.New("missing X509-SVID")
+	}
+	return svid, nil
+}
+
+// GetX509BundleForTrustDomain returns the X.509 bundle for the given trust
+// domain. It implements the x509bundle.Source interface.
+func (s *X509Source) GetX509BundleForTrustDomain(trustDomain spiffeid.TrustDomain) (*x509bundle.Bundle, error) {
+	if err := s.checkClosed(); err != nil {
+		return nil, err
+	}
+
+	return s.bundles.GetX509BundleForTrustDomain(trustDomain)
+}
+
+// WaitUntilUpdated waits until the source is updated or the context is done,
+// in which case ctx.Err() is returned.
+func (s *X509Source) WaitUntilUpdated(ctx context.Context) error {
+	return s.watcher.WaitUntilUpdated(ctx)
+}
+
+// Updated returns a channel that is sent on whenever the source is updated.
+func (s *X509Source) Updated() <-chan struct{} {
+	return s.watcher.Updated()
+}
+
+func (s *X509Source) setX509Context(x509Context *X509Context) {
+	var svid *x509svid.SVID
+	if s.picker == nil {
+		svid = x509Context.DefaultSVID()
+	} else {
+		svid = s.picker(x509Context.SVIDs)
+	}
+
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	s.svid = svid
+	s.bundles = x509Context.Bundles
+}
+
+func (s *X509Source) checkClosed() error {
+	s.closeMtx.RLock()
+	defer s.closeMtx.RUnlock()
+	if s.closed {
+		return x509sourceErr.New("source is closed")
+	}
+	return nil
+}


### PR DESCRIPTION
The goal of these changes is to create Kafka Producer with OAUTHBEARER for Go clients by communicating with the SPIRE agent.

- Create `handleJWTTokenRefreshEvent` function to handle token refresh events
- Create `retrieveJWTToken` function to fetch JWT from SPIRE agent
- Integrate OAuth Bearer mechanism into Kafka Producer to enable secure communication