### PR TITLE
Add log channel support to AdminClient

### DIFF
--- a/kafka/adminapi_test.go
+++ b/kafka/adminapi_test.go
@@ -1336,3 +1336,63 @@ func TestAdminAPIs(t *testing.T) {
 
 	a.Close()
 }
+
+func TestAdminClientLog(t *testing.T) {
+	logsChan := make(chan LogEvent, 100)
+
+	admin, err := NewAdminClient(&ConfigMap{
+		"debug": "all",
+		"bootstrap.servers": "localhost:65533", // Unreachable to generate logs
+		"go.logs.channel.enable": true,
+		"go.logs.channel": logsChan,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create AdminClient: %v", err)
+	}
+
+	defer admin.Close()
+
+	expectedLogs := map[struct {
+		tag     string
+		message string
+	}]bool{
+		{"INIT", "librdkafka"}: false,
+	}
+
+	go func() {
+		for {
+			select {
+			case log, ok := <-logsChan:
+				if !ok {
+					return
+				}
+
+				t.Log(log.String())
+
+				for expectedLog, found := range expectedLogs {
+					if found {
+						continue
+					}
+					if log.Tag != expectedLog.tag {
+						continue
+					}
+					if strings.Contains(log.Message, expectedLog.message) {
+						expectedLogs[expectedLog] = true
+					}
+				}
+			}
+		}
+	}()
+
+	<-time.After(time.Second * 5)
+
+	for expectedLog, found := range expectedLogs {
+		if !found {
+			t.Errorf(
+				"Expected to find log with tag `%s' and message containing `%s',"+
+					" but didn't find any.",
+				expectedLog.tag,
+				expectedLog.message)
+		}
+	}
+}


### PR DESCRIPTION
#### Summary
This PR adds support for forwarding librdkafka log events to a Go channel in the AdminClient, similar to the existing functionality in the Producer and Consumer clients. This allows users to programmatically consume and process log events generated by the underlying librdkafka instance used by the AdminClient.

#### Motivation
- Addresses issue https://github.com/confluentinc/confluent-kafka-go/issues/1119 and https://github.com/confluentinc/confluent-kafka-go/issues/1127 
where users requested the ability to receive log events from the AdminClient via a Go channel.
- Enables better observability and integration with Go-based logging and monitoring systems.

#### Changes
- AdminClient struct: Added an adminTermChan field to manage the lifecycle of the log polling goroutine.
- NewAdminClient:
   - Accepts go.logs.channel.enable and go.logs.channel in the ConfigMap.
   - If enabled, sets up a log channel and starts a goroutine to forward log events.
- Close method: Ensures the log polling goroutine is properly terminated when the AdminClient is closed.

#### Test
###### Unit Test
- Added a test to verify that log events are received as expected.

###### Manual test

- Test Code:

```
func main() {
	_, version := kafka.LibraryVersion()
	fmt.Printf("librdkafka version: %s\n", version)

	logsChan := make(chan kafka.LogEvent, 100)

	admin, err := kafka.NewAdminClient(&kafka.ConfigMap{
		"bootstrap.servers":      "localhost:9092", // Change as needed
		"debug":                  "all",
		"go.logs.channel.enable": true,
		"go.logs.channel":        logsChan,
	})
	if err != nil {
		fmt.Printf("Failed to create AdminClient: %v\n", err)
		return
	}
	defer admin.Close()

	fmt.Println("AdminClient created. Listening for log events... (Ctrl+C to exit)")

	sigchan := make(chan os.Signal, 1)
	signal.Notify(sigchan, os.Interrupt)

	go func() {
		for log := range logsChan {
			fmt.Printf("%s INFO kafka admin - LogEvent {\n", log.Timestamp.Format("15:04:05.00000"))
			fmt.Printf("  Name: '%s',\n", log.Name)
			fmt.Printf("  Tag: '%s',\n", log.Tag)
			fmt.Printf("  Message: '%s',\n", log.Message)
			fmt.Printf("  Level: %d,\n", log.Level)
			fmt.Printf("  Timestamp: Time {\n")
			fmt.Printf("   wall: %d,\n", log.Timestamp.UnixNano())
			fmt.Printf("   ext: %d,\n", log.Timestamp.Unix())
			fmt.Printf("   loc: %s\n", log.Timestamp.Location())
			fmt.Printf("  }\n")
			fmt.Printf(" } \n\n")
		}
	}()

	// Optionally, perform an admin operation to generate some logs
	_, _ = admin.GetMetadata(nil, true, 1000)

	<-sigchan
	fmt.Println("Exiting...")
} 
```

- Output
```
15:57:12.20329 INFO kafka admin - LogEvent {
  Name: 'rdkafka#producer-1',
  Tag: 'SEND',
  Message: '[thrd:localhost:9092/1]: localhost:9092/1: Sent MetadataRequest (v12, 26 bytes @ 0, CorrId 2)',
  Level: 7,
  Timestamp: Time {
   wall: 1751020032203293000,
   ext: 1751020032,
   loc: Local
  }
 } 

15:57:12.20335 INFO kafka admin - LogEvent {
  Name: 'rdkafka#producer-1',
  Tag: 'METADATA',
  Message: '[thrd:app]: localhost:9092/1: Request metadata for all topics: application requested',
  Level: 7,
  Timestamp: Time {
   wall: 1751020032203356000,
   ext: 1751020032,
   loc: Local
  }
 } 

15:57:12.20341 INFO kafka admin - LogEvent {
  Name: 'rdkafka#producer-1',
  Tag: 'SETBROKER',
  Message: '[thrd:main]: Setting telemetry broker to localhost:9092/1
',
  Level: 7,
  Timestamp: Time {
   wall: 1751020032203415000,
   ext: 1751020032,
   loc: Local
  }
 } 

15:57:12.20347 INFO kafka admin - LogEvent {
  Name: 'rdkafka#producer-1',
  Tag: 'SEND',
  Message: '[thrd:localhost:9092/1]: localhost:9092/1: Sent MetadataRequest (v12, 29 bytes @ 0, CorrId 3)',
  Level: 7,
  Timestamp: Time {
   wall: 1751020032203475000,
   ext: 1751020032,
   loc: Local
  }
 } 

15:57:12.20351 INFO kafka admin - LogEvent {
  Name: 'rdkafka#producer-1',
  Tag: 'GETSUBSCRIPTIONS',
  Message: '[thrd:main]: Sending GetTelemetryRequest',
  Level: 7,
  Timestamp: Time {
   wall: 1751020032203517000,
   ext: 1751020032,
   loc: Local
  }
 } 
```