### PR TITLE
[internal branch] mock schema registry client does not return correct id from cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Confluent's Golang client for Apache Kafka
 
+# v2.3.0
+
+This is a maintenance release.
+
+## Fixes
+
+ * Fixes a bug in the mock schema registry client where the wrong ID was being
+   returned for pre-registered schema (#971, @srlk).
+
 
 # v2.2.0
 

--- a/schemaregistry/mock_schemaregistry_client.go
+++ b/schemaregistry/mock_schemaregistry_client.go
@@ -84,7 +84,7 @@ func (c *mockclient) Register(subject string, schema SchemaInfo, normalize bool)
 	}
 	c.schemaCacheLock.RUnlock()
 	if ok {
-		return id, nil
+		return idCacheEntryVal.id, nil
 	}
 
 	id, err = c.getIDFromRegistry(subject, schema)


### PR DESCRIPTION
See #971, moved to internal branch to run CI.