### PR TITLE
Minor change to pass array as type to rule

### DIFF
--- a/schemaregistry/serde/protobuf/protobuf_util.go
+++ b/schemaregistry/serde/protobuf/protobuf_util.go
@@ -108,6 +108,9 @@ func getType(fd protoreflect.FieldDescriptor) serde.FieldType {
 	if fd.IsMap() {
 		return serde.TypeMap
 	}
+	if fd.IsList() {
+		return serde.TypeArray
+	}
 	switch fd.Kind() {
 	case protoreflect.MessageKind:
 		return serde.TypeRecord


### PR DESCRIPTION
Minor change to pass array as type to rule. This allows a rule to see that the type of the field is "ARRAY"