### PR TITLE
Fix flaky test TestConsumerMethodCallsWhileClosing

### DIFF
--- a/kafka/integration_mock_test.go
+++ b/kafka/integration_mock_test.go
@@ -136,7 +136,8 @@ func TestConsumerMethodCallsWhileClosing(t *testing.T) {
 	})
 
 	// Poll for enough time that we do the rebalance.
-	for !partitionsAssigned {
+	until := time.Now().Add(60 * time.Second)
+	for !partitionsAssigned && time.Now().Before(until) {
 		consumer.Poll(1 * 1000)
 	}
 


### PR DESCRIPTION
by awaiting for an assignment before closing the consumer, so it's sure a revocation must happen.

<!--
Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [ ] Did you add sufficient unit test and/or integration test coverage for this PR?
  - If not, please explain why it is not required

References
----------
JIRA: 
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow-ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
