### PR TITLE
Get effective compatibility level of subject

### DIFF
--- a/schemaregistry/mock_schemaregistry_client.go
+++ b/schemaregistry/mock_schemaregistry_client.go
@@ -425,14 +425,15 @@ func (c *mockclient) DeleteSubjectVersion(subject string, version int, permanent
 
 // Fetch compatibility level currently configured for provided subject
 // Returns compatibility level string upon success
-func (c *mockclient) GetCompatibility(subject string) (compatibility Compatibility, err error) {
+func (c *mockclient) GetCompatibility(subject string, defaultToGlobal bool) (compatibility Compatibility, err error) {
 	c.compatibilityCacheLock.RLock()
 	compatibility, ok := c.compatibilityCache[subject]
 	c.compatibilityCacheLock.RUnlock()
+	fmt.Printf(subjectConfigDefaultToGlobal, url.PathEscape(subject), defaultToGlobal)
 	if !ok {
 		posErr := url.Error{
 			Op:  "GET",
-			URL: c.url.String() + fmt.Sprintf(subjectConfig, url.PathEscape(subject)),
+			URL: c.url.String() + fmt.Sprintf(subjectConfigDefaultToGlobal, url.PathEscape(subject), defaultToGlobal),
 			Err: errors.New("Subject Not Found"),
 		}
 		return compatibility, &posErr

--- a/schemaregistry/rest_service.go
+++ b/schemaregistry/rest_service.go
@@ -52,6 +52,7 @@ const (
 	compatibility     = "/compatibility" + versions
 	config            = "/config"
 	subjectConfig     = config + "/%s"
+	subjectConfigDefaultToGlobal = subjectConfig + "?defaultToGlobal=%t"
 	mode              = "/mode"
 	modeConfig        = mode + "/%s"
 

--- a/schemaregistry/schemaregistry_client.go
+++ b/schemaregistry/schemaregistry_client.go
@@ -212,7 +212,7 @@ type Client interface {
 	GetAllSubjects() ([]string, error)
 	DeleteSubject(subject string, permanent bool) ([]int, error)
 	DeleteSubjectVersion(subject string, version int, permanent bool) (deletes int, err error)
-	GetCompatibility(subject string) (compatibility Compatibility, err error)
+	GetCompatibility(subject string, defaultToGlobal bool) (compatibility Compatibility, err error)
 	UpdateCompatibility(subject string, update Compatibility) (compatibility Compatibility, err error)
 	TestCompatibility(subject string, version int, schema SchemaInfo) (compatible bool, err error)
 	GetDefaultCompatibility() (compatibility Compatibility, err error)
@@ -672,9 +672,10 @@ func (c *Compatibility) ParseString(val string) error {
 
 // Fetch compatibility level currently configured for provided subject
 // Returns compatibility level string upon success
-func (c *client) GetCompatibility(subject string) (compatibility Compatibility, err error) {
+func (c *client) GetCompatibility(subject string, defaultToGlobal bool) (compatibility Compatibility, err error) {
 	var result compatibilityLevel
-	err = c.restService.handleRequest(newRequest("GET", subjectConfig, nil, url.PathEscape(subject)), &result)
+	err = c.restService.handleRequest(newRequest("GET", subjectConfigDefaultToGlobal, nil,
+		url.PathEscape(subject), defaultToGlobal), &result)
 
 	return result.Compatibility, err
 }

--- a/schemaregistry/schemaregistry_client_test.go
+++ b/schemaregistry/schemaregistry_client_test.go
@@ -102,8 +102,8 @@ func testGetAllVersions(subject string, expected []int) {
 	maybeFail(subject, err, expect(actual, expected))
 }
 
-func testGetCompatibility(subject string, expected Compatibility) {
-	actual, err := srClient.GetCompatibility(subject)
+func testGetCompatibility(subject string, defaultToGlobal bool, expected Compatibility) {
+	actual, err := srClient.GetCompatibility(subject, defaultToGlobal)
 	maybeFail(subject, err, expect(actual, expected))
 }
 
@@ -216,7 +216,7 @@ func TestClient(t *testing.T) {
 			testGetLatestSchemaMetadata(subject)
 
 			testUpdateCompatibility(subject, Forward, Forward)
-			testGetCompatibility(subject, Forward)
+			testGetCompatibility(subject, false, Forward)
 
 			testUpdateDefaultCompatibility(None, None)
 			testGetDefaultCompatibility(None)


### PR DESCRIPTION
This PR extends `GET` request to get effective compatibility level of a given subject.
The orginal issue is described here https://github.com/confluentinc/confluent-kafka-go/issues/1090.