### PR TITLE
Adding producer latency to Message Delivery Report

### DIFF
--- a/kafka/producer_test.go
+++ b/kafka/producer_test.go
@@ -136,6 +136,9 @@ func TestProducerAPIs(t *testing.T) {
 		switch e := ev.(type) {
 		case *Message:
 			msgCnt++
+			if *e.ProducerLatency <= 0 {
+				t.Errorf("Producer Latency should be included in delivery reports, instead got %v", *e.ProducerLatency)
+			}
 			if (string)(e.Value) == "ProducerChannel" {
 				s := e.Opaque.(*string)
 				if s != &myOpq {


### PR DESCRIPTION
Originally in response to this message, and better metrics internally. 

https://github.com/confluentinc/confluent-kafka-go/issues/425#issue-559017454

### Background:

Our internal applications measure producer latency, by consuming directly from the topic and producing a diff of the message timestamp, and the event timestamp. Exposing the Producer Latency directly to the delivery report will help prevent having an unnecessary consumer to report on Producer Latency. 