### PR TITLE
Removed redundant type in avrov2_producer_encryption_example.go

### DIFF
--- a/examples/avrov2_producer_encryption_example/avrov2_producer_encryption_example.go
+++ b/examples/avrov2_producer_encryption_example/avrov2_producer_encryption_example.go
@@ -87,7 +87,7 @@ func main() {
 		SchemaType: "AVRO",
 		RuleSet: &schemaregistry.RuleSet{
 			DomainRules: []schemaregistry.Rule{
-				schemaregistry.Rule{
+				{
 					Name: "encryptPII",
 					Kind: "TRANSFORM",
 					Mode: "WRITEREAD",


### PR DESCRIPTION
schemaregistry.Rule type is inferred by `[]schemaregistry.Rule{`