### PR TITLE
feat: use hamba encoder schema function if available

### DIFF
--- a/schemaregistry/serde/avrov2/avro_test.go
+++ b/schemaregistry/serde/avrov2/avro_test.go
@@ -18,10 +18,12 @@ package avrov2
 
 import (
 	"errors"
-	"github.com/confluentinc/confluent-kafka-go/v2/schemaregistry/rules/cel"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/confluentinc/confluent-kafka-go/v2/schemaregistry/rules/cel"
+	"github.com/hamba/avro/v2"
 
 	_ "github.com/confluentinc/confluent-kafka-go/v2/schemaregistry/rules/cel"
 	"github.com/confluentinc/confluent-kafka-go/v2/schemaregistry/rules/encryption"
@@ -286,7 +288,62 @@ const (
       "confluent:tags": [ "PII" ]
     }
   ]
-} 
+}
+`
+	demoWithSchemaFuncSchema = `
+{
+  "name": "DemoWithSchemaFunc",
+  "type": "record",
+  "fields": [
+    {
+      "name": "IntField",
+      "type": "int"
+    },
+    {
+      "name": "BoolField",
+      "type": "boolean"
+    },
+    {
+      "name": "ArrayField",
+      "type": {
+        "type": "array",
+        "items": "string"
+      }
+    },
+    {
+      "name": "MapField",
+      "type": {
+        "type": "map",
+        "values": "string"
+      }
+    },
+    {
+      "name": "StringField",
+      "type": ["null", "string"]
+    },
+    {
+      "name": "EnumField",
+      "type": {
+        "name": "GreetingsEnum",
+        "type": "enum",
+        "symbols": ["hey", "bye"]
+      }
+    },
+    {
+      "name": "RecordField",
+      "type": {
+        "name": "GreetingsObj",
+        "type": "record",
+        "fields": [
+          {
+            "name": "Hey",
+            "type": "string"
+          }
+        ]
+      }
+    }
+  ]
+}
 `
 )
 
@@ -302,6 +359,8 @@ func testMessageFactory(subject string, name string) (interface{}, error) {
 		return &DemoSchemaSingleTag{}, nil
 	case "DemoSchemaWithUnion":
 		return &DemoSchemaWithUnion{}, nil
+	case "DemoWithSchemaFunc":
+		return &DemoWithSchemaFunc{}, nil
 	case "ComplexSchema":
 		return &ComplexSchema{}, nil
 	case "SchemaEvolution":
@@ -802,6 +861,46 @@ func TestAvroSchemaEvolution(t *testing.T) {
 
 	msg, err := deser.Deserialize("topic1", bytes)
 	serde.MaybeFail("deserialization", err, serde.Expect(msg, &obj2))
+}
+
+func TestAvroSerdeWithEncodingSchemaFunc(t *testing.T) {
+	serde.MaybeFail = serde.InitFailFunc(t)
+	var err error
+	conf := schemaregistry.NewConfig("mock://")
+
+	client, err := schemaregistry.NewClient(conf)
+	serde.MaybeFail("Schema Registry configuration", err)
+
+	ser, err := NewSerializer(client, serde.ValueSerde, NewSerializerConfig())
+	serde.MaybeFail("Serializer configuration", err)
+
+	obj := DemoWithSchemaFunc{
+		IntField:    123,
+		StringField: nil,
+		BoolField:   true,
+		ArrayField:  []string{"hello", "world"},
+		MapField: map[string]string{
+			"hello": "world",
+		},
+		EnumField: "hey",
+		RecordField: struct {
+			Hey string `json:"Hey"`
+		}{Hey: "bye"},
+	}
+	bytes, err := ser.Serialize("topic1", &obj)
+	serde.MaybeFail("serialization", err)
+
+	deser, err := NewDeserializer(client, serde.ValueSerde, NewDeserializerConfig())
+	serde.MaybeFail("Deserializer configuration", err)
+	deser.Client = ser.Client
+	deser.MessageFactory = testMessageFactory
+
+	var newobj DemoWithSchemaFunc
+	err = deser.DeserializeInto("topic1", bytes, &newobj)
+	serde.MaybeFail("deserialization into", err, serde.Expect(newobj, obj))
+
+	msg, err := deser.Deserialize("topic1", bytes)
+	serde.MaybeFail("deserialization", err, serde.Expect(msg, &obj))
 }
 
 func TestAvroSerdeWithCELCondition(t *testing.T) {
@@ -2687,4 +2786,20 @@ type SchemaEvolution1 struct {
 
 type SchemaEvolution2 struct {
 	NewOptionalField string `json:"NewOptionalField"`
+}
+
+type DemoWithSchemaFunc struct {
+	IntField    int32             `json:"IntField"`
+	BoolField   bool              `json:"BoolField"`
+	StringField *string           `json:"StringField"`
+	ArrayField  []string          `json:"ArrayField"`
+	MapField    map[string]string `json:"MapField"`
+	EnumField   string            `json:"EnumField"`
+	RecordField struct {
+		Hey string `json:"Hey"`
+	} `json:"RecordField"`
+}
+
+func (d *DemoWithSchemaFunc) Schema() avro.Schema {
+	return avro.MustParse(demoWithSchemaFuncSchema)
 }


### PR DESCRIPTION
What
----
This PR introduces a change in how the `avrov2` package is calculating the avro schema of a Kafka message. A serializer with the default config will use reflection to create the schema from the message variable. 
If the message schema contains an `enum` then it isn't possible to create a schema with this type from reflection. 

The `hamba` `avrogen` command can be run with the `-encoders` flag to create encoder code for the generated structs. This code also generates the `Schema() avro.Schema` function which returns the original Avro schema of a struct. 

This PR is checking if the Kafka message struct contains this function and if yes, then retrieves the schema by calling it instead of calculating the schema using reflection. The reflection path is still kept as a fallback. 

This change allows messages containing `enum` types to be correctly serialised using the `hamba/avro` encoder. 

#1372 may be another related issue which can be resolved with this change. 

Checklist
------------------
- [x] Contains customer facing changes? Including API/behavior changes
- [x] Did you add sufficient unit test and/or integration test coverage for this PR?

Test & Review
------------
The unit tests should cover most of the primitive and all the complex types for an Avro field. 

**To reproduce the original error:**
1. Register the `demoWithSchemaFuncSchema` in the Registry
2. Use the `hamba/avro/avrogen` command to generate Go types for the above schema
3. Try to serialize a message using the generated Go types and the default serializer configuration.
