### PR TITLE
Add support for RD_KAFKA_RESOURCE_TRANSACTIONAL_ID in adminapi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v2.x.x
 
 ### Enhancements
+* Add support for `ResourceTransactionalID` in AdminClient ACL APIs (#1407)
 
 ### Fixes
 * Handle non-HTTP errors during retries (#1563)

--- a/kafka/adminapi.go
+++ b/kafka/adminapi.go
@@ -498,6 +498,8 @@ const (
 	ResourceUnknown ResourceType = C.RD_KAFKA_RESOURCE_UNKNOWN
 	// ResourceAny - match any resource type (DescribeConfigs)
 	ResourceAny ResourceType = C.RD_KAFKA_RESOURCE_ANY
+	// ResourceTransactionalID - Transactional ID
+	ResourceTransactionalID ResourceType = C.RD_KAFKA_RESOURCE_TRANSACTIONAL_ID
 	// ResourceTopic - Topic
 	ResourceTopic ResourceType = C.RD_KAFKA_RESOURCE_TOPIC
 	// ResourceGroup - Group
@@ -517,6 +519,8 @@ func ResourceTypeFromString(typeString string) (ResourceType, error) {
 	switch strings.ToUpper(typeString) {
 	case "ANY":
 		return ResourceAny, nil
+	case "TRANSACTIONAL_ID":
+		return ResourceTransactionalID, nil
 	case "TOPIC":
 		return ResourceTopic, nil
 	case "GROUP":

--- a/kafka/adminapi.go
+++ b/kafka/adminapi.go
@@ -498,14 +498,14 @@ const (
 	ResourceUnknown ResourceType = C.RD_KAFKA_RESOURCE_UNKNOWN
 	// ResourceAny - match any resource type (DescribeConfigs)
 	ResourceAny ResourceType = C.RD_KAFKA_RESOURCE_ANY
-	// ResourceTransactionalID - Transactional ID
-	ResourceTransactionalID ResourceType = C.RD_KAFKA_RESOURCE_TRANSACTIONAL_ID
 	// ResourceTopic - Topic
 	ResourceTopic ResourceType = C.RD_KAFKA_RESOURCE_TOPIC
 	// ResourceGroup - Group
 	ResourceGroup ResourceType = C.RD_KAFKA_RESOURCE_GROUP
 	// ResourceBroker - Broker
 	ResourceBroker ResourceType = C.RD_KAFKA_RESOURCE_BROKER
+	// ResourceTransactionalID - Transactional ID
+	ResourceTransactionalID ResourceType = C.RD_KAFKA_RESOURCE_TRANSACTIONAL_ID
 )
 
 // String returns the human-readable representation of a ResourceType
@@ -519,14 +519,14 @@ func ResourceTypeFromString(typeString string) (ResourceType, error) {
 	switch strings.ToUpper(typeString) {
 	case "ANY":
 		return ResourceAny, nil
-	case "TRANSACTIONAL_ID":
-		return ResourceTransactionalID, nil
 	case "TOPIC":
 		return ResourceTopic, nil
 	case "GROUP":
 		return ResourceGroup, nil
 	case "BROKER":
 		return ResourceBroker, nil
+	case "TRANSACTIONAL_ID":
+		return ResourceTransactionalID, nil
 	default:
 		return ResourceUnknown, NewError(ErrInvalidArg, "Unknown resource type", false)
 	}

--- a/kafka/integration/integration_test.go
+++ b/kafka/integration/integration_test.go
@@ -2211,6 +2211,15 @@ func (its *IntegrationTestSuite) TestAdminACLs() {
 			PermissionType:      ACLPermissionTypeAllow,
 		},
 		{
+			Type:                ResourceTransactionalID,
+			Name:                group,
+			ResourcePatternType: ResourcePatternTypePrefixed,
+			Principal:           "User:test-user-2",
+			Host:                "*",
+			Operation:           ACLOperationAll,
+			PermissionType:      ACLPermissionTypeAllow,
+		},
+		{
 			Type:                ResourceTopic,
 			Name:                topic,
 			ResourcePatternType: ResourcePatternTypePrefixed,
@@ -2280,7 +2289,7 @@ func (its *IntegrationTestSuite) TestAdminACLs() {
 		if err != nil {
 			t.Fatalf("CreateACLs() failed: %s", err)
 		}
-		expectedCreateACLs = []CreateACLResult{{Error: noError}, {Error: noError}, {Error: noError}}
+		expectedCreateACLs = []CreateACLResult{{Error: noError}, {Error: noError}, {Error: noError}, {Error: noError}}
 		checkExpectedResult(expectedCreateACLs, resultCreateACLs)
 	}
 

--- a/kafka/integration/integration_test.go
+++ b/kafka/integration/integration_test.go
@@ -2211,15 +2211,6 @@ func (its *IntegrationTestSuite) TestAdminACLs() {
 			PermissionType:      ACLPermissionTypeAllow,
 		},
 		{
-			Type:                ResourceTransactionalID,
-			Name:                group,
-			ResourcePatternType: ResourcePatternTypePrefixed,
-			Principal:           "User:test-user-2",
-			Host:                "*",
-			Operation:           ACLOperationAll,
-			PermissionType:      ACLPermissionTypeAllow,
-		},
-		{
 			Type:                ResourceTopic,
 			Name:                topic,
 			ResourcePatternType: ResourcePatternTypePrefixed,
@@ -2230,6 +2221,15 @@ func (its *IntegrationTestSuite) TestAdminACLs() {
 		},
 		{
 			Type:                ResourceGroup,
+			Name:                group,
+			ResourcePatternType: ResourcePatternTypePrefixed,
+			Principal:           "User:test-user-2",
+			Host:                "*",
+			Operation:           ACLOperationAll,
+			PermissionType:      ACLPermissionTypeAllow,
+		},
+		{
+			Type:                ResourceTransactionalID,
 			Name:                group,
 			ResourcePatternType: ResourcePatternTypePrefixed,
 			Principal:           "User:test-user-2",
@@ -2314,7 +2314,7 @@ func (its *IntegrationTestSuite) TestAdminACLs() {
 			resultCreateACLs[0].Error.Code())
 	}
 
-	// DescribeACLs must return the three ACLs
+	// DescribeACLs must return the four ACLs
 	ctx, cancel = context.WithTimeout(context.Background(), maxDuration)
 	defer cancel()
 	resultDescribeACLs, err := a.DescribeACLs(ctx, aclBindingFilters[0], SetAdminRequestTimeout(requestTimeout))
@@ -2335,7 +2335,7 @@ func (its *IntegrationTestSuite) TestAdminACLs() {
 	expectedDeleteACLs = []DeleteACLsResult{
 		{
 			Error:       noError,
-			ACLBindings: newACLs[1:3],
+			ACLBindings: newACLs[1:4],
 		},
 	}
 	if err != nil {


### PR DESCRIPTION
We need to set transactional.id ACL permissions with adminapi. ResourceTransactionalID is currently missing in golang implementation despite C.RD_KAFKA_RESOURCE_TRANSACTIONAL_ID is available. In scope of this PR I am adding support for ResourceTransactionalID.