### PR TITLE
consumer: return rebalance event via Poll() when appRebalanceEnable && no RebalanceCb

### DIFF
--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -1026,7 +1026,7 @@ func (c *Consumer) handleRebalanceEvent(channel chan Event, rkev *C.rd_kafka_eve
 
 	}
 
-	if channel != nil && c.appRebalanceEnable && c.rebalanceCb == nil {
+	if c.appRebalanceEnable && c.rebalanceCb == nil {
 		// Channel-based consumer with rebalancing enabled,
 		// return the rebalance event and rely on the application
 		// to call *Assign() / *Unassign().


### PR DESCRIPTION
What

Return the rebalance event from `handleRebalanceEvent` when
`go.application.rebalance.enable == true` **and** no `RebalanceCb` is set,
regardless of whether an events channel is used.

Why: In this configuration, Poll()-based consumers did not receive the
rebalance event and could hang until a callback was wired. This change makes
Poll()-based apps receive `AssignedPartitions` / `RevokedPartitions` so they
can call `Assign()` / `Unassign()` to ack, aligning behavior with the config’s
intent. No API changes; callback path unchanged.

Checklist

- [x] Contains customer facing changes? Including API/behavior changes  
      (Behavioral bug fix only; no API change; backward-compatible.)
- [ ] Did you add sufficient unit test and/or integration test coverage for this PR?  
      (No new unit test in this PR; integration test typically requires a broker.
       See “Test & Review” for manual steps. I can follow up with a tagged
       integration test if desired.)

References

Fixes #1457

Test & Review

Local sanity:
- `go build ./...` ✅
- `go test ./...` ✅ (unit tests; no broker required)

Manual verification (requires reachable Kafka):
1. Create a consumer with:
"bootstrap.servers": "<brokers>",
"group.id": "rebalance-poll-it",
"auto.offset.reset": "earliest",
"go.application.rebalance.enable": true
(No `RebalanceCb`; use `Poll()` — no events channel.)

2. `Subscribe()` to a topic and call `Poll()` in a loop.

3. **Before** this change: no rebalance event arrives via `Poll()`.  
**After** this change: an `AssignedPartitions`/`RevokedPartitions` event is
returned by `Poll()`.

4. Call `Assign()` / `Unassign()` accordingly; consumer proceeds and closes cleanly.

Open questions / Follow-ups

- I can send a tiny follow-up PR to update the comment above
`handleRebalanceEvent` to explicitly document this behavior (refs #1421).
- If maintainers prefer, I can also add a small integration test behind a build
tag (requires `kafka/testconf.json` and a broker).

