### PR TITLE
disable cc-service-bot's management of the Semaphore pipeline contents

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -8,6 +8,7 @@ github:
   repo_name: confluentinc/confluent-kafka-go
 semaphore:
   enable: true
+  pipeline_enable: false
 sonarqube:
   enable: true
   coverage_exclusions:


### PR DESCRIPTION
<!--
Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->
This changes the `service.yml` so that cc-service-bot will no longer try to manage the contents of `.semaphore/semaphore.yml`.

Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [ ] Did you add sufficient unit test and/or integration test coverage for this PR?
  - If not, please explain why it is not required

References
----------
JIRA: 
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow-ups.
-->
N/A - can only be tested on the default branch

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
