### PR TITLE
ISSUE-1393 send the body on each http.Request retry

### DIFF
--- a/schemaregistry/internal/rest_service.go
+++ b/schemaregistry/internal/rest_service.go
@@ -378,24 +378,29 @@ func (rs *RestService) HandleHTTPRequest(url *url.URL, request *API) (*http.Resp
 		return nil, err
 	}
 
-	var readCloser io.ReadCloser
+	var outbuf []byte
 	if request.body != nil {
-		outbuf, err := json.Marshal(request.body)
+		outbuf, err = json.Marshal(request.body)
 		if err != nil {
 			return nil, err
 		}
-		readCloser = ioutil.NopCloser(bytes.NewBuffer(outbuf))
-	}
-
-	req := &http.Request{
-		Method: request.method,
-		URL:    endpoint,
-		Body:   readCloser,
-		Header: rs.headers,
 	}
 
 	var resp *http.Response
 	for i := 0; i < rs.maxRetries+1; i++ {
+
+		var readCloser io.ReadCloser
+		if outbuf != nil {
+			readCloser = ioutil.NopCloser(bytes.NewBuffer(outbuf))
+		}
+
+		req := &http.Request{
+			Method: request.method,
+			URL:    endpoint,
+			Body:   readCloser,
+			Header: rs.headers,
+		}
+
 		resp, err = rs.Do(req)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
What
----
Fix HTTP retries that send a body to actually send the body on retries.

Checklist
------------------
- [ ] Contains customer facing changes? No
- [ ] Did you add sufficient unit test and/or integration test coverage for this PR?
  - No: no existing tests for retry payloads

References
----------
JIRA: https://github.com/confluentinc/confluent-kafka-go/issues/1393

Test & Review
------------
Local testing only
