### PR TITLE
chore: cleanup schemaregistry and improve error handling

### DIFF
--- a/schemaregistry/mock_schemaregistry_client.go
+++ b/schemaregistry/mock_schemaregistry_client.go
@@ -19,12 +19,13 @@ package schemaregistry
 import (
 	"errors"
 	"fmt"
-	"github.com/confluentinc/confluent-kafka-go/v2/schemaregistry/internal"
 	"net/url"
 	"reflect"
 	"sort"
 	"strings"
 	"sync"
+
+	"github.com/confluentinc/confluent-kafka-go/v2/schemaregistry/internal"
 )
 
 const noSubject = ""
@@ -547,13 +548,13 @@ func (c *mockclient) DeleteSubjectVersion(subject string, version int, permanent
 // TestSubjectCompatibility verifies schema against all schemas in the subject
 // Returns true if the schema is compatible, false otherwise
 func (c *mockclient) TestSubjectCompatibility(subject string, schema SchemaInfo) (ok bool, err error) {
-	return false, errors.New("unsupported operaiton")
+	return false, errors.New("unsupported operation")
 }
 
 // TestCompatibility verifies schema against the subject's compatibility policy
 // Returns true if the schema is compatible, false otherwise
 func (c *mockclient) TestCompatibility(subject string, version int, schema SchemaInfo) (ok bool, err error) {
-	return false, errors.New("unsupported operaiton")
+	return false, errors.New("unsupported operation")
 }
 
 // Fetch compatibility level currently configured for provided subject

--- a/schemaregistry/rest_service.go
+++ b/schemaregistry/rest_service.go
@@ -125,9 +125,6 @@ func newRestService(conf *Config) (*restService, error) {
 	}
 
 	headers.Add("Content-Type", "application/vnd.schemaregistry.v1+json")
-	if err != nil {
-		return nil, err
-	}
 
 	if conf.HTTPClient == nil {
 		transport, err := configureTransport(conf)
@@ -336,7 +333,7 @@ func (rs *restService) handleRequest(request *api, response interface{}) error {
 		if err != nil {
 			return err
 		}
-		readCloser = ioutil.NopCloser(bytes.NewBuffer(outbuf))
+		readCloser = io.NopCloser(bytes.NewBuffer(outbuf))
 	}
 
 	req := &http.Request{

--- a/schemaregistry/serde/avrov2/avro_test.go
+++ b/schemaregistry/serde/avrov2/avro_test.go
@@ -18,6 +18,10 @@ package avrov2
 
 import (
 	"errors"
+	"reflect"
+	"testing"
+	"time"
+
 	_ "github.com/confluentinc/confluent-kafka-go/v2/schemaregistry/rules/cel"
 	"github.com/confluentinc/confluent-kafka-go/v2/schemaregistry/rules/encryption"
 	_ "github.com/confluentinc/confluent-kafka-go/v2/schemaregistry/rules/encryption/awskms"
@@ -26,9 +30,6 @@ import (
 	_ "github.com/confluentinc/confluent-kafka-go/v2/schemaregistry/rules/encryption/hcvault"
 	_ "github.com/confluentinc/confluent-kafka-go/v2/schemaregistry/rules/encryption/localkms"
 	_ "github.com/confluentinc/confluent-kafka-go/v2/schemaregistry/rules/jsonata"
-	"reflect"
-	"testing"
-	"time"
 
 	"github.com/confluentinc/confluent-kafka-go/v2/schemaregistry"
 	"github.com/confluentinc/confluent-kafka-go/v2/schemaregistry/serde"
@@ -319,7 +320,7 @@ func TestAvroSerdeWithReferences(t *testing.T) {
 		Schema:     string(rootSchema),
 		SchemaType: "AVRO",
 		References: []schemaregistry.Reference{
-			schemaregistry.Reference{
+			{
 				Name:    "DemoSchema",
 				Subject: "demo-value",
 				Version: 1,
@@ -1025,7 +1026,7 @@ func TestAvroSerdeEncryptionWithReferences(t *testing.T) {
 		Schema:     string(rootSchema),
 		SchemaType: "AVRO",
 		References: []schemaregistry.Reference{
-			schemaregistry.Reference{
+			{
 				Name:    "DemoSchema",
 				Subject: "demo-value",
 				Version: 1,
@@ -1131,7 +1132,7 @@ func TestAvroSerdeEncryptionWithPointerReferences(t *testing.T) {
 		Schema:     string(rootPointerSchema),
 		SchemaType: "AVRO",
 		References: []schemaregistry.Reference{
-			schemaregistry.Reference{
+			{
 				Name:    "DemoSchema",
 				Subject: "demo-value",
 				Version: 1,
@@ -1302,7 +1303,7 @@ func TestAvroSerdeJSONataFullyCompatible(t *testing.T) {
 		},
 		RuleSet: &schemaregistry.RuleSet{
 			MigrationRules: []schemaregistry.Rule{
-				schemaregistry.Rule{
+				{
 					Name:      "myRule1",
 					Doc:       "",
 					Kind:      "TRANSFORM",
@@ -1315,7 +1316,7 @@ func TestAvroSerdeJSONataFullyCompatible(t *testing.T) {
 					OnFailure: "",
 					Disabled:  false,
 				},
-				schemaregistry.Rule{
+				{
 					Name:      "myRule2",
 					Doc:       "",
 					Kind:      "TRANSFORM",
@@ -1358,7 +1359,7 @@ func TestAvroSerdeJSONataFullyCompatible(t *testing.T) {
 		},
 		RuleSet: &schemaregistry.RuleSet{
 			MigrationRules: []schemaregistry.Rule{
-				schemaregistry.Rule{
+				{
 					Name:      "myRule1",
 					Doc:       "",
 					Kind:      "TRANSFORM",
@@ -1371,7 +1372,7 @@ func TestAvroSerdeJSONataFullyCompatible(t *testing.T) {
 					OnFailure: "",
 					Disabled:  false,
 				},
-				schemaregistry.Rule{
+				{
 					Name:      "myRule2",
 					Doc:       "",
 					Kind:      "TRANSFORM",
@@ -1408,7 +1409,7 @@ func TestAvroSerdeJSONataFullyCompatible(t *testing.T) {
 	bytes, err := ser1.Serialize("topic1", &widget)
 	serde.MaybeFail("serialization", err)
 
-	deserializeWithAllVersions(err, client, ser1, bytes, widget, newWidget, newerWidget)
+	deserializeWithAllVersions(client, ser1, bytes, widget, newWidget, newerWidget)
 
 	serConfig2 := NewSerializerConfig()
 	serConfig2.AutoRegisterSchemas = false
@@ -1423,7 +1424,7 @@ func TestAvroSerdeJSONataFullyCompatible(t *testing.T) {
 	bytes, err = ser2.Serialize("topic1", &newWidget)
 	serde.MaybeFail("serialization", err)
 
-	deserializeWithAllVersions(err, client, ser2, bytes, widget, newWidget, newerWidget)
+	deserializeWithAllVersions(client, ser2, bytes, widget, newWidget, newerWidget)
 
 	serConfig3 := NewSerializerConfig()
 	serConfig3.AutoRegisterSchemas = false
@@ -1438,10 +1439,10 @@ func TestAvroSerdeJSONataFullyCompatible(t *testing.T) {
 	bytes, err = ser3.Serialize("topic1", &newerWidget)
 	serde.MaybeFail("serialization", err)
 
-	deserializeWithAllVersions(err, client, ser3, bytes, widget, newWidget, newerWidget)
+	deserializeWithAllVersions(client, ser3, bytes, widget, newWidget, newerWidget)
 }
 
-func deserializeWithAllVersions(err error, client schemaregistry.Client, ser *Serializer,
+func deserializeWithAllVersions(client schemaregistry.Client, ser *Serializer,
 	bytes []byte, widget OldWidget, newWidget NewWidget, newerWidget NewerWidget) {
 	deserConfig1 := NewDeserializerConfig()
 	deserConfig1.UseLatestWithMetadata = map[string]string{

--- a/schemaregistry/serde/jsonschema/json_schema.go
+++ b/schemaregistry/serde/jsonschema/json_schema.go
@@ -19,11 +19,12 @@ package jsonschema
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/confluentinc/confluent-kafka-go/v2/schemaregistry/cache"
 	"io"
 	"reflect"
 	"strings"
 	"sync"
+
+	"github.com/confluentinc/confluent-kafka-go/v2/schemaregistry/cache"
 
 	"github.com/confluentinc/confluent-kafka-go/v2/schemaregistry"
 	"github.com/confluentinc/confluent-kafka-go/v2/schemaregistry/serde"
@@ -60,6 +61,9 @@ var _ serde.Deserializer = new(Deserializer)
 // NewSerializer creates a JSON serializer for generic objects
 func NewSerializer(client schemaregistry.Client, serdeType serde.Type, conf *SerializerConfig) (*Serializer, error) {
 	schemaToTypeCache, err := cache.NewLRUCache(1000)
+	if err != nil {
+		return nil, err
+	}
 	sr := &Serde{
 		validate:          conf.EnableValidation,
 		schemaToTypeCache: schemaToTypeCache,
@@ -140,6 +144,9 @@ func (s *Serializer) Serialize(topic string, msg interface{}) ([]byte, error) {
 // NewDeserializer creates a JSON deserializer for generic objects
 func NewDeserializer(client schemaregistry.Client, serdeType serde.Type, conf *DeserializerConfig) (*Deserializer, error) {
 	schemaToTypeCache, err := cache.NewLRUCache(1000)
+	if err != nil {
+		return nil, err
+	}
 	sr := &Serde{
 		validate:          conf.EnableValidation,
 		schemaToTypeCache: schemaToTypeCache,

--- a/schemaregistry/serde/jsonschema/json_schema_test.go
+++ b/schemaregistry/serde/jsonschema/json_schema_test.go
@@ -19,6 +19,7 @@ package jsonschema
 import (
 	"encoding/base64"
 	"errors"
+
 	_ "github.com/confluentinc/confluent-kafka-go/v2/schemaregistry/rules/cel"
 	_ "github.com/confluentinc/confluent-kafka-go/v2/schemaregistry/rules/encryption/awskms"
 	_ "github.com/confluentinc/confluent-kafka-go/v2/schemaregistry/rules/encryption/azurekms"
@@ -28,9 +29,10 @@ import (
 	_ "github.com/confluentinc/confluent-kafka-go/v2/schemaregistry/rules/jsonata"
 
 	"encoding/json"
-	"github.com/invopop/jsonschema"
 	"strings"
 	"testing"
+
+	"github.com/invopop/jsonschema"
 
 	"github.com/confluentinc/confluent-kafka-go/v2/schemaregistry"
 	"github.com/confluentinc/confluent-kafka-go/v2/schemaregistry/serde"
@@ -895,7 +897,7 @@ func TestJSONSchemaSerdeEncryptionWithReferences(t *testing.T) {
 		Schema:     rootSchema,
 		SchemaType: "JSON",
 		References: []schemaregistry.Reference{
-			schemaregistry.Reference{
+			{
 				Name:    "DemoSchema",
 				Subject: "demo-value",
 				Version: 1,
@@ -994,7 +996,7 @@ func TestJSONSchemaSerdeJSONataFullyCompatible(t *testing.T) {
 		},
 		RuleSet: &schemaregistry.RuleSet{
 			MigrationRules: []schemaregistry.Rule{
-				schemaregistry.Rule{
+				{
 					Name:      "myRule1",
 					Doc:       "",
 					Kind:      "TRANSFORM",
@@ -1007,7 +1009,7 @@ func TestJSONSchemaSerdeJSONataFullyCompatible(t *testing.T) {
 					OnFailure: "",
 					Disabled:  false,
 				},
-				schemaregistry.Rule{
+				{
 					Name:      "myRule2",
 					Doc:       "",
 					Kind:      "TRANSFORM",
@@ -1048,7 +1050,7 @@ func TestJSONSchemaSerdeJSONataFullyCompatible(t *testing.T) {
 		},
 		RuleSet: &schemaregistry.RuleSet{
 			MigrationRules: []schemaregistry.Rule{
-				schemaregistry.Rule{
+				{
 					Name:      "myRule1",
 					Doc:       "",
 					Kind:      "TRANSFORM",
@@ -1061,7 +1063,7 @@ func TestJSONSchemaSerdeJSONataFullyCompatible(t *testing.T) {
 					OnFailure: "",
 					Disabled:  false,
 				},
-				schemaregistry.Rule{
+				{
 					Name:      "myRule2",
 					Doc:       "",
 					Kind:      "TRANSFORM",
@@ -1098,7 +1100,7 @@ func TestJSONSchemaSerdeJSONataFullyCompatible(t *testing.T) {
 	bytes, err := ser1.Serialize("topic1", &widget)
 	serde.MaybeFail("serialization", err)
 
-	deserializeWithAllVersions(err, client, ser1, bytes, widget, newWidget, newerWidget)
+	deserializeWithAllVersions(client, ser1, bytes, widget, newWidget, newerWidget)
 
 	serConfig2 := NewSerializerConfig()
 	serConfig2.AutoRegisterSchemas = false
@@ -1113,7 +1115,7 @@ func TestJSONSchemaSerdeJSONataFullyCompatible(t *testing.T) {
 	bytes, err = ser2.Serialize("topic1", &newWidget)
 	serde.MaybeFail("serialization", err)
 
-	deserializeWithAllVersions(err, client, ser2, bytes, widget, newWidget, newerWidget)
+	deserializeWithAllVersions(client, ser2, bytes, widget, newWidget, newerWidget)
 
 	serConfig3 := NewSerializerConfig()
 	serConfig3.AutoRegisterSchemas = false
@@ -1128,10 +1130,10 @@ func TestJSONSchemaSerdeJSONataFullyCompatible(t *testing.T) {
 	bytes, err = ser3.Serialize("topic1", &newerWidget)
 	serde.MaybeFail("serialization", err)
 
-	deserializeWithAllVersions(err, client, ser3, bytes, widget, newWidget, newerWidget)
+	deserializeWithAllVersions(client, ser3, bytes, widget, newWidget, newerWidget)
 }
 
-func deserializeWithAllVersions(err error, client schemaregistry.Client, ser *Serializer,
+func deserializeWithAllVersions(client schemaregistry.Client, ser *Serializer,
 	bytes []byte, widget OldWidget, newWidget NewWidget, newerWidget NewerWidget) {
 	deserConfig1 := NewDeserializerConfig()
 	deserConfig1.UseLatestWithMetadata = map[string]string{

--- a/schemaregistry/serde/protobuf/protobuf_test.go
+++ b/schemaregistry/serde/protobuf/protobuf_test.go
@@ -18,6 +18,8 @@ package protobuf
 
 import (
 	"errors"
+	"testing"
+
 	_ "github.com/confluentinc/confluent-kafka-go/v2/schemaregistry/rules/cel"
 	_ "github.com/confluentinc/confluent-kafka-go/v2/schemaregistry/rules/encryption/awskms"
 	_ "github.com/confluentinc/confluent-kafka-go/v2/schemaregistry/rules/encryption/azurekms"
@@ -25,7 +27,6 @@ import (
 	_ "github.com/confluentinc/confluent-kafka-go/v2/schemaregistry/rules/encryption/hcvault"
 	_ "github.com/confluentinc/confluent-kafka-go/v2/schemaregistry/rules/encryption/localkms"
 	_ "github.com/confluentinc/confluent-kafka-go/v2/schemaregistry/rules/jsonata"
-	"testing"
 
 	"github.com/confluentinc/confluent-kafka-go/v2/schemaregistry"
 	"github.com/confluentinc/confluent-kafka-go/v2/schemaregistry/serde"
@@ -35,65 +36,65 @@ import (
 
 const (
 	authorSchema = `
-syntax = "proto3";
-
-package test;
-option go_package="../test";
-
-import "confluent/meta.proto";
-
-message Author {
-  string name = 1 [
-   (confluent.field_meta).tags = "PII"
-  ];
-  int32 id = 2;
-  bytes picture = 3 [
-   (confluent.field_meta).tags = "PII"
-  ];
-  repeated string works = 4;
-}
-
-message Pizza {
-  string size = 1;
-  repeated string toppings = 2;
-}
-`
+ syntax = "proto3";
+ 
+ package test;
+ option go_package="../test";
+ 
+ import "confluent/meta.proto";
+ 
+ message Author {
+	 string name = 1 [
+		(confluent.field_meta).tags = "PII"
+	 ];
+	 int32 id = 2;
+	 bytes picture = 3 [
+		(confluent.field_meta).tags = "PII"
+	 ];
+	 repeated string works = 4;
+ }
+ 
+ message Pizza {
+	 string size = 1;
+	 repeated string toppings = 2;
+ }
+ `
 	widgetSchema = `
-syntax = "proto3";
-
-package test;
-option go_package="../test";
-
-message Widget {
-    string name = 1;
-    int32 size = 2;
-    int32 version = 3;
-}
-`
+ syntax = "proto3";
+ 
+ package test;
+ option go_package="../test";
+ 
+ message Widget {
+		 string name = 1;
+		 int32 size = 2;
+		 int32 version = 3;
+ }
+ `
 	newWidgetSchema = `
-syntax = "proto3";
-
-package test;
-option go_package="../test";
-
-message NewWidget {
-    string name = 1;
-    int32 height = 2;
-    int32 version = 3;
-}
-`
+ syntax = "proto3";
+ 
+ package test;
+ option go_package="../test";
+ 
+ message NewWidget {
+		 string name = 1;
+		 int32 height = 2;
+		 int32 version = 3;
+ }
+ `
 	newerWidgetSchema = `
-syntax = "proto3";
-
-package test;
-option go_package="../test";
-
-message NewerWidget {
-    string name = 1;
-    int32 length = 2;
-    int32 version = 3;
-}
-`
+ syntax = "proto3";
+ 
+ package test;
+ option go_package="../test";
+ 
+ message NewerWidget {
+		 string name = 1;
+		 int32 length = 2;
+		 int32 version = 3;
+ }
+ `
 )
 
 func TestProtobufSerdeWithSimple(t *testing.T) {
@@ -704,7 +705,7 @@ func TestProtobufSerdeJSONataFullyCompatible(t *testing.T) {
 		},
 		RuleSet: &schemaregistry.RuleSet{
 			MigrationRules: []schemaregistry.Rule{
-				schemaregistry.Rule{
+				{
 					Name:      "myRule1",
 					Doc:       "",
 					Kind:      "TRANSFORM",
@@ -717,7 +718,7 @@ func TestProtobufSerdeJSONataFullyCompatible(t *testing.T) {
 					OnFailure: "",
 					Disabled:  false,
 				},
-				schemaregistry.Rule{
+				{
 					Name:      "myRule2",
 					Doc:       "",
 					Kind:      "TRANSFORM",
@@ -758,7 +759,7 @@ func TestProtobufSerdeJSONataFullyCompatible(t *testing.T) {
 		},
 		RuleSet: &schemaregistry.RuleSet{
 			MigrationRules: []schemaregistry.Rule{
-				schemaregistry.Rule{
+				{
 					Name:      "myRule1",
 					Doc:       "",
 					Kind:      "TRANSFORM",
@@ -771,7 +772,7 @@ func TestProtobufSerdeJSONataFullyCompatible(t *testing.T) {
 					OnFailure: "",
 					Disabled:  false,
 				},
-				schemaregistry.Rule{
+				{
 					Name:      "myRule2",
 					Doc:       "",
 					Kind:      "TRANSFORM",
@@ -808,7 +809,7 @@ func TestProtobufSerdeJSONataFullyCompatible(t *testing.T) {
 	bytes, err := ser1.Serialize("topic1", &widget)
 	serde.MaybeFail("serialization", err)
 
-	deserializeWithAllVersions(err, client, ser1, bytes, widget, newWidget, newerWidget)
+	deserializeWithAllVersions(client, ser1, bytes, widget, newWidget, newerWidget)
 
 	serConfig2 := NewSerializerConfig()
 	serConfig2.AutoRegisterSchemas = false
@@ -823,7 +824,7 @@ func TestProtobufSerdeJSONataFullyCompatible(t *testing.T) {
 	bytes, err = ser2.Serialize("topic1", &newWidget)
 	serde.MaybeFail("serialization", err)
 
-	deserializeWithAllVersions(err, client, ser2, bytes, widget, newWidget, newerWidget)
+	deserializeWithAllVersions(client, ser2, bytes, widget, newWidget, newerWidget)
 
 	serConfig3 := NewSerializerConfig()
 	serConfig3.AutoRegisterSchemas = false
@@ -838,10 +839,10 @@ func TestProtobufSerdeJSONataFullyCompatible(t *testing.T) {
 	bytes, err = ser3.Serialize("topic1", &newerWidget)
 	serde.MaybeFail("serialization", err)
 
-	deserializeWithAllVersions(err, client, ser3, bytes, widget, newWidget, newerWidget)
+	deserializeWithAllVersions(client, ser3, bytes, widget, newWidget, newerWidget)
 }
 
-func deserializeWithAllVersions(err error, client schemaregistry.Client, ser *Serializer,
+func deserializeWithAllVersions(client schemaregistry.Client, ser *Serializer,
 	bytes []byte, widget test.Widget, newWidget test.NewWidget, newerWidget test.NewerWidget) {
 	deserConfig1 := NewDeserializerConfig()
 	deserConfig1.UseLatestWithMetadata = map[string]string{

--- a/schemaregistry/serde/serde.go
+++ b/schemaregistry/serde/serde.go
@@ -717,7 +717,7 @@ func (s *Serde) getRuleActionName(rule schemaregistry.Rule, ruleMode schemaregis
 	return &actionName
 }
 
-func (s *Serde) getRuleAction(ctx RuleContext, actionName string) RuleAction {
+func (s *Serde) getRuleAction(_ RuleContext, actionName string) RuleAction {
 	if actionName == "ERROR" {
 		return ErrorAction{}
 	} else if actionName == "NONE" {


### PR DESCRIPTION
Inside the schemaregistry:
- Added error handling for unchecked errors.
- Replaced unused variables with blank identifiers.
- Removed unused code.
- Removed redundant type specifications.
- Fixed typos.