### PR TITLE
godoc: Minor API doc edits. Timestamps are Unix milliseconds.

### DIFF
--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -736,7 +736,7 @@ func (c *Consumer) GetWatermarkOffsets(topic string, partition int32) (low, high
 //
 // The timestamps to query are represented as `.Offset` in the `times`
 // argument and the looked up offsets are represented as `.Offset` in the returned
-// `offsets` list.
+// `offsets` list. Timestamps are in Unix milliseconds.
 //
 // The function will block for at most timeoutMs milliseconds.
 //

--- a/kafka/error.go
+++ b/kafka/error.go
@@ -31,7 +31,8 @@ import (
 	"unsafe"
 )
 
-// Error provides a Kafka-specific error container
+// Error provides a Kafka-specific error container. Check that Code() != ErrorNoError
+// when embedded in result structs.
 type Error struct {
 	code             ErrorCode
 	str              string
@@ -85,8 +86,8 @@ func newErrorFromCErrorDestroy(cError *C.rd_kafka_error_t) Error {
 	return newErrorFromCError(cError)
 }
 
-// Error returns a human readable representation of an Error
-// Same as Error.String()
+// Error returns a human readable representation of an Error.
+// Same as Error.String().
 func (e Error) Error() string {
 	return e.String()
 }
@@ -107,7 +108,7 @@ func (e Error) String() string {
 	return errstr
 }
 
-// Code returns the ErrorCode of an Error
+// Code returns the ErrorCode of this Error.
 func (e Error) Code() ErrorCode {
 	return e.code
 }

--- a/kafka/error_gen.go
+++ b/kafka/error_gen.go
@@ -73,7 +73,8 @@ func WriteErrorCodes(f *os.File) {
 */
 import "C"
 
-// ErrorCode is the integer representation of local and broker error codes
+// ErrorCode is the integer representation of local and broker error codes.
+// ErrNoError (0) represents success.
 type ErrorCode int
 
 // String returns a human readable representation of an error code

--- a/kafka/offset.go
+++ b/kafka/offset.go
@@ -129,7 +129,7 @@ func OffsetTail(relativeOffset Offset) Offset {
 //
 // The timestamps to query are represented as `.Offset` in the `times`
 // argument and the looked up offsets are represented as `.Offset` in the returned
-// `offsets` list.
+// `offsets` list. Timestamps are in Unix milliseconds.
 //
 // The function will block for at most timeoutMs milliseconds.
 //

--- a/kafka/producer.go
+++ b/kafka/producer.go
@@ -726,7 +726,7 @@ func (p *Producer) QueryWatermarkOffsets(topic string, partition int32, timeoutM
 //
 // The timestamps to query are represented as `.Offset` in the `times`
 // argument and the looked up offsets are represented as `.Offset` in the returned
-// `offsets` list.
+// `offsets` list. Timestamps are in Unix milliseconds.
 //
 // The function will block for at most timeoutMs milliseconds.
 //


### PR DESCRIPTION
This is a collection of minor API documentation edits I noticed while using ListOffsets. Notably: I had to look around to figure out that timestamps are Unix milliseconds.

Detailed edits:

* OffsetSpec: Reference defined constants and NewOffsetSpecForTimestamp. Attempt to clarify the constants using the wording from Java: https://kafka.apache.org/26/javadoc/org/apache/kafka/clients/admin/OffsetSpec.html
* NewOffsetSpecForTimestamp: Rename parameter and clarify that timestamps are in Unix milliseconds.
* ListOffsetsResultInfo: Timestamp is in Unix milliseconds.
* ListOffsetsResult: Fix TopicPartiton typo. Clarify that this returns offsets for many TopicPartitions. Document how to create a valid OffsetSpec.
* Consumer.OffsetsForTimes: Timestamps are Unix milliseconds.
* Error: Document that Code() == ErrNoError is not an error.
* Error.Error(): Separate two sentences so they are not incorrectly combined by godoc e.g. here: https://pkg.go.dev/github.com/confluentinc/confluent-kafka-go/v2@v2.3.0/kafka#Error.Error
* ErrorCode: Document that ErrNoError is success.
* offsets.go offsetsForTimes: Copy doc from Consumer.OffsetsForTimes.
* Producer.OffsetsForTimes: Copy doc from Consumer.OffsetsForTimes.