### PR TITLE
feat(schemaregistry): allow custom http client

### DIFF
--- a/schemaregistry/config.go
+++ b/schemaregistry/config.go
@@ -54,10 +54,10 @@ type Config struct {
 	// CacheCapacity positive integer or zero for unbounded capacity
 	CacheCapacity int
 
-	// BaseClient will override the default http.Client.
+	// HTTPClient will override the default http.Client.
 	//
 	// The TLS and Timeout configuration above will still be applied.
-	BaseClient *http.Client
+	HTTPClient *http.Client
 }
 
 // NewConfig returns a new configuration instance with sane defaults.

--- a/schemaregistry/config.go
+++ b/schemaregistry/config.go
@@ -16,7 +16,10 @@
 
 package schemaregistry
 
-import "fmt"
+import (
+	"fmt"
+	"net/http"
+)
 
 // Config is used to pass multiple configuration options to the Schema Registry client.
 type Config struct {
@@ -50,6 +53,11 @@ type Config struct {
 	RequestTimeoutMs int
 	// CacheCapacity positive integer or zero for unbounded capacity
 	CacheCapacity int
+
+	// BaseClient will override the default http.Client.
+	//
+	// The TLS and Timeout configuration above will still be applied.
+	BaseClient *http.Client
 }
 
 // NewConfig returns a new configuration instance with sane defaults.

--- a/schemaregistry/rest_service.go
+++ b/schemaregistry/rest_service.go
@@ -133,7 +133,7 @@ func newRestService(conf *Config) (*restService, error) {
 
 	timeout := conf.RequestTimeoutMs
 
-	client := conf.BaseClient
+	client := conf.HTTPClient
 	if client == nil {
 		client = new(http.Client)
 	}

--- a/schemaregistry/rest_service.go
+++ b/schemaregistry/rest_service.go
@@ -133,13 +133,18 @@ func newRestService(conf *Config) (*restService, error) {
 
 	timeout := conf.RequestTimeoutMs
 
+	client := conf.BaseClient
+	if client == nil {
+		client = new(http.Client)
+	}
+
+	client.Transport = transport
+	client.Timeout = time.Duration(timeout) * time.Millisecond
+
 	return &restService{
 		url:     u,
 		headers: headers,
-		Client: &http.Client{
-			Transport: transport,
-			Timeout:   time.Duration(timeout) * time.Millisecond,
-		},
+		Client:  client,
 	}, nil
 }
 

--- a/schemaregistry/rest_service_test.go
+++ b/schemaregistry/rest_service_test.go
@@ -18,6 +18,7 @@ package schemaregistry
 
 import (
 	"crypto/tls"
+	"net/http"
 	"strings"
 	"testing"
 )
@@ -81,5 +82,22 @@ func TestConfigureTLS(t *testing.T) {
 	config.SslCaLocation = "test/secrets/rootCA.crt"
 	if err := configureTLS(config, tlsConfig); err != nil {
 		t.Errorf("Should work with valid CA, certificate and key, got %s", err)
+	}
+}
+
+func TestNewRestService(t *testing.T) {
+	conf := NewConfig("mock://")
+	rest, err := newRestService(conf)
+	if err != nil {
+		t.Errorf("Should work with empty config, got %s", err)
+	}
+
+	conf.BaseClient = new(http.Client)
+	rest, err = newRestService(conf)
+	if err != nil {
+		t.Errorf("Should work with base client set, got %s", err)
+	}
+	if rest.Client != conf.BaseClient {
+		t.Errorf("Should use BaseClient if provided")
 	}
 }

--- a/schemaregistry/rest_service_test.go
+++ b/schemaregistry/rest_service_test.go
@@ -92,12 +92,12 @@ func TestNewRestService(t *testing.T) {
 		t.Errorf("Should work with empty config, got %s", err)
 	}
 
-	conf.BaseClient = new(http.Client)
+	conf.HTTPClient = new(http.Client)
 	rest, err = newRestService(conf)
 	if err != nil {
 		t.Errorf("Should work with base client set, got %s", err)
 	}
-	if rest.Client != conf.BaseClient {
-		t.Errorf("Should use BaseClient if provided")
+	if rest.Client != conf.HTTPClient {
+		t.Errorf("Should use HTTPClient if provided")
 	}
 }


### PR DESCRIPTION
This patch introduces the ability to set a custom base http client that will be used for the rest calls to the Schema Registry. 

Common use cases include using traced http clients from telemetry providers.  (This may be a viable solution for #712)

```golang
// example
package main

import (
	"net/http"

	"github.com/confluentinc/confluent-kafka-go/schemaregistry"
	httptrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http"
)

func main() {
	conf := schemaregistry.NewConfig()
	conf.BaseClient = httptrace.WrapClient(new(http.Client))
	client, err := schemaregistry.NewClient(conf)
}
```