### PR TITLE
Fix issue in admin_describe_cluster.go

### DIFF
--- a/examples/admin_describe_cluster/admin_describe_cluster.go
+++ b/examples/admin_describe_cluster/admin_describe_cluster.go
@@ -68,7 +68,7 @@ func main() {
 
 	// Print results
 	fmt.Printf("ClusterId: %s\nController: %s\nNodes: %s\n",
-		clusterDesc.ClusterID, clusterDesc.Controller, clusterDesc.Nodes)
+		*clusterDesc.ClusterID, clusterDesc.Controller, clusterDesc.Nodes)
 	if includeAuthorizedOperations {
 		fmt.Printf("Allowed operations: %s\n", clusterDesc.AuthorizedOperations)
 	}


### PR DESCRIPTION
The results print was printing a pointer to clusterDesc.ClusterID and not the cluster id itself