### PR TITLE
Use registered trademark symbol in first mention of Kafka in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-Confluent's Golang Client for Apache Kafka<sup>TM</sup>
-=====================================================
+Confluent's Golang Client for Apache Kafka®
+===========================================
 
 **confluent-kafka-go** is Confluent's Golang client for [Apache Kafka](http://kafka.apache.org/) and the
 [Confluent Platform](https://www.confluent.io/product/compare/).


### PR DESCRIPTION
What
----
Apache Kafka should be followed by registered trademark symbol, not TM, in first mention

Checklist
------------------
simple README fix, no breaking changes