### PR TITLE
fix: prevent concurrent map panic in RestService header access

### DIFF
--- a/schemaregistry/internal/rest_service.go
+++ b/schemaregistry/internal/rest_service.go
@@ -569,8 +569,11 @@ func (rs *RestService) HandleHTTPRequest(url *url.URL, request *API) (*http.Resp
 	var req *http.Request
 	var resp *http.Response
 
-	err = SetAuthenticationHeaders(rs.authenticationHeaderProvider, &rs.headers)
-
+	// Clone base headers before setting auth to avoid concurrent map access
+	// when multiple goroutines call HandleHTTPRequest simultaneously.
+	// Each request gets its own header copy, so no synchronization is needed.
+	headers := rs.headers.Clone()
+	err = SetAuthenticationHeaders(rs.authenticationHeaderProvider, &headers)
 	if err != nil {
 		return nil, err
 	}
@@ -582,7 +585,7 @@ func (rs *RestService) HandleHTTPRequest(url *url.URL, request *API) (*http.Resp
 			endpoint.String(),
 			outbuf,
 		)
-		req.Header = rs.headers
+		req.Header = headers
 
 		resp, err = rs.Do(req)
 		if err != nil {

--- a/schemaregistry/internal/rest_service_test.go
+++ b/schemaregistry/internal/rest_service_test.go
@@ -441,3 +441,44 @@ func TestHandleRequest_SuccessResponse(t *testing.T) {
 		t.Errorf("Expected response name 'test-subject', got %v", response["name"])
 	}
 }
+
+func TestHandleRequest_ConcurrentAccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"id":1}`))
+	}))
+	defer server.Close()
+
+	config := &ClientConfig{
+		SchemaRegistryURL:          server.URL,
+		BearerAuthCredentialsSource: "STATIC_TOKEN",
+		BearerAuthToken:            "test-token",
+		BearerAuthLogicalCluster:   "lsrc-123",
+		BearerAuthIdentityPoolID:   "pool-id",
+	}
+
+	rs, err := NewRestService(config)
+	if err != nil {
+		t.Fatalf("Failed to create RestService: %v", err)
+	}
+
+	// Launch multiple goroutines to trigger concurrent map access.
+	// Before the fix, this would cause a fatal "concurrent map read and map write" panic.
+	const goroutines = 20
+	errs := make(chan error, goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			request := NewRequest("GET", "/subjects", nil)
+			var response interface{}
+			errs <- rs.HandleRequest(request, &response)
+		}()
+	}
+
+	for i := 0; i < goroutines; i++ {
+		if err := <-errs; err != nil {
+			t.Errorf("Concurrent request failed: %v", err)
+		}
+	}
+}

--- a/schemaregistry/internal/rest_service_test.go
+++ b/schemaregistry/internal/rest_service_test.go
@@ -23,6 +23,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -463,21 +464,34 @@ func TestHandleRequest_ConcurrentAccess(t *testing.T) {
 		t.Fatalf("Failed to create RestService: %v", err)
 	}
 
-	// Launch multiple goroutines to trigger concurrent map access.
-	// Before the fix, this would cause a fatal "concurrent map read and map write" panic.
+	// Use a start barrier so all goroutines begin at the same time,
+	// maximizing the chance of concurrent header map access.
 	const goroutines = 20
-	errs := make(chan error, goroutines)
+	const requestsPerGoroutine = 5
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	errs := make(chan error, goroutines*requestsPerGoroutine)
 
 	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
 		go func() {
-			request := NewRequest("GET", "/subjects", nil)
-			var response interface{}
-			errs <- rs.HandleRequest(request, &response)
+			defer wg.Done()
+			<-start
+			for j := 0; j < requestsPerGoroutine; j++ {
+				request := NewRequest("GET", "/subjects", nil)
+				var response interface{}
+				errs <- rs.HandleRequest(request, &response)
+			}
 		}()
 	}
 
-	for i := 0; i < goroutines; i++ {
-		if err := <-errs; err != nil {
+	// Release all goroutines simultaneously
+	close(start)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		if err != nil {
 			t.Errorf("Concurrent request failed: %v", err)
 		}
 	}


### PR DESCRIPTION
The RestService.HandleHTTPRequest method previously mutated a shared http.Header map via SetAuthenticationHeaders and then assigned it directly to each request. When multiple goroutines call Serialize() concurrently (typical for Kafka producers with multiple partition handlers), this causes a fatal 'concurrent map read and map write' panic that cannot be recovered.

Fix: clone the base headers per-request and apply authentication headers to the clone. Each goroutine operates on its own copy so no mutex or other synchronization is needed.

Changes:
- Clone rs.headers before calling SetAuthenticationHeaders, so the shared map is never mutated during request handling
- Assign the per-request clone to the outgoing http.Request
- Add a concurrency test with a start barrier (sync.WaitGroup) and multiple requests per goroutine to reliably reproduce the original panic under -race

Fixes #1548