### PR TITLE
Fix SchemaRegistry cache issue when value addition

### DIFF
--- a/schemaregistry/cache/lrucache.go
+++ b/schemaregistry/cache/lrucache.go
@@ -95,7 +95,7 @@ func (c *LRUCache) Put(key interface{}, value interface{}) {
 			back := c.lruKeys.Back()
 			if back != nil {
 				value := c.lruKeys.Remove(back)
-				delete(c.lruElements, back)
+				delete(c.lruElements, value)
 				delete(c.entries, value)
 			}
 		}


### PR DESCRIPTION
Fix SchemaRegistry cache issue when value addition, lruElements entry deletion does not occur(when needed), nothing much just a word.

take care.