### PR TITLE
ci: Update mac build agents versions

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -16,7 +16,7 @@ blocks:
     task:
       agent:
         machine:
-          type: s1-prod-macos
+          type: s1-prod-macos-13-5-amd64
       prologue:
         commands:
           - sem-version go 1.19


### PR DESCRIPTION
- Update mac agent to 13.5 which is close to developer's local versions.
- new mac agent syntax is same as ubuntu agents