### PR TITLE
Move internal RestError to public rest.Error (#30)

### DIFF
--- a/schemaregistry/internal/rest_service.go
+++ b/schemaregistry/internal/rest_service.go
@@ -33,6 +33,8 @@ import (
 	"path"
 	"strings"
 	"time"
+
+	"github.com/confluentinc/confluent-kafka-go/v2/schemaregistry/rest"
 )
 
 // Relative Confluent Schema Registry REST API endpoints as described in the Confluent documentation
@@ -104,17 +106,6 @@ func NewRequest(method string, endpoint string, body interface{}, arguments ...i
 *		- 50002 - Operation timed out
 *		- 50003 - Error forwarding request to SR leader
  */
-
-// RestError represents a Schema Registry HTTP Error response
-type RestError struct {
-	Code    int    `json:"error_code"`
-	Message string `json:"message"`
-}
-
-// Error implements the errors.Error interface
-func (err *RestError) Error() string {
-	return fmt.Sprintf("schema registry request failed error code: %d: %s", err.Code, err.Message)
-}
 
 // RestService represents a REST client
 type RestService struct {
@@ -373,7 +364,7 @@ func (rs *RestService) HandleRequest(request *API, response interface{}) error {
 		return nil
 	}
 
-	var failure RestError
+	var failure rest.Error
 	if err := json.NewDecoder(resp.Body).Decode(&failure); err != nil {
 		return err
 	}

--- a/schemaregistry/rest/rest_error.go
+++ b/schemaregistry/rest/rest_error.go
@@ -1,0 +1,16 @@
+package rest
+
+import (
+	"fmt"
+)
+
+// Error represents a Schema Registry HTTP Error response
+type Error struct {
+	Code    int    `json:"error_code"`
+	Message string `json:"message"`
+}
+
+// Error implements the errors.Error interface
+func (err *Error) Error() string {
+	return fmt.Sprintf("schema registry request failed error code: %d: %s", err.Code, err.Message)
+}

--- a/schemaregistry/rules/encryption/deks/mock_dekregistry_client.go
+++ b/schemaregistry/rules/encryption/deks/mock_dekregistry_client.go
@@ -18,7 +18,7 @@ package deks
 
 import (
 	"github.com/confluentinc/confluent-kafka-go/v2/schemaregistry"
-	"github.com/confluentinc/confluent-kafka-go/v2/schemaregistry/internal"
+	"github.com/confluentinc/confluent-kafka-go/v2/schemaregistry/rest"
 	"net/url"
 	"sync"
 	"time"
@@ -87,7 +87,7 @@ func (c *mockclient) GetKek(name string, deleted bool) (kek Kek, err error) {
 			return kek, nil
 		}
 	}
-	posErr := internal.RestError{
+	posErr := rest.Error{
 		Code:    404,
 		Message: "Key Not Found",
 	}
@@ -150,7 +150,7 @@ func (c *mockclient) GetDekVersion(kekName string, subject string, version int, 
 			}
 		}
 		if latestVersion == 0 {
-			posErr := internal.RestError{
+			posErr := rest.Error{
 				Code:    404,
 				Message: "Key Not Found",
 			}
@@ -173,7 +173,7 @@ func (c *mockclient) GetDekVersion(kekName string, subject string, version int, 
 			return dek, nil
 		}
 	}
-	posErr := internal.RestError{
+	posErr := rest.Error{
 		Code:    404,
 		Message: "Key Not Found",
 	}

--- a/schemaregistry/rules/encryption/encrypt_executor.go
+++ b/schemaregistry/rules/encryption/encrypt_executor.go
@@ -23,7 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/confluentinc/confluent-kafka-go/v2/schemaregistry"
-	"github.com/confluentinc/confluent-kafka-go/v2/schemaregistry/internal"
+	"github.com/confluentinc/confluent-kafka-go/v2/schemaregistry/rest"
 	"github.com/confluentinc/confluent-kafka-go/v2/schemaregistry/rules/encryption/deks"
 	"github.com/confluentinc/confluent-kafka-go/v2/schemaregistry/serde"
 	"github.com/tink-crypto/tink-go/v2/aead"
@@ -303,7 +303,7 @@ func (f *FieldEncryptionExecutorTransform) getOrCreateKek(ctx serde.RuleContext)
 func (f *FieldEncryptionExecutorTransform) retrieveKekFromRegistry(key deks.KekID) (*deks.Kek, error) {
 	kek, err := f.Executor.Client.GetKek(key.Name, key.Deleted)
 	if err != nil {
-		var restErr *internal.RestError
+		var restErr *rest.Error
 		if errors.As(err, &restErr) {
 			if strings.HasPrefix(strconv.Itoa(restErr.Code), "404") {
 				return nil, nil
@@ -317,7 +317,7 @@ func (f *FieldEncryptionExecutorTransform) retrieveKekFromRegistry(key deks.KekI
 func (f *FieldEncryptionExecutorTransform) storeKekToRegistry(key deks.KekID, kmsType string, kmsKeyID string, shared bool) (*deks.Kek, error) {
 	kek, err := f.Executor.Client.RegisterKek(key.Name, kmsType, kmsKeyID, nil, "", shared)
 	if err != nil {
-		var restErr *internal.RestError
+		var restErr *rest.Error
 		if errors.As(err, &restErr) {
 			if strings.HasPrefix(strconv.Itoa(restErr.Code), "409") {
 				return nil, nil
@@ -426,7 +426,7 @@ func (f *FieldEncryptionExecutorTransform) retrieveDekFromRegistry(key deks.DekI
 		dek, err = f.Executor.Client.GetDek(key.KekName, key.Subject, key.Algorithm, key.Deleted)
 	}
 	if err != nil {
-		var restErr *internal.RestError
+		var restErr *rest.Error
 		if errors.As(err, &restErr) {
 			if strings.HasPrefix(strconv.Itoa(restErr.Code), "404") {
 				return nil, nil
@@ -450,7 +450,7 @@ func (f *FieldEncryptionExecutorTransform) storeDekToRegistry(key deks.DekID, en
 		dek, err = f.Executor.Client.RegisterDek(key.KekName, key.Subject, key.Algorithm, encryptedDekStr)
 	}
 	if err != nil {
-		var restErr *internal.RestError
+		var restErr *rest.Error
 		if errors.As(err, &restErr) {
 			if strings.HasPrefix(strconv.Itoa(restErr.Code), "409") {
 				return nil, nil


### PR DESCRIPTION
Fixes https://github.com/confluentinc/confluent-kafka-go/issues/1300