### PR TITLE
Add retry logic to RestService

### DIFF
--- a/schemaregistry/config.go
+++ b/schemaregistry/config.go
@@ -44,6 +44,10 @@ func NewConfig(url string) *Config {
 	c.ConnectionTimeoutMs = 10000
 	c.RequestTimeoutMs = 10000
 
+	c.MaxRetries = 2
+	c.RetriesWaitMs = 1000
+	c.RetriesMaxWaitMs = 20000
+
 	return c
 }
 

--- a/schemaregistry/internal/client_config.go
+++ b/schemaregistry/internal/client_config.go
@@ -64,6 +64,13 @@ type ClientConfig struct {
 	// CacheLatestTTLSecs ttl in secs for caching the latest schema
 	CacheLatestTTLSecs int
 
+	// MaxRetries specifices the maximum number of retries for a request
+	MaxRetries int
+	// RetriesWaitMs specifies the maximum time to wait for the first retry.
+	RetriesWaitMs int
+	// RetriesMaxWaitMs specifies the maximum time to wait any retry.
+	RetriesMaxWaitMs int
+
 	// HTTP client
 	HTTPClient *http.Client
 }


### PR DESCRIPTION
Add retry logic to RestService.  We implement exponential backoff with full jitter per https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/