### PR TITLE
Move doc from InitTransactions to BeginTransaction

### DIFF
--- a/kafka/producer.go
+++ b/kafka/producer.go
@@ -807,14 +807,6 @@ func (p *Producer) SetOAuthBearerTokenFailure(errstr string) error {
 // will acquire the internal producer id and epoch, used in all future
 // transactional messages issued by this producer instance.
 //
-// Upon successful return from this function the application has to perform at
-// least one of the following operations within `transaction.timeout.ms` to
-// avoid timing out the transaction on the broker:
-//   - `Produce()` (et.al)
-//   - `SendOffsetsToTransaction()`
-//   - `CommitTransaction()`
-//   - `AbortTransaction()`
-//
 // Parameters:
 //   - `ctx` - The maximum time to block, or nil for indefinite.
 //     On timeout the operation may continue in the background,
@@ -845,6 +837,14 @@ func (p *Producer) InitTransactions(ctx context.Context) error {
 //
 // `InitTransactions()` must have been called successfully (once)
 // before this function is called.
+//
+// Upon successful return from this function the application has to perform at
+// least one of the following operations within `transaction.timeout.ms` to
+// avoid timing out the transaction on the broker:
+//   - `Produce()` (et.al)
+//   - `SendOffsetsToTransaction()`
+//   - `CommitTransaction()`
+//   - `AbortTransaction()`
 //
 // Any messages produced, offsets sent (`SendOffsetsToTransaction()`),
 // etc, after the successful return of this function will be part of


### PR DESCRIPTION
The way I understand it, the text about `transaction.timeout.ms` is relevant for `BeginTransaction` and not for `InitTransactions` (but please correct me if I'm misunderstanding this).