### PR TITLE
KIP 848:Extend DescribeConfigs and IncrementalAlterConfigs to support GROUP Config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This is a feature release:
 confluent-kafka-go is based on librdkafka v2.10.0, see the
 [librdkafka v2.10.0 release notes](https://github.com/confluentinc/librdkafka/releases/tag/v2.10.0)
 for a complete list of changes, enhancements, fixes and upgrade considerations.
+* [KIP-848] Group Config is now supported in AlterConfigs, IncrementalAlterConfigs and DescribeConfigs. (#1344)
 
 
 There was no v2.9.0 release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@ This is a feature release:
 confluent-kafka-go is based on librdkafka v2.10.0, see the
 [librdkafka v2.10.0 release notes](https://github.com/confluentinc/librdkafka/releases/tag/v2.10.0)
 for a complete list of changes, enhancements, fixes and upgrade considerations.
-* [KIP-848] Group Config is now supported in AlterConfigs, IncrementalAlterConfigs and DescribeConfigs. (#1344)
-
 
 There was no v2.9.0 release.
+
+### Enhancements
+
+* [KIP-848] Group Config is now supported in AlterConfigs, IncrementalAlterConfigs and DescribeConfigs. (#1344)
 
 
 ## v2.8.0

--- a/kafka/adminapi.go
+++ b/kafka/adminapi.go
@@ -539,6 +539,8 @@ const (
 	ConfigSourceStaticBroker ConfigSource = C.RD_KAFKA_CONFIG_SOURCE_STATIC_BROKER_CONFIG
 	// ConfigSourceDefault is built-in default configuration for configs that have a default value
 	ConfigSourceDefault ConfigSource = C.RD_KAFKA_CONFIG_SOURCE_DEFAULT_CONFIG
+	// ConfigSourceGroup is group config that is configured for a specific group
+	ConfigSourceGroup ConfigSource = C.RD_KAFKA_CONFIG_SOURCE_GROUP_CONFIG
 )
 
 // String returns the human-readable representation of a ConfigSource type

--- a/kafka/integration_test.go
+++ b/kafka/integration_test.go
@@ -2016,6 +2016,8 @@ func (its *IntegrationTestSuite) TestAdminConfig() {
 		t.Fatalf("Failed to delete topic %s: %s", topic, topicResult[0].Error)
 	}
 
+	// TODO: enable this test for the classic run too, when
+	// Confluent Platform test cluster is upgraded to 8.0.0
 	if !testConsumerGroupProtocolClassic() {
 		// Test configs that are configured for a specific group.
 		groupID := fmt.Sprintf("test-group-%d", rand.Intn(100000))

--- a/kafka/integration_test.go
+++ b/kafka/integration_test.go
@@ -2017,7 +2017,7 @@ func (its *IntegrationTestSuite) TestAdminConfig() {
 	}
 
 	if !testConsumerGroupProtocolClassic() {
-		// New test case for ResourceType.Group (ResourceGroup)
+		// Test configs that are configured for a specific group.
 		groupID := fmt.Sprintf("test-group-%d", rand.Intn(100000))
 
 		// Incremental Alter Configs for group

--- a/kafka/integration_test.go
+++ b/kafka/integration_test.go
@@ -2015,6 +2015,63 @@ func (its *IntegrationTestSuite) TestAdminConfig() {
 	if topicResult[0].Error.Code() != ErrNoError {
 		t.Fatalf("Failed to delete topic %s: %s", topic, topicResult[0].Error)
 	}
+
+	if !testConsumerGroupProtocolClassic() {
+		// New test case for ResourceType.Group (ResourceGroup)
+		groupID := fmt.Sprintf("test-group-%d", rand.Intn(100000))
+
+		// Incremental Alter Configs for group
+		t.Logf("Incrementally altering configs for consumer group %s", groupID)
+		groupConfig := map[string]string{
+			"consumer.session.timeout.ms": "50000",
+		}
+		groupOps := map[string]AlterConfigOpType{
+			"consumer.session.timeout.ms": AlterConfigOpTypeSet,
+		}
+
+		groupConfigResource := ConfigResource{
+			Type:   ResourceGroup,
+			Name:   groupID,
+			Config: StringMapToIncrementalConfigEntries(groupConfig, groupOps),
+		}
+
+		ctx, cancel = context.WithCancel(context.Background())
+		defer cancel()
+
+		// Perform IncrementalAlterConfigs
+		t.Logf("Performing IncrementalAlterConfigs for group %s", groupID)
+		alterRes, err = a.IncrementalAlterConfigs(ctx, []ConfigResource{groupConfigResource})
+		if err != nil {
+			t.Fatalf("IncrementalAlterConfigs request failed for group %s: %v", groupID, err)
+		}
+
+		// Expected results
+		expectedGroupConfig := []ConfigResourceResult{
+			{
+				Type: ResourceGroup,
+				Name: groupID,
+				Config: map[string]ConfigEntryResult{
+					"consumer.session.timeout.ms": {
+						Name:  "consumer.session.timeout.ms",
+						Value: "50000",
+					},
+				},
+			},
+		}
+
+		// Validate results from IncrementalAlterConfigs
+		validateConfig(t, alterRes, expectedGroupConfig, false)
+
+		// Read back group config to verify
+		t.Logf("Describing configs for group %s", groupID)
+		describeRes, err = a.DescribeConfigs(ctx, []ConfigResource{{Type: ResourceGroup, Name: groupID}})
+		if err != nil {
+			t.Fatalf("DescribeConfigs request failed for group %s: %v", groupID, err)
+		}
+
+		// Validate described configs
+		validateConfig(t, describeRes, expectedGroupConfig, true)
+	}
 }
 
 // Test AdminClient GetMetadata API


### PR DESCRIPTION
This PR intends to add support for Group Resource type for IncrementalALterConfigs API as specified in KIP 848 and extended the DescribeConfigs support till API version 3.
Additional changed the integration test to check for Group Resource Type.
Librdkafka PR: https://github.com/confluentinc/librdkafka/pull/4939