### PR TITLE
add CacheSchemas option to Serializer

### DIFF
--- a/schemaregistry/serde/protobuf/config.go
+++ b/schemaregistry/serde/protobuf/config.go
@@ -21,12 +21,21 @@ import "github.com/confluentinc/confluent-kafka-go/v2/schemaregistry/serde"
 // SerializerConfig is used to pass multiple configuration options to the serializers.
 type SerializerConfig struct {
 	serde.SerializerConfig
+	// CacheSchemas will cache serialization results based on the name of the protobuf file
+	// corresponding to the message being serialized. This will drastically improve serialization
+	// performance if you are only ever using a _single_ version of a specific protobuf schema
+	// during any given run of your application. This should be the case for most applications,
+	// but might not apply if you're not creating proto messages based on generated files (e.g.
+	// you are proxying or reading raw protobuf messages from a data source), or if for some reason
+	// you are including multiple versions of the same schema/protobuf in your application.
+	CacheSchemas bool
 }
 
 // NewSerializerConfig returns a new configuration instance with sane defaults.
 func NewSerializerConfig() *SerializerConfig {
 	c := &SerializerConfig{
 		SerializerConfig: *serde.NewSerializerConfig(),
+		CacheSchemas:     false,
 	}
 
 	return c

--- a/schemaregistry/serde/protobuf/protobuf_test.go
+++ b/schemaregistry/serde/protobuf/protobuf_test.go
@@ -199,3 +199,130 @@ func TestProtobufSerdeEmptyMessage(t *testing.T) {
 	_, err = deser.Deserialize("topic1", []byte{})
 	serde.MaybeFail("deserialization", err)
 }
+
+func BenchmarkProtobufSerWithReference(b *testing.B) {
+	serde.MaybeFail = serde.InitFailFuncBenchmark(b)
+	var err error
+	conf := schemaregistry.NewConfig("mock://")
+
+	client, err := schemaregistry.NewClient(conf)
+	serde.MaybeFail("Schema Registry configuration", err)
+
+	ser, err := NewSerializer(client, serde.ValueSerde, NewSerializerConfig())
+	serde.MaybeFail("Serializer configuration", err)
+
+	msg := test.TestMessage{
+		TestString:   "hi",
+		TestBool:     true,
+		TestBytes:    []byte{1, 2},
+		TestDouble:   1.23,
+		TestFloat:    3.45,
+		TestFixed32:  67,
+		TestFixed64:  89,
+		TestInt32:    100,
+		TestInt64:    200,
+		TestSfixed32: 300,
+		TestSfixed64: 400,
+		TestSint32:   500,
+		TestSint64:   600,
+		TestUint32:   700,
+		TestUint64:   800,
+	}
+	obj := test.DependencyMessage{
+		IsActive:     true,
+		TestMesssage: &msg,
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ser.Serialize("topic1", &obj)
+	}
+}
+
+func BenchmarkProtobufSerWithReferenceCached(b *testing.B) {
+	serde.MaybeFail = serde.InitFailFuncBenchmark(b)
+	var err error
+	conf := schemaregistry.NewConfig("mock://")
+
+	client, err := schemaregistry.NewClient(conf)
+	serde.MaybeFail("Schema Registry configuration", err)
+
+	serConf := NewSerializerConfig()
+	serConf.CacheSchemas = true
+	ser, err := NewSerializer(client, serde.ValueSerde, serConf)
+	serde.MaybeFail("Serializer configuration", err)
+
+	msg := test.TestMessage{
+		TestString:   "hi",
+		TestBool:     true,
+		TestBytes:    []byte{1, 2},
+		TestDouble:   1.23,
+		TestFloat:    3.45,
+		TestFixed32:  67,
+		TestFixed64:  89,
+		TestInt32:    100,
+		TestInt64:    200,
+		TestSfixed32: 300,
+		TestSfixed64: 400,
+		TestSint32:   500,
+		TestSint64:   600,
+		TestUint32:   700,
+		TestUint64:   800,
+	}
+	obj := test.DependencyMessage{
+		IsActive:     true,
+		TestMesssage: &msg,
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ser.Serialize("topic1", &obj)
+	}
+}
+
+func BenchmarkProtobufDeserWithReference(b *testing.B) {
+	serde.MaybeFail = serde.InitFailFuncBenchmark(b)
+	var err error
+	conf := schemaregistry.NewConfig("mock://")
+
+	client, err := schemaregistry.NewClient(conf)
+	serde.MaybeFail("Schema Registry configuration", err)
+
+	ser, err := NewSerializer(client, serde.ValueSerde, NewSerializerConfig())
+	serde.MaybeFail("Serializer configuration", err)
+
+	msg := test.TestMessage{
+		TestString:   "hi",
+		TestBool:     true,
+		TestBytes:    []byte{1, 2},
+		TestDouble:   1.23,
+		TestFloat:    3.45,
+		TestFixed32:  67,
+		TestFixed64:  89,
+		TestInt32:    100,
+		TestInt64:    200,
+		TestSfixed32: 300,
+		TestSfixed64: 400,
+		TestSint32:   500,
+		TestSint64:   600,
+		TestUint32:   700,
+		TestUint64:   800,
+	}
+	obj := test.DependencyMessage{
+		IsActive:     true,
+		TestMesssage: &msg,
+	}
+	bytes, err := ser.Serialize("topic1", &obj)
+	serde.MaybeFail("serialization", err)
+
+	deser, err := NewDeserializer(client, serde.ValueSerde, NewDeserializerConfig())
+	serde.MaybeFail("Deserializer configuration", err)
+	deser.Client = ser.Client
+
+	deser.ProtoRegistry.RegisterMessage(obj.ProtoReflect().Type())
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		deser.Deserialize("topic1", bytes)
+	}
+}

--- a/schemaregistry/serde/testhelpers.go
+++ b/schemaregistry/serde/testhelpers.go
@@ -46,6 +46,22 @@ func InitFailFunc(t *testing.T) FailFunc {
 	}
 }
 
+func InitFailFuncBenchmark(b *testing.B) FailFunc {
+	tester := b
+	return func(msg string, errors ...error) {
+		for _, err := range errors {
+			if err != nil {
+				pc := make([]uintptr, 1)
+				runtime.Callers(2, pc)
+				caller := runtime.FuncForPC(pc[0])
+				_, line := caller.FileLine(caller.Entry())
+
+				tester.Fatalf("%s:%d failed: %s %s", caller.Name(), line, msg, err)
+			}
+		}
+	}
+}
+
 // Expect compares the actual and expected values
 func Expect(actual, expected interface{}) error {
 	if !reflect.DeepEqual(actual, expected) {


### PR DESCRIPTION
This adds code to the Serializer that caches the `SchemaInfo` for each `FileDescriptor`, which improves performance by over an order of magnitude by caching the string manipulation bottleneck (see flamegraph [here](https://github.com/confluentinc/confluent-kafka-go/issues/1146#issuecomment-1983975280)). In order to do this, there was also some refactoring to isolate the "cachable" code (getting SchemaInfo from a proto).

Benchmark results:

```
go test -bench . -benchmem
goos: darwin
goarch: arm64
pkg: github.com/confluentinc/confluent-kafka-go/v2/schemaregistry/serde/protobuf
BenchmarkProtobufSerWithReference-8         	   30640	     38625 ns/op	  21778 B/op	     696 allocs/op
BenchmarkProtobufSerWithReferenceCached-8   	 1000000	      1047 ns/op	   1089 B/op	      10 allocs/op
BenchmarkProtobufDeserWithReference-8       	 2469417	       490.1 ns/op	    304 B/op	       8 allocs/op
PASS
```

This is analogous to the approach take in https://github.com/confluentinc/confluent-kafka-go/pull/1128, but the main difference is that this caching is gated behind a config which defaults to false (i.e. default no behavior change). I believe this optimization can be used by most use cases, but there is a specific scenario where it is not appropriate which is why it is gated behind a config:
* The caching uses the file descriptor as key, which reflects the state of the protobuf file a message comes from
* Thus, the exact same protobuf file/message with a different version of a dependency will result in a duplicate key
* So caching should not be used for applications that are not creating new protobuf messages themselves (e.g. proxying proto messages from some data source), or that explicitly include multiple versions of the same set of bindings

Since this caching can be enabled for most users (generally users are generating one set of protobuf bindings and creating messages based on that and thus there won't be multiple versions of protobufs within one run of the application) I think it's appropriate to have this upstreamed into the confluent-kafka-go library

Test: ran existing tests with config enabled; added benchmarks
