### PR TITLE
Allow consumer methods to run while closing

### DIFF
--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -553,6 +553,9 @@ func (c *Consumer) Close() (err error) {
 		c.Poll(100)
 	}
 
+	// After this point, no more consumer methods may be called.
+	atomic.StoreUint32(&c.isClosed, 1)
+
 	// Destroy our queue
 	C.rd_kafka_queue_destroy(c.handle.rkq)
 	c.handle.rkq = nil
@@ -561,7 +564,6 @@ func (c *Consumer) Close() (err error) {
 
 	C.rd_kafka_destroy(c.handle.rk)
 
-	atomic.StoreUint32(&c.isClosed, 1)
 	return nil
 }
 

--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -49,7 +49,8 @@ type Consumer struct {
 	appReassigned      bool
 	appRebalanceEnable bool // SerializerConfig setting
 
-	isClosed uint32
+	isClosed  uint32
+	isClosing uint32
 }
 
 // IsClosed returns boolean representing if client is closed or not
@@ -528,8 +529,15 @@ func (c *Consumer) ReadMessage(timeout time.Duration) (*Message, error) {
 // Close Consumer instance.
 // The object is no longer usable after this call.
 func (c *Consumer) Close() (err error) {
-	if !atomic.CompareAndSwapUint32(&c.isClosed, 0, 1) {
-		return getOperationNotAllowedErrorForClosedClient()
+	// Check if the client is already closed.
+	err = c.verifyClient()
+	if err != nil {
+		return err
+	}
+
+	// Client is in the process of closing.
+	if !atomic.CompareAndSwapUint32(&c.isClosing, 0, 1) {
+		return newErrorFromString(ErrState, "Consumer is already closing")
 	}
 
 	// Wait for consumerReader() or pollLogEvents to terminate (by closing readerTermChan)
@@ -553,6 +561,7 @@ func (c *Consumer) Close() (err error) {
 
 	C.rd_kafka_destroy(c.handle.rk)
 
+	atomic.StoreUint32(&c.isClosed, 1)
 	return nil
 }
 

--- a/kafka/integration_mock_test.go
+++ b/kafka/integration_mock_test.go
@@ -19,6 +19,7 @@ package kafka
 // Integration tests using the mock cluster.
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -78,4 +79,142 @@ func TestImmediateFlush(t *testing.T) {
 		"Flush should not take more than %dms, took %dms",
 		expectedFlushMs, elapsed.Milliseconds())
 	assert.Zero(n, "Nothing should be unflushed")
+}
+
+// TestConsumerMethodCallsAfterClose tests that consumer methods can be called
+// while closing. (Issue #1062).
+func TestConsumerMethodCallsWhileClosing(t *testing.T) {
+	assert := assert.New(t)
+
+	// Create mock cluster
+	mockCluster, err := NewMockCluster(2)
+	assert.NoError(err, "Mock cluster creation should succeed")
+	defer mockCluster.Close()
+
+	// Create topic by producing to it.
+	// TODO: Later, use CreateTopic, once that PR is merged.
+	cfg := &ConfigMap{
+		"bootstrap.servers": mockCluster.BootstrapServers(),
+	}
+	p, err := NewProducer(cfg)
+	assert.NoError(err, "Producer creation should succeed")
+	defer p.Close()
+	assert.NoError(err, "Message should be produced")
+
+	topic := "topic"
+	msg := Message{
+		TopicPartition: TopicPartition{
+			Topic:     &topic,
+			Partition: PartitionAny,
+		},
+		Value: []byte("value"),
+	}
+	err = p.Produce(&msg, nil)
+
+	cfg = &ConfigMap{
+		"bootstrap.servers": mockCluster.BootstrapServers(),
+		"group.id":          "group",
+	}
+
+	consumer, err := NewConsumer(cfg)
+	assert.NoError(err, "Consumer creation should succeed")
+
+	partitionsRevoked := false
+	err = consumer.SubscribeTopics([]string{topic}, func(c *Consumer, e Event) error {
+		switch e.(type) {
+		case RevokedPartitions:
+			partitionsRevoked = true
+			_, err := c.Commit()
+			assert.NotErrorIs(err, getOperationNotAllowedErrorForClosedClient(),
+				"Commit should not fail with '%s'",
+				getOperationNotAllowedErrorForClosedClient())
+		}
+		return nil
+	})
+
+	// Poll for enough time that we do the rebalance.
+	consumer.Poll(10 * 1000)
+
+	err = consumer.Close()
+	assert.NoError(err, "Consumer closure should succeed")
+	assert.True(partitionsRevoked, "Partitions should be revoked after close.")
+}
+
+// TestParallelConsumerCloses tests that two goroutines cannot close the
+// consumer at one time.
+func TestParallelConsumerCloses(t *testing.T) {
+	assert := assert.New(t)
+
+	// Create mock cluster
+	mockCluster, err := NewMockCluster(2)
+	assert.NoError(err, "Mock cluster creation should succeed")
+	defer mockCluster.Close()
+
+	// Create topic by producing to it.
+	// TODO: Later, use CreateTopic, once that PR is merged.
+	cfg := &ConfigMap{
+		"bootstrap.servers": mockCluster.BootstrapServers(),
+	}
+	p, err := NewProducer(cfg)
+	assert.NoError(err, "Producer creation should succeed")
+	defer p.Close()
+	assert.NoError(err, "Message should be produced")
+
+	topic := "topic"
+	msg := Message{
+		TopicPartition: TopicPartition{
+			Topic:     &topic,
+			Partition: PartitionAny,
+		},
+		Value: []byte("value"),
+	}
+	err = p.Produce(&msg, nil)
+
+	cfg = &ConfigMap{
+		"bootstrap.servers": mockCluster.BootstrapServers(),
+		"group.id":          "group",
+	}
+
+	consumer, err := NewConsumer(cfg)
+	assert.NoError(err, "Consumer creation should succeed")
+
+	err = consumer.SubscribeTopics([]string{topic}, func(c *Consumer, e Event) error {
+		switch e.(type) {
+		case RevokedPartitions:
+			// Slow down the closure, since the close method will wait for this
+			// callback to run first.
+			time.Sleep(time.Second)
+		}
+		return nil
+	})
+
+	// Poll for enough time that we do the rebalance.
+	consumer.Poll(10 * 1000)
+
+	// Try closing the consumer from two different go-routines
+	var err0 error
+	var err1 error
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		err0 = consumer.Close()
+		wg.Done()
+	}()
+	go func() {
+		err1 = consumer.Close()
+		wg.Done()
+	}()
+
+	wg.Wait()
+
+	assert.True((err0 == nil) || (err1 == nil), "Exactly one of the errors must be nil")
+	assert.True((err0 != nil) || (err1 != nil), "Exactly one of the errors must be nil")
+
+	if err0 != nil {
+		assert.Equal(err0.(Error).String(), "Consumer is already closing")
+	}
+	if err1 != nil {
+		assert.Equal(err1.(Error).String(), "Consumer is already closing")
+	}
 }


### PR DESCRIPTION
See #1062
https://github.com/confluentinc/confluent-kafka-go/pull/901#issuecomment-1688151851

With #901, such flows were no longer working after the final Close(). 
```
rebalanceCb() {
   ...
   ...
   if (partitions_are_being_revoked) { 
     commit(some_offsets) 
   }
```

This was because the consumer would be counted as closed and commit would return an error.

it's based on the dev_go_flush_ignore_queue_buffering_time since I'm using the same file