### PR TITLE
Support transforming maps in Data Contract rules

### DIFF
--- a/schemaregistry/serde/avrov2/avro_util.go
+++ b/schemaregistry/serde/avrov2/avro_util.go
@@ -76,19 +76,32 @@ func transform(ctx serde.RuleContext, resolver *avro.TypeResolver, schema avro.S
 		return msg, nil
 	case *avro.RecordSchema:
 		val := deref(msg)
-		fieldByNames := fieldByNames(val)
 		recordSchema := schema.(*avro.RecordSchema)
-		for _, avroField := range recordSchema.Fields() {
-			structField, ok := fieldByNames[avroField.Name()]
-			if !ok {
-				return nil, fmt.Errorf("avro: missing field %s", avroField.Name())
+		if val.Kind() == reflect.Struct {
+			fieldByNames := fieldByNames(val)
+			for _, avroField := range recordSchema.Fields() {
+				structField, ok := fieldByNames[avroField.Name()]
+				if !ok {
+					return nil, fmt.Errorf("avro: missing field %s", avroField.Name())
+				}
+				err := transformField(ctx, resolver, recordSchema, avroField, structField, val, fieldTransform)
+				if err != nil {
+					return nil, err
+				}
 			}
-			err := transformField(ctx, resolver, recordSchema, avroField, structField, val, fieldTransform)
-			if err != nil {
-				return nil, err
+			return msg, nil
+		} else if val.Kind() == reflect.Map {
+			for _, avroField := range recordSchema.Fields() {
+				mapField := val.MapIndex(reflect.ValueOf(avroField.Name()))
+				err := transformField(ctx, resolver, recordSchema, avroField, &mapField, val, fieldTransform)
+				if err != nil {
+					return nil, err
+				}
 			}
+			return msg, nil
+		} else {
+			return nil, fmt.Errorf("message of kind %s is not a struct or map, value: %v", val.Kind(), val)
 		}
-		return msg, nil
 	default:
 		if fieldCtx != nil {
 			ruleTags := ctx.Rule.Tags
@@ -137,9 +150,13 @@ func transformField(ctx serde.RuleContext, resolver *avro.TypeResolver, recordSc
 			}
 		}
 	} else {
-		err = setField(structField, newVal)
-		if err != nil {
-			return err
+		if val.Kind() == reflect.Struct {
+			err = setField(structField, newVal)
+			if err != nil {
+				return err
+			}
+		} else {
+			val.SetMapIndex(reflect.ValueOf(avroField.Name()), *newVal)
 		}
 	}
 	return nil
@@ -203,6 +220,9 @@ func disjoint(slice1 []string, map1 map[string]bool) bool {
 }
 
 func getField(msg *reflect.Value, name string) (*reflect.Value, error) {
+	if msg.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("message is not a struct")
+	}
 	fieldVal := msg.FieldByName(name)
 	return &fieldVal, nil
 }

--- a/schemaregistry/serde/avrov2/avro_util.go
+++ b/schemaregistry/serde/avrov2/avro_util.go
@@ -100,7 +100,7 @@ func transform(ctx serde.RuleContext, resolver *avro.TypeResolver, schema avro.S
 			}
 			return msg, nil
 		} else {
-			return nil, fmt.Errorf("message of kind %s is not a struct or map, value: %v", val.Kind(), val)
+			return nil, fmt.Errorf("message of kind %s is not a struct or map", val.Kind())
 		}
 	default:
 		if fieldCtx != nil {

--- a/schemaregistry/serde/jsonschema/json_schema_util.go
+++ b/schemaregistry/serde/jsonschema/json_schema_util.go
@@ -78,18 +78,31 @@ func transform(ctx serde.RuleContext, schema *jsonschema2.Schema, path string, m
 	switch typ {
 	case serde.TypeRecord:
 		val := deref(msg)
-		fieldByNames := fieldByNames(val)
-		for propName, propSchema := range schema.Properties {
-			structField, ok := fieldByNames[propName]
-			if !ok {
-				return nil, fmt.Errorf("json: missing field %s", propName)
+		if val.Kind() == reflect.Struct {
+			fieldByNames := fieldByNames(val)
+			for propName, propSchema := range schema.Properties {
+				structField, ok := fieldByNames[propName]
+				if !ok {
+					return nil, fmt.Errorf("json: missing field %s", propName)
+				}
+				err := transformField(ctx, path, propName, structField, val, propSchema, fieldTransform)
+				if err != nil {
+					return nil, err
+				}
 			}
-			err := transformField(ctx, path, propName, structField, val, propSchema, fieldTransform)
-			if err != nil {
-				return nil, err
+			return msg, nil
+		} else if val.Kind() == reflect.Map {
+			for propName, propSchema := range schema.Properties {
+				mapField := val.MapIndex(reflect.ValueOf(propName))
+				err := transformField(ctx, path, propName, &mapField, val, propSchema, fieldTransform)
+				if err != nil {
+					return nil, err
+				}
 			}
+			return msg, nil
+		} else {
+			return nil, fmt.Errorf("message is not a struct or map")
 		}
-		return msg, nil
 	case serde.TypeEnum, serde.TypeString, serde.TypeInt, serde.TypeDouble, serde.TypeBoolean:
 		if fieldCtx != nil {
 			ruleTags := ctx.Rule.Tags
@@ -140,9 +153,13 @@ func transformField(ctx serde.RuleContext, path string, propName string, structF
 			}
 		}
 	} else {
-		err = setField(structField, newVal)
-		if err != nil {
-			return err
+		if val.Kind() == reflect.Struct {
+			err = setField(structField, newVal)
+			if err != nil {
+				return err
+			}
+		} else if val.Kind() == reflect.Map {
+			val.SetMapIndex(reflect.ValueOf(propName), *newVal)
 		}
 	}
 	return nil
@@ -238,6 +255,9 @@ func disjoint(slice1 []string, map1 map[string]bool) bool {
 }
 
 func getField(msg *reflect.Value, name string) (*reflect.Value, error) {
+	if msg.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("message is not a struct")
+	}
 	fieldVal := msg.FieldByName(name)
 	return &fieldVal, nil
 }

--- a/schemaregistry/serde/jsonschema/json_schema_util.go
+++ b/schemaregistry/serde/jsonschema/json_schema_util.go
@@ -101,7 +101,7 @@ func transform(ctx serde.RuleContext, schema *jsonschema2.Schema, path string, m
 			}
 			return msg, nil
 		} else {
-			return nil, fmt.Errorf("message is not a struct or map")
+			return nil, fmt.Errorf("message of kind %s is not a struct or map", val.Kind())
 		}
 	case serde.TypeEnum, serde.TypeString, serde.TypeInt, serde.TypeDouble, serde.TypeBoolean:
 		if fieldCtx != nil {


### PR DESCRIPTION
Support transforming maps in Data Contract rules.  Previously only transforming fields in structs were supported.  This PR adds ability to transform entries in maps.