### PR TITLE
Add `CreateTopic` method to `MockCluster`

### DIFF
--- a/kafka/mockcluster.go
+++ b/kafka/mockcluster.go
@@ -93,11 +93,11 @@ func (mc *MockCluster) SetRoundtripDuration(brokerID int, duration time.Duration
 }
 
 // CreateTopic creates a topic without having to use a producer
-func (mc *MockCluster) CreateTopic(topic string, partitons, replicationFactor int) error {
+func (mc *MockCluster) CreateTopic(topic string, partitions, replicationFactor int) error {
 	topicStr := C.CString(topic)
 	defer C.free(unsafe.Pointer(topicStr))
 
-	cError := C.rd_kafka_mock_topic_create(mc.mcluster, topicStr, C.int(partitons), C.int(replicationFactor))
+	cError := C.rd_kafka_mock_topic_create(mc.mcluster, topicStr, C.int(partitions), C.int(replicationFactor))
 	if cError != C.RD_KAFKA_RESP_ERR_NO_ERROR {
 		return newError(cError)
 	}

--- a/kafka/mockcluster.go
+++ b/kafka/mockcluster.go
@@ -92,6 +92,18 @@ func (mc *MockCluster) SetRoundtripDuration(brokerID int, duration time.Duration
 	return nil
 }
 
+// CreateTopic creates a topic without having to use a producer
+func (mc *MockCluster) CreateTopic(topic string, partitons, replicationFactor int) error {
+	topicStr := C.CString(topic)
+	defer C.free(unsafe.Pointer(topicStr))
+
+	cError := C.rd_kafka_mock_topic_create(mc.mcluster, topicStr, C.int(partitons), C.int(replicationFactor))
+	if cError != C.RD_KAFKA_RESP_ERR_NO_ERROR {
+		return newError(cError)
+	}
+	return nil
+}
+
 // Close and destroy the MockCluster
 func (mc *MockCluster) Close() {
 	C.rd_kafka_mock_cluster_destroy(mc.mcluster)


### PR DESCRIPTION
This commit adds the `CreateTopic` method to `MockCluster`. This allows the creation of topics without having to use a `Producer`.