### PR TITLE
Fix header check condition in message.go

### DIFF
--- a/kafka/message.go
+++ b/kafka/message.go
@@ -148,7 +148,7 @@ func (h *handle) setupMessageFromC(msg *Message, cmsg *C.rd_kafka_message_t) {
 	if cmsg.key != nil && h.msgFields.Key {
 		msg.Key = C.GoBytes(unsafe.Pointer(cmsg.key), C.int(cmsg.key_len))
 	}
-	if h.msgFields.Headers {
+	if h.msgFields.Headers && msg.Headers == nil {
 		var gMsg C.glue_msg_t
 		gMsg.msg = cmsg
 		gMsg.want_hdrs = C.int8_t(1)


### PR DESCRIPTION
What
Fix memory leak caused by double header extraction in confluent-kafka-go v2.8.0's message deserialization path.

In message.go, newMessageFromGlueMsg() calls setupHeadersFromGlueMsg() to extract headers via C.GoBytes, then immediately calls setupMessageFromC() which extracts the same headers again via C.GoBytes — overwriting the first set. This doubles C.GoBytes allocations per consumed message for every header, creating unnecessary GC pressure and a measurable memory increase (visible in pprof as _Cfunc_GoBytes being the top growing allocation).

Fix: Add msg.Headers == nil guard in setupMessageFromC so headers are only extracted if they weren't already set by the caller.

Before (per message with N headers):

C.GoBytes called: 2 (Value+Key) + 2×N (headers extracted twice)
C.malloc for tmphdrs: 2 times
First header set immediately becomes garbage
After (per message with N headers):

C.GoBytes called: 2 (Value+Key) + N (headers extracted once)
C.malloc for tmphdrs: 1 time
With ~5-6 headers per message, this eliminates ~40% of C.GoBytes allocations per consumed message.

Checklist
Contains customer facing changes? Including API/behavior changes
No. Internal vendor patch only. No API or behavior change.
Did you add sufficient unit test and/or integration test coverage for this PR?
No new tests required — this is a one-line guard on an existing code path in vendored code. newMessageFromC (producer delivery reports) still extracts headers as before since msg.Headers starts nil. newMessageFromGlueMsg (consumer fetch) now extracts headers once instead of twice — same end result, less allocation.
References
Root cause: _Cfunc_GoBytes (github.com/confluentinc/confluent-kafka-go/v2/kafka) shows the maximum memory increase after upgrading to confluent-kafka-go v2.8.0
File changed: vendor/github.com/confluentinc/confluent-kafka-go/v2/kafka/message.go line 151
Call path:
eventPoll → newMessageFromGlueMsg → setupHeadersFromGlueMsg (1st extraction) → setupMessageFromC → setupHeadersFromGlueMsg (2nd extraction, now skipped)
Test & Review
How to verify:

Deploy to a staging consumer
Take two pprof heap snapshots 10 minutes apart:
go tool pprof http://<host>:<port>/debug/pprof/heap
Compare _Cfunc_GoBytes allocation delta — should be ~40% lower than before this fix
Monitor RSS/heap over 1 hour — should show reduced growth rate
Safety of the change:

newMessageFromGlueMsg (consumer path): headers already extracted before setupMessageFromC → msg.Headers != nil → skip. Same result, less work.
newMessageFromC (producer delivery report path): msg = &Message{} → msg.Headers == nil → headers extracted as before.  No behavior change.
Open questions / Follow-ups
Consider upstreaming this fix to [confluentinc/confluent-kafka-go](https://github.com/confluentinc/confluent-kafka-go) — this is a bug in v2.8.0's msgFields refactor where setupMessageFromC was made self-contained but didn't account for the caller already extracting headers.