### PR TITLE
Fixed incorrect error log in mockcluster.go

### DIFF
--- a/examples/mockcluster_example/mockcluster.go
+++ b/examples/mockcluster_example/mockcluster.go
@@ -81,7 +81,7 @@ func main() {
 
 	err = c.SubscribeTopics([]string{topic}, nil)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to subscribe to consumer: %s\n", err)
+		fmt.Fprintf(os.Stderr, "Failed to subscribe to topics: %s\n", err)
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
Error logs for SubscribeTopics printed an inaccurate message in in mockcluster.go