### PR TITLE
feat(schemaregistry): add ability to turn on assertformat and assertcontent forjson schemas

### DIFF
--- a/schemaregistry/serde/jsonschema/config.go
+++ b/schemaregistry/serde/jsonschema/config.go
@@ -23,6 +23,10 @@ type SerializerConfig struct {
 	serde.SerializerConfig
 	// EnableValidation enables validation of the JSON against the schema.
 	EnableValidation bool
+	// AssertContent explicitly configures content assertions in draft 2019 and above.
+	AssertContent bool
+	// AssertFormat explicitly configures format assertions in draft 2019 and above.
+	AssertFormat bool
 }
 
 // NewSerializerConfig returns a new configuration instance with sane defaults.
@@ -30,6 +34,8 @@ func NewSerializerConfig() *SerializerConfig {
 	c := &SerializerConfig{
 		SerializerConfig: *serde.NewSerializerConfig(),
 		EnableValidation: false,
+		AssertContent:    false,
+		AssertFormat:     false,
 	}
 
 	return c
@@ -39,6 +45,10 @@ func NewSerializerConfig() *SerializerConfig {
 type DeserializerConfig struct {
 	serde.DeserializerConfig
 	EnableValidation bool
+	// AssertContent explicitly configures content assertions in draft 2019 and above.
+	AssertContent bool
+	// AssertFormat explicitly configures format assertions in draft 2019 and above.
+	AssertFormat bool
 }
 
 // NewDeserializerConfig returns a new configuration instance with sane defaults.

--- a/schemaregistry/serde/jsonschema/config.go
+++ b/schemaregistry/serde/jsonschema/config.go
@@ -56,6 +56,8 @@ func NewDeserializerConfig() *DeserializerConfig {
 	c := &DeserializerConfig{
 		DeserializerConfig: *serde.NewDeserializerConfig(),
 		EnableValidation:   false,
+		AssertContent:      false,
+		AssertFormat:       false,
 	}
 
 	return c

--- a/schemaregistry/serde/jsonschema/json_schema.go
+++ b/schemaregistry/serde/jsonschema/json_schema.go
@@ -55,6 +55,8 @@ type Deserializer struct {
 // Serde represents a JSON Schema serde
 type Serde struct {
 	validate              bool
+	assertContent         bool
+	assertFormat          bool
 	schemaToTypeCache     cache.Cache
 	schemaToTypeCacheLock sync.RWMutex
 }
@@ -69,6 +71,8 @@ func NewSerializer(client schemaregistry.Client, serdeType serde.Type, conf *Ser
 		return nil, err
 	}
 	sr := &Serde{
+		assertContent:     conf.AssertContent,
+		assertFormat:      conf.AssertFormat,
 		validate:          conf.EnableValidation,
 		schemaToTypeCache: schemaToTypeCache,
 	}
@@ -189,6 +193,8 @@ func NewDeserializer(client schemaregistry.Client, serdeType serde.Type, conf *D
 	}
 	sr := &Serde{
 		validate:          conf.EnableValidation,
+		assertContent:     conf.AssertContent,
+		assertFormat:      conf.AssertFormat,
 		schemaToTypeCache: schemaToTypeCache,
 	}
 	s := &Deserializer{
@@ -374,6 +380,9 @@ func (s *Serde) toJSONSchema(c schemaregistry.Client, schema schemaregistry.Sche
 		return nil, err
 	}
 	compiler := jsonschema2.NewCompiler()
+	compiler.AssertContent = s.assertContent
+	compiler.AssertFormat = s.assertFormat
+
 	compiler.RegisterExtension("confluent:tags", tagsMeta, tagsCompiler{})
 	compiler.LoadURL = func(url string) (io.ReadCloser, error) {
 		url = strings.TrimPrefix(url, defaultBaseURL)

--- a/schemaregistry/serde/jsonschema/json_schema_test.go
+++ b/schemaregistry/serde/jsonschema/json_schema_test.go
@@ -667,6 +667,583 @@ func TestFailingJSONSchemaValidationWithSimple(t *testing.T) {
 	}
 }
 
+func TestJSONSchemaSerializerValidationAssertFlags(t *testing.T) {
+	serde.MaybeFail = serde.InitFailFunc(t)
+
+	schemaWithFormats := `
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "email": {
+      "type": "string",
+      "format": "email"
+    },
+    "date": {
+      "type": "string",
+      "format": "date"
+    },
+    "uri": {
+      "type": "string",
+      "format": "uri"
+    }
+  }
+}
+`
+
+	schemaWithContent := `
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "encodedData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "jsonData": {
+      "type": "string",
+      "contentMediaType": "application/json"
+    }
+  }
+}
+`
+
+	schemaCombined := `
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "email": {
+      "type": "string",
+      "format": "email"
+    },
+    "encodedData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    }
+  }
+}
+`
+
+	testCases := []struct {
+		name          string
+		assertFormat  bool
+		assertContent bool
+		schema        string
+		topic         string
+		validObj      map[string]interface{}
+		invalidObj    map[string]interface{}
+		expectError   bool
+		errorContains []string
+	}{
+		{
+			name:          "AssertFormat enabled - valid email",
+			assertFormat:  true,
+			assertContent: false,
+			schema:        schemaWithFormats,
+			topic:         "assert-format-valid",
+			validObj: map[string]interface{}{
+				"email": "test@example.com",
+				"date":  "2024-01-01",
+				"uri":   "https://example.com",
+			},
+			expectError: false,
+		},
+		{
+			name:          "AssertFormat enabled - invalid email",
+			assertFormat:  true,
+			assertContent: false,
+			schema:        schemaWithFormats,
+			topic:         "assert-format-invalid-email",
+			invalidObj: map[string]interface{}{
+				"email": "not-an-email",
+				"date":  "2024-01-01",
+				"uri":   "https://example.com",
+			},
+			expectError:   true,
+			errorContains: []string{"jsonschema", "email"},
+		},
+		{
+			name:          "AssertFormat enabled - invalid date",
+			assertFormat:  true,
+			assertContent: false,
+			schema:        schemaWithFormats,
+			topic:         "assert-format-invalid-date",
+			invalidObj: map[string]interface{}{
+				"email": "test@example.com",
+				"date":  "not-a-date",
+				"uri":   "https://example.com",
+			},
+			expectError:   true,
+			errorContains: []string{"jsonschema", "date"},
+		},
+		{
+			name:          "AssertFormat enabled - invalid URI",
+			assertFormat:  true,
+			assertContent: false,
+			schema:        schemaWithFormats,
+			topic:         "assert-format-invalid-uri",
+			invalidObj: map[string]interface{}{
+				"email": "test@example.com",
+				"date":  "2024-01-01",
+				"uri":   "not a valid uri",
+			},
+			expectError:   true,
+			errorContains: []string{"jsonschema", "uri"},
+		},
+		{
+			name:          "AssertContent enabled - valid content",
+			assertFormat:  false,
+			assertContent: true,
+			schema:        schemaWithContent,
+			topic:         "assert-content-valid",
+			validObj: map[string]interface{}{
+				"encodedData": base64.StdEncoding.EncodeToString([]byte("test data")),
+				"jsonData":    `{"key":"value"}`,
+			},
+			expectError: false,
+		},
+		{
+			name:          "AssertContent enabled - invalid base64",
+			assertFormat:  false,
+			assertContent: true,
+			schema:        schemaWithContent,
+			topic:         "assert-content-invalid-base64",
+			invalidObj: map[string]interface{}{
+				"encodedData": "not-valid-base64!@#$%",
+				"jsonData":    `{"key":"value"}`,
+			},
+			expectError:   true,
+			errorContains: []string{"jsonschema"},
+		},
+		{
+			name:          "AssertContent enabled - invalid JSON",
+			assertFormat:  false,
+			assertContent: true,
+			schema:        schemaWithContent,
+			topic:         "assert-content-invalid-json",
+			invalidObj: map[string]interface{}{
+				"encodedData": base64.StdEncoding.EncodeToString([]byte("test data")),
+				"jsonData":    "not valid json {",
+			},
+			expectError:   true,
+			errorContains: []string{"jsonschema"},
+		},
+		{
+			name:          "AssertContent disabled - invalid content",
+			assertFormat:  false,
+			assertContent: false,
+			schema:        schemaWithContent,
+			topic:         "assert-content-disabled",
+			invalidObj: map[string]interface{}{
+				"encodedData": "not-valid-base64!@#$%",
+				"jsonData":    "not valid json {",
+			},
+			expectError: false,
+		},
+		{
+			name:          "Both flags enabled - valid",
+			assertFormat:  true,
+			assertContent: true,
+			schema:        schemaCombined,
+			topic:         "both-flags-valid",
+			validObj: map[string]interface{}{
+				"email":       "test@example.com",
+				"encodedData": base64.StdEncoding.EncodeToString([]byte("data")),
+			},
+			expectError: false,
+		},
+		{
+			name:          "Both flags enabled - invalid email",
+			assertFormat:  true,
+			assertContent: true,
+			schema:        schemaCombined,
+			topic:         "both-flags-invalid-email",
+			invalidObj: map[string]interface{}{
+				"email":       "not-an-email",
+				"encodedData": base64.StdEncoding.EncodeToString([]byte("data")),
+			},
+			expectError: true,
+		},
+		{
+			name:          "Both flags enabled - invalid encoding",
+			assertFormat:  true,
+			assertContent: true,
+			schema:        schemaCombined,
+			topic:         "both-flags-invalid-encoding",
+			invalidObj: map[string]interface{}{
+				"email":       "test@example.com",
+				"encodedData": "not-valid-base64!@#",
+			},
+			expectError: true,
+		},
+		{
+			name:          "Both flags enabled - both invalid",
+			assertFormat:  true,
+			assertContent: true,
+			schema:        schemaCombined,
+			topic:         "both-flags-both-invalid",
+			invalidObj: map[string]interface{}{
+				"email":       "not-an-email",
+				"encodedData": "not-valid-base64!@#",
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			conf := schemaregistry.NewConfig("mock://")
+			client, err := schemaregistry.NewClient(conf)
+			serde.MaybeFail("Schema Registry configuration", err)
+
+			serConfig := NewSerializerConfig()
+			serConfig.EnableValidation = true
+			serConfig.AssertFormat = tc.assertFormat
+			serConfig.AssertContent = tc.assertContent
+			serConfig.AutoRegisterSchemas = false
+			serConfig.UseLatestVersion = true
+			ser, err := NewSerializer(client, serde.ValueSerde, serConfig)
+			serde.MaybeFail("Serializer configuration", err)
+
+			info := schemaregistry.SchemaInfo{
+				Schema:     tc.schema,
+				SchemaType: "JSON",
+			}
+
+			id, err := client.Register(tc.topic+"-value", info, false)
+			serde.MaybeFail("Schema registration", err)
+			if id <= 0 {
+				t.Errorf("Expected valid schema id, found %d", id)
+			}
+
+			var obj map[string]interface{}
+			if tc.validObj != nil {
+				obj = tc.validObj
+			} else {
+				obj = tc.invalidObj
+			}
+
+			_, err = ser.Serialize(tc.topic, &obj)
+
+			if tc.expectError {
+				if err == nil {
+					t.Errorf("Expected validation error but got none")
+				} else if len(tc.errorContains) > 0 {
+					foundAny := false
+					for _, substring := range tc.errorContains {
+						if strings.Contains(err.Error(), substring) {
+							foundAny = true
+							break
+						}
+					}
+					if !foundAny {
+						t.Errorf("Expected error to contain one of %v, found: %s", tc.errorContains, err)
+					}
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Expected no validation error, found: %s", err)
+				}
+			}
+		})
+	}
+}
+
+func TestJSONSchemaDeserializerValidationAssertFlags(t *testing.T) {
+	serde.MaybeFail = serde.InitFailFunc(t)
+
+	schemaWithFormats := `
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "email": {
+      "type": "string",
+      "format": "email"
+    },
+    "date": {
+      "type": "string",
+      "format": "date"
+    },
+    "uri": {
+      "type": "string",
+      "format": "uri"
+    }
+  }
+}
+`
+
+	schemaWithContent := `
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "encodedData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "jsonData": {
+      "type": "string",
+      "contentMediaType": "application/json"
+    }
+  }
+}
+`
+
+	schemaCombined := `
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "email": {
+      "type": "string",
+      "format": "email"
+    },
+    "encodedData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    }
+  }
+}
+`
+
+	testCases := []struct {
+		name          string
+		assertFormat  bool
+		assertContent bool
+		schema        string
+		topic         string
+		validObj      map[string]interface{}
+		invalidObj    map[string]interface{}
+		expectError   bool
+		errorContains []string
+	}{
+		{
+			name:          "AssertFormat enabled - valid email",
+			assertFormat:  true,
+			assertContent: false,
+			schema:        schemaWithFormats,
+			topic:         "deser-assert-format-valid",
+			validObj: map[string]interface{}{
+				"email": "test@example.com",
+				"date":  "2024-01-01",
+				"uri":   "https://example.com",
+			},
+			expectError: false,
+		},
+		{
+			name:          "AssertFormat enabled - invalid email",
+			assertFormat:  true,
+			assertContent: false,
+			schema:        schemaWithFormats,
+			topic:         "deser-assert-format-invalid-email",
+			invalidObj: map[string]interface{}{
+				"email": "not-an-email",
+				"date":  "2024-01-01",
+				"uri":   "https://example.com",
+			},
+			expectError:   true,
+			errorContains: []string{"jsonschema", "email"},
+		},
+		{
+			name:          "AssertFormat enabled - invalid date",
+			assertFormat:  true,
+			assertContent: false,
+			schema:        schemaWithFormats,
+			topic:         "deser-assert-format-invalid-date",
+			invalidObj: map[string]interface{}{
+				"email": "test@example.com",
+				"date":  "not-a-date",
+				"uri":   "https://example.com",
+			},
+			expectError:   true,
+			errorContains: []string{"jsonschema", "date"},
+		},
+		{
+			name:          "AssertFormat enabled - invalid URI",
+			assertFormat:  true,
+			assertContent: false,
+			schema:        schemaWithFormats,
+			topic:         "deser-assert-format-invalid-uri",
+			invalidObj: map[string]interface{}{
+				"email": "test@example.com",
+				"date":  "2024-01-01",
+				"uri":   "not a valid uri",
+			},
+			expectError:   true,
+			errorContains: []string{"jsonschema", "uri"},
+		},
+		{
+			name:          "AssertContent enabled - valid content",
+			assertFormat:  false,
+			assertContent: true,
+			schema:        schemaWithContent,
+			topic:         "deser-assert-content-valid",
+			validObj: map[string]interface{}{
+				"encodedData": base64.StdEncoding.EncodeToString([]byte("test data")),
+				"jsonData":    `{"key":"value"}`,
+			},
+			expectError: false,
+		},
+		{
+			name:          "AssertContent enabled - invalid base64",
+			assertFormat:  false,
+			assertContent: true,
+			schema:        schemaWithContent,
+			topic:         "deser-assert-content-invalid-base64",
+			invalidObj: map[string]interface{}{
+				"encodedData": "not-valid-base64!@#$%",
+				"jsonData":    `{"key":"value"}`,
+			},
+			expectError:   true,
+			errorContains: []string{"jsonschema"},
+		},
+		{
+			name:          "AssertContent enabled - invalid JSON",
+			assertFormat:  false,
+			assertContent: true,
+			schema:        schemaWithContent,
+			topic:         "deser-assert-content-invalid-json",
+			invalidObj: map[string]interface{}{
+				"encodedData": base64.StdEncoding.EncodeToString([]byte("test data")),
+				"jsonData":    "not valid json {",
+			},
+			expectError:   true,
+			errorContains: []string{"jsonschema"},
+		},
+		{
+			name:          "AssertContent disabled - invalid content",
+			assertFormat:  false,
+			assertContent: false,
+			schema:        schemaWithContent,
+			topic:         "deser-assert-content-disabled",
+			invalidObj: map[string]interface{}{
+				"encodedData": "not-valid-base64!@#$%",
+				"jsonData":    "not valid json {",
+			},
+			expectError: false,
+		},
+		{
+			name:          "Both flags enabled - valid",
+			assertFormat:  true,
+			assertContent: true,
+			schema:        schemaCombined,
+			topic:         "deser-both-flags-valid",
+			validObj: map[string]interface{}{
+				"email":       "test@example.com",
+				"encodedData": base64.StdEncoding.EncodeToString([]byte("data")),
+			},
+			expectError: false,
+		},
+		{
+			name:          "Both flags enabled - invalid email",
+			assertFormat:  true,
+			assertContent: true,
+			schema:        schemaCombined,
+			topic:         "deser-both-flags-invalid-email",
+			invalidObj: map[string]interface{}{
+				"email":       "not-an-email",
+				"encodedData": base64.StdEncoding.EncodeToString([]byte("data")),
+			},
+			expectError: true,
+		},
+		{
+			name:          "Both flags enabled - invalid encoding",
+			assertFormat:  true,
+			assertContent: true,
+			schema:        schemaCombined,
+			topic:         "deser-both-flags-invalid-encoding",
+			invalidObj: map[string]interface{}{
+				"email":       "test@example.com",
+				"encodedData": "not-valid-base64!@#",
+			},
+			expectError: true,
+		},
+		{
+			name:          "Both flags enabled - both invalid",
+			assertFormat:  true,
+			assertContent: true,
+			schema:        schemaCombined,
+			topic:         "deser-both-flags-both-invalid",
+			invalidObj: map[string]interface{}{
+				"email":       "not-an-email",
+				"encodedData": "not-valid-base64!@#",
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			conf := schemaregistry.NewConfig("mock://")
+			client, err := schemaregistry.NewClient(conf)
+			serde.MaybeFail("Schema Registry configuration", err)
+
+			// First serialize the data without validation to get serialized bytes
+			serConfig := NewSerializerConfig()
+			serConfig.EnableValidation = false
+			serConfig.AutoRegisterSchemas = false
+			serConfig.UseLatestVersion = true
+			ser, err := NewSerializer(client, serde.ValueSerde, serConfig)
+			serde.MaybeFail("Serializer configuration", err)
+
+			info := schemaregistry.SchemaInfo{
+				Schema:     tc.schema,
+				SchemaType: "JSON",
+			}
+
+			id, err := client.Register(tc.topic+"-value", info, false)
+			serde.MaybeFail("Schema registration", err)
+			if id <= 0 {
+				t.Errorf("Expected valid schema id, found %d", id)
+			}
+
+			var obj map[string]interface{}
+			if tc.validObj != nil {
+				obj = tc.validObj
+			} else {
+				obj = tc.invalidObj
+			}
+
+			bytes, err := ser.Serialize(tc.topic, &obj)
+			serde.MaybeFail("serialization", err)
+
+			deserConfig := NewDeserializerConfig()
+			deserConfig.EnableValidation = true
+			deserConfig.AssertFormat = tc.assertFormat
+			deserConfig.AssertContent = tc.assertContent
+			deser, err := NewDeserializer(client, serde.ValueSerde, deserConfig)
+			serde.MaybeFail("Deserializer configuration", err)
+			deser.Client = ser.Client
+
+			var newobj map[string]interface{}
+			err = deser.DeserializeInto(tc.topic, bytes, &newobj)
+
+			if tc.expectError {
+				if err == nil {
+					t.Errorf("Expected validation error but got none")
+				} else if len(tc.errorContains) > 0 {
+					foundAny := false
+					for _, substring := range tc.errorContains {
+						if strings.Contains(err.Error(), substring) {
+							foundAny = true
+							break
+						}
+					}
+					if !foundAny {
+						t.Errorf("Expected error to contain one of %v, found: %s", tc.errorContains, err)
+					}
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Expected no validation error, found: %s", err)
+				}
+			}
+		})
+	}
+}
+
 func TestJSONSchemaSerdeWithCELCondition(t *testing.T) {
 	serde.MaybeFail = serde.InitFailFunc(t)
 	var err error

--- a/schemaregistry/serde/jsonschema/json_schema_test.go
+++ b/schemaregistry/serde/jsonschema/json_schema_test.go
@@ -305,6 +305,7 @@ const (
         }
     }
 `
+<<<<<<< HEAD
 	allOfSchema = `
 {
     "type": "object",
@@ -385,6 +386,63 @@ const (
     }
 }
 `
+||||||| parent of 7e25407 (chore: pr reverts)
+=======
+	schemaWithFormats = `
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "email": {
+      "type": "string",
+      "format": "email"
+    },
+    "date": {
+      "type": "string",
+      "format": "date"
+    },
+    "uri": {
+      "type": "string",
+      "format": "uri"
+    }
+  }
+}
+`
+
+	schemaWithContent = `
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "encodedData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    },
+    "jsonData": {
+      "type": "string",
+      "contentMediaType": "application/json"
+    }
+  }
+}
+`
+
+	schemaCombined = `
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "email": {
+      "type": "string",
+      "format": "email"
+    },
+    "encodedData": {
+      "type": "string",
+      "contentEncoding": "base64"
+    }
+  }
+}
+`
+>>>>>>> 7e25407 (chore: pr reverts)
 )
 
 func testMessageFactory1(subject string, name string) (interface{}, error) {
@@ -670,61 +728,6 @@ func TestFailingJSONSchemaValidationWithSimple(t *testing.T) {
 func TestJSONSchemaSerializerValidationAssertFlags(t *testing.T) {
 	serde.MaybeFail = serde.InitFailFunc(t)
 
-	schemaWithFormats := `
-{
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "type": "object",
-  "properties": {
-    "email": {
-      "type": "string",
-      "format": "email"
-    },
-    "date": {
-      "type": "string",
-      "format": "date"
-    },
-    "uri": {
-      "type": "string",
-      "format": "uri"
-    }
-  }
-}
-`
-
-	schemaWithContent := `
-{
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "type": "object",
-  "properties": {
-    "encodedData": {
-      "type": "string",
-      "contentEncoding": "base64"
-    },
-    "jsonData": {
-      "type": "string",
-      "contentMediaType": "application/json"
-    }
-  }
-}
-`
-
-	schemaCombined := `
-{
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "type": "object",
-  "properties": {
-    "email": {
-      "type": "string",
-      "format": "email"
-    },
-    "encodedData": {
-      "type": "string",
-      "contentEncoding": "base64"
-    }
-  }
-}
-`
-
 	testCases := []struct {
 		name          string
 		assertFormat  bool
@@ -952,61 +955,6 @@ func TestJSONSchemaSerializerValidationAssertFlags(t *testing.T) {
 
 func TestJSONSchemaDeserializerValidationAssertFlags(t *testing.T) {
 	serde.MaybeFail = serde.InitFailFunc(t)
-
-	schemaWithFormats := `
-{
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "type": "object",
-  "properties": {
-    "email": {
-      "type": "string",
-      "format": "email"
-    },
-    "date": {
-      "type": "string",
-      "format": "date"
-    },
-    "uri": {
-      "type": "string",
-      "format": "uri"
-    }
-  }
-}
-`
-
-	schemaWithContent := `
-{
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "type": "object",
-  "properties": {
-    "encodedData": {
-      "type": "string",
-      "contentEncoding": "base64"
-    },
-    "jsonData": {
-      "type": "string",
-      "contentMediaType": "application/json"
-    }
-  }
-}
-`
-
-	schemaCombined := `
-{
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "type": "object",
-  "properties": {
-    "email": {
-      "type": "string",
-      "format": "email"
-    },
-    "encodedData": {
-      "type": "string",
-      "contentEncoding": "base64"
-    }
-  }
-}
-`
 
 	testCases := []struct {
 		name          string

--- a/schemaregistry/serde/jsonschema/json_schema_test.go
+++ b/schemaregistry/serde/jsonschema/json_schema_test.go
@@ -305,7 +305,6 @@ const (
         }
     }
 `
-<<<<<<< HEAD
 	allOfSchema = `
 {
     "type": "object",
@@ -386,8 +385,6 @@ const (
     }
 }
 `
-||||||| parent of 7e25407 (chore: pr reverts)
-=======
 	schemaWithFormats = `
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -442,7 +439,6 @@ const (
   }
 }
 `
->>>>>>> 7e25407 (chore: pr reverts)
 )
 
 func testMessageFactory1(subject string, name string) (interface{}, error) {


### PR DESCRIPTION
…ontent forjson schemas

<!--
Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What

- Adds config options for AssertFormat and AssertContent to the json schema serdes. These options are available for configuration in the underlying library, github.com/santhosh-tekuri/jsonschema/v5, but not set and are not configurable via the confluent calling code.

While the schema creator can define that format should be asserted on via the [format-assertion](https://github.com/orgs/json-schema-org/discussions/437#discussioncomment-6443928) vocabulary, it's still nice for client's to be able to configure this option as needed.

This PR just add those options to the JSON serde config and configures the json schema validator with these options set.
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
- [x] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [x] Did you add sufficient unit test and/or integration test coverage for this PR?
  - If not, please explain why it is not required

References
----------
JIRA: 
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

I have added table driven tests to the schemaregistry/serde/jsonschema/json_schema_test.go. The default behavior remains as it has been before with the enablement case covered by tests.

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow-ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
