### PR TITLE
Fix json validation during serialization

### DIFF
--- a/schemaregistry/serde/avro/avro_generic.go
+++ b/schemaregistry/serde/avro/avro_generic.go
@@ -67,7 +67,7 @@ func (s *GenericSerializer) Serialize(topic string, msg interface{}) ([]byte, er
 	info := schemaregistry.SchemaInfo{
 		Schema: avroType.String(),
 	}
-	id, err := s.GetID(topic, msg, info)
+	id, err := s.GetID(topic, msg, &info)
 	if err != nil {
 		return nil, err
 	}

--- a/schemaregistry/serde/avro/avro_specific.go
+++ b/schemaregistry/serde/avro/avro_specific.go
@@ -76,7 +76,7 @@ func (s *SpecificSerializer) Serialize(topic string, msg interface{}) ([]byte, e
 	info := schemaregistry.SchemaInfo{
 		Schema: avroMsg.Schema(),
 	}
-	id, err := s.GetID(topic, avroMsg, info)
+	id, err := s.GetID(topic, avroMsg, &info)
 	if err != nil {
 		return nil, err
 	}

--- a/schemaregistry/serde/jsonschema/json_schema.go
+++ b/schemaregistry/serde/jsonschema/json_schema.go
@@ -68,7 +68,7 @@ func (s *Serializer) Serialize(topic string, msg interface{}) ([]byte, error) {
 		Schema:     string(raw),
 		SchemaType: "JSON",
 	}
-	id, err := s.GetID(topic, msg, info)
+	id, err := s.GetID(topic, msg, &info)
 	if err != nil {
 		return nil, err
 	}

--- a/schemaregistry/serde/protobuf/protobuf.go
+++ b/schemaregistry/serde/protobuf/protobuf.go
@@ -177,7 +177,7 @@ func (s *Serializer) Serialize(topic string, msg interface{}) ([]byte, error) {
 		SchemaType: metadata.SchemaType,
 		References: metadata.References,
 	}
-	id, err := s.GetID(topic, protoMsg, info)
+	id, err := s.GetID(topic, protoMsg, &info)
 	if err != nil {
 		return nil, err
 	}

--- a/schemaregistry/serde/serde.go
+++ b/schemaregistry/serde/serde.go
@@ -128,28 +128,28 @@ func TopicNameStrategy(topic string, serdeType Type, schema schemaregistry.Schem
 }
 
 // GetID returns a schema ID for the given schema
-func (s *BaseSerializer) GetID(topic string, msg interface{}, info schemaregistry.SchemaInfo) (int, error) {
+func (s *BaseSerializer) GetID(topic string, msg interface{}, info *schemaregistry.SchemaInfo) (int, error) {
 	autoRegister := s.Conf.AutoRegisterSchemas
 	useSchemaID := s.Conf.UseSchemaID
 	useLatest := s.Conf.UseLatestVersion
 	normalizeSchema := s.Conf.NormalizeSchemas
 
 	var id = -1
-	subject, err := s.SubjectNameStrategy(topic, s.SerdeType, info)
+	subject, err := s.SubjectNameStrategy(topic, s.SerdeType, *info)
 	if err != nil {
 		return -1, err
 	}
 	if autoRegister {
-		id, err = s.Client.Register(subject, info, normalizeSchema)
+		id, err = s.Client.Register(subject, *info, normalizeSchema)
 		if err != nil {
 			return -1, err
 		}
 	} else if useSchemaID >= 0 {
-		info, err = s.Client.GetBySubjectAndID(subject, useSchemaID)
+		*info, err = s.Client.GetBySubjectAndID(subject, useSchemaID)
 		if err != nil {
 			return -1, err
 		}
-		id, err = s.Client.GetID(subject, info, false)
+		id, err = s.Client.GetID(subject, *info, false)
 		if err != nil {
 			return -1, err
 		}
@@ -161,17 +161,17 @@ func (s *BaseSerializer) GetID(topic string, msg interface{}, info schemaregistr
 		if err != nil {
 			return -1, err
 		}
-		info = schemaregistry.SchemaInfo{
+		*info = schemaregistry.SchemaInfo{
 			Schema:     metadata.Schema,
 			SchemaType: metadata.SchemaType,
 			References: metadata.References,
 		}
-		id, err = s.Client.GetID(subject, info, false)
+		id, err = s.Client.GetID(subject, *info, false)
 		if err != nil {
 			return -1, err
 		}
 	} else {
-		id, err = s.Client.GetID(subject, info, normalizeSchema)
+		id, err = s.Client.GetID(subject, *info, normalizeSchema)
 		if err != nil {
 			return -1, err
 		}


### PR DESCRIPTION
Ensure the schema info is updated before using it for JSON validation.

Fixes https://github.com/confluentinc/confluent-kafka-go/issues/1078

Supercedes https://github.com/confluentinc/confluent-kafka-go/pull/984