### PR TITLE
RefreshLatestSchemaMetadataCache implementation refreshing latestToSchemaCache entries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/google/cel-go v0.20.1
 	github.com/google/uuid v1.6.0
 	github.com/hamba/avro/v2 v2.24.0
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/vault/api v1.12.1
 	github.com/heetch/avro v0.4.5
 	github.com/invopop/jsonschema v0.12.0
@@ -118,7 +119,6 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.5 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
 	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.6 // indirect

--- a/schemaregistry/mock_schemaregistry_client.go
+++ b/schemaregistry/mock_schemaregistry_client.go
@@ -296,6 +296,10 @@ func (c *mockclient) GetLatestSchemaMetadata(subject string) (result SchemaMetad
 	return c.GetSchemaMetadata(subject, version)
 }
 
+func (c *mockclient) RefreshLatestSchemaMetadataCache(subjects ...string) (err error) {
+	return nil
+}
+
 // GetSchemaMetadata fetches the requested subject schema identified by version
 // Returns SchemaMetadata object
 func (c *mockclient) GetSchemaMetadata(subject string, version int) (result SchemaMetadata, err error) {


### PR DESCRIPTION
**`RefreshLatestSchemaMetadataCache` implementation refreshing `latestToSchemaCache` entries** [Issue #1274](https://github.com/confluentinc/confluent-kafka-go/issues/1274)
    

**Why?:** in order to allow refresh the internal state of cache that belongs to, the first time that `GetLatestSchemaMetadata` method is executed (client#`latestToSchemaCache`) or when the ttl cache is exired
    
**Implementation:**
    
- `RefreshLatestSchemaMetadataCache` method implementation into schemaregistry_client.go, assuming variadic string with subjects arguments, iterating it and getting the schema-metadata for each one
- by each schema-metadata, when it call occurs and get the schema-metadata into `&SchemaMetadata`
     - lock `latestToSchemaCacheLock` for possible R/W ah update `latestToSchemaCache` internal-state
     - when an error occurs when calling schema-metadata obtention, it puts in a `multierror` and returns the possible errors to be aware about this behavior