### PR TITLE
For Protobuf, copy the result into the target if necessary

### DIFF
--- a/schemaregistry/serde/protobuf/protobuf.go
+++ b/schemaregistry/serde/protobuf/protobuf.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"reflect"
 	"strings"
 	"sync"
 
@@ -518,7 +519,13 @@ func (s *Deserializer) Deserialize(topic string, payload []byte) (interface{}, e
 
 // DeserializeInto implements deserialization of Protobuf data to the given object
 func (s *Deserializer) DeserializeInto(topic string, payload []byte, msg interface{}) error {
-	_, err := s.deserialize(topic, payload, msg)
+	result, err := s.deserialize(topic, payload, msg)
+	// Copy the result into the target since we may have created a clone during transformations
+	value := reflect.ValueOf(msg)
+	if value.Kind() == reflect.Ptr {
+		rv := value.Elem()
+		rv.Set(reflect.ValueOf(result).Elem())
+	}
 	return err
 }
 

--- a/schemaregistry/serde/protobuf/protobuf_test.go
+++ b/schemaregistry/serde/protobuf/protobuf_test.go
@@ -137,6 +137,9 @@ func TestProtobufSerdeWithSimple(t *testing.T) {
 
 	newobj, err = deser.Deserialize("topic1", bytes)
 	serde.MaybeFail("deserialization", err, serde.Expect(newobj.(proto.Message).ProtoReflect(), obj.ProtoReflect()))
+
+	err = deser.DeserializeInto("topic1", bytes, newobj)
+	serde.MaybeFail("deserialization", err, serde.Expect(newobj.(proto.Message).ProtoReflect(), obj.ProtoReflect()))
 }
 
 func TestProtobufSerdeWithSecondMessage(t *testing.T) {
@@ -647,7 +650,10 @@ func TestProtobufSerdeEncryption(t *testing.T) {
 	serde.MaybeFail("register message", err)
 
 	newobj, err := deser.Deserialize("topic1", bytes)
-	serde.MaybeFail("deserialization", err, serde.Expect(newobj.(proto.Message).ProtoReflect(), obj.ProtoReflect()))
+	serde.MaybeFail("deserialization", err, serde.Expect(newobj.(*test.Author).Name, obj.Name))
+
+	err = deser.DeserializeInto("topic1", bytes, newobj)
+	serde.MaybeFail("deserialization", err, serde.Expect(newobj.(*test.Author).Name, obj.Name))
 }
 
 func TestProtobufSerdeJSONataFullyCompatible(t *testing.T) {


### PR DESCRIPTION
The copying is only needed for the DeserializeInto method for Protobuf.