### PR TITLE
Allow Azure KMS key version to be optional

### DIFF
--- a/schemaregistry/rules/encryption/azurekms/azure_client.go
+++ b/schemaregistry/rules/encryption/azurekms/azure_client.go
@@ -18,10 +18,11 @@ package azurekms
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys"
 	"github.com/tink-crypto/tink-go/v2/core/registry"
-	"strings"
 
 	"github.com/tink-crypto/tink-go/v2/tink"
 )
@@ -55,7 +56,8 @@ func (c *azureClient) Supported(keyURI string) bool {
 }
 
 // GetAEAD gets an AEAD backend by keyURI.
-// keyURI must have the following format: 'azure-kms://https://{vaultURL}/keys/{keyName}/{keyVersion}"
+// keyURI must have the following format: 'azure-kms://https://{vaultURL}/keys/{keyName}/{keyVersion}'
+// where keyVersion is optional and if not provided, the latest version will be used.
 func (c *azureClient) GetAEAD(keyURI string) (tink.AEAD, error) {
 	if !c.Supported(keyURI) {
 		return nil, fmt.Errorf("keyURI must start with prefix %s, but got %s", c.keyURI, keyURI)


### PR DESCRIPTION
<!--
Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
Allow Azure KMS version to be optional.  Tested manually by using keys both with and without a version.
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [ ] Did you add sufficient unit test and/or integration test coverage for this PR?
  - If not, please explain why it is not required

References
----------
JIRA: 
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow-ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
