### PR TITLE
feat(avrov3): expose UnionResolutionError + PartialUnionTypeResolution

### DIFF
--- a/schemaregistry/serde/avrov3/avro.go
+++ b/schemaregistry/serde/avrov3/avro.go
@@ -66,7 +66,10 @@ func NewSerializer(client schemaregistry.Client, serdeType serde.Type, conf *Ser
 		return nil, err
 	}
 	ps := &Serde{
-		api:               avro.Config{}.Freeze(),
+		api: avro.Config{
+			UnionResolutionError:       conf.UnionResolutionError,
+			PartialUnionTypeResolution: conf.PartialUnionTypeResolution,
+		}.Freeze(),
 		resolver:          avro.NewTypeResolver(),
 		schemaToTypeCache: schemaToTypeCache,
 	}
@@ -182,7 +185,10 @@ func NewDeserializer(client schemaregistry.Client, serdeType serde.Type, conf *D
 		return nil, err
 	}
 	ps := &Serde{
-		api:               avro.Config{}.Freeze(),
+		api: avro.Config{
+			UnionResolutionError:       conf.UnionResolutionError,
+			PartialUnionTypeResolution: conf.PartialUnionTypeResolution,
+		}.Freeze(),
 		resolver:          avro.NewTypeResolver(),
 		schemaToTypeCache: schemaToTypeCache,
 	}

--- a/schemaregistry/serde/avrov3/avro_test.go
+++ b/schemaregistry/serde/avrov3/avro_test.go
@@ -912,6 +912,95 @@ func TestAvroSerdeUnionWithReferences(t *testing.T) {
 	serde.MaybeFail("deserialization into", err, serde.Expect(newobj, obj))
 }
 
+// TestAvroSerdeUnionWithPartialResolution covers the case where a union has
+// some variants registered with the deserializer and others not. With the
+// PartialUnionTypeResolution flag enabled, registered variants decode into
+// their typed Go struct while unregistered variants fall back to
+// map[string]any. Without the flag, even a single unregistered variant in
+// the union forces every variant to decode as map[string]any.
+func TestAvroSerdeUnionWithPartialResolution(t *testing.T) {
+	serde.MaybeFail = serde.InitFailFunc(t)
+	var err error
+
+	conf := schemaregistry.NewConfig("mock://")
+	client, err := schemaregistry.NewClient(conf)
+	serde.MaybeFail("Schema Registry configuration", err)
+
+	// Serializer needs to know about both variants so it can encode either one.
+	serConfig := NewSerializerConfig()
+	serConfig.AutoRegisterSchemas = false
+	serConfig.UseLatestVersion = true
+	ser, err := NewSerializer(client, serde.ValueSerde, serConfig)
+	serde.MaybeFail("Serializer configuration", err)
+	_ = ser.RegisterTypeFromMessageFactory("DemoSchema", testMessageFactory)
+	_ = ser.RegisterTypeFromMessageFactory("ComplexSchema", testMessageFactory)
+
+	_, err = client.Register("demo-value", schemaregistry.SchemaInfo{
+		Schema: string(demoSchema), SchemaType: "AVRO",
+	}, false)
+	serde.MaybeFail("Schema registration", err)
+
+	_, err = client.Register("complex-value", schemaregistry.SchemaInfo{
+		Schema: string(complexSchema), SchemaType: "AVRO",
+	}, false)
+	serde.MaybeFail("Schema registration", err)
+
+	_, err = client.Register("topic1-value", schemaregistry.SchemaInfo{
+		Schema:     `[ "DemoSchema", "ComplexSchema" ]`,
+		SchemaType: "AVRO",
+		References: []schemaregistry.Reference{
+			{Name: "DemoSchema", Subject: "demo-value", Version: 1},
+			{Name: "ComplexSchema", Subject: "complex-value", Version: 1},
+		},
+	}, false)
+	serde.MaybeFail("Schema registration", err)
+
+	obj := DemoSchema{
+		IntField: 123, DoubleField: 45.67, StringField: "hi",
+		BoolField: true, BytesField: []byte{1, 2},
+	}
+	bytes, err := ser.Serialize("topic1", &obj)
+	serde.MaybeFail("serialization", err)
+
+	// Deserializer registers DemoSchema only — ComplexSchema is intentionally
+	// left unregistered to exercise the partial-resolution path.
+	deserConfig := NewDeserializerConfig()
+	deserConfig.PartialUnionTypeResolution = true
+	deser, err := NewDeserializer(client, serde.ValueSerde, deserConfig)
+	serde.MaybeFail("Deserializer configuration", err)
+	deser.Client = ser.Client
+	deser.MessageFactory = testMessageFactory
+	_ = deser.RegisterTypeFromMessageFactory("DemoSchema", testMessageFactory)
+
+	// With PartialUnionTypeResolution=true the registered variant should
+	// decode into the typed Go struct.
+	var got interface{}
+	err = deser.DeserializeInto("topic1", bytes, &got)
+	serde.MaybeFail("deserialization (registered variant, partial enabled)", err)
+	if _, ok := got.(DemoSchema); !ok {
+		t.Errorf("with PartialUnionTypeResolution=true the registered DemoSchema "+
+			"variant should decode into its typed struct, got %T", got)
+	}
+
+	// Sanity-check the default (PartialUnionTypeResolution == false) so a
+	// future change to the default doesn't silently make this test useless:
+	// the *registered* variant should fall back to map because the *other*
+	// variant in the union is unregistered.
+	deserDefault, err := NewDeserializer(client, serde.ValueSerde, NewDeserializerConfig())
+	serde.MaybeFail("Default deserializer configuration", err)
+	deserDefault.Client = ser.Client
+	deserDefault.MessageFactory = testMessageFactory
+	_ = deserDefault.RegisterTypeFromMessageFactory("DemoSchema", testMessageFactory)
+
+	var gotDefault interface{}
+	err = deserDefault.DeserializeInto("topic1", bytes, &gotDefault)
+	serde.MaybeFail("deserialization (default, no partial)", err)
+	if _, ok := gotDefault.(DemoSchema); ok {
+		t.Errorf("default config should fall back to map[string]any when any "+
+			"union variant is unregistered, got typed %T", gotDefault)
+	}
+}
+
 func TestAvroSchemaEvolution(t *testing.T) {
 	serde.MaybeFail = serde.InitFailFunc(t)
 	var err error

--- a/schemaregistry/serde/avrov3/config.go
+++ b/schemaregistry/serde/avrov3/config.go
@@ -23,6 +23,19 @@ import (
 // SerializerConfig is used to pass multiple configuration options to the serializers.
 type SerializerConfig struct {
 	serde.SerializerConfig
+
+	// UnionResolutionError, if true, causes encoding to return an error when
+	// a union type cannot be resolved. Forwarded to the underlying
+	// confluent-avro-go Config of the same name.
+	UnionResolutionError bool
+
+	// PartialUnionTypeResolution, if true, lets union type resolution succeed
+	// when only some of the union's variants have been registered: registered
+	// variants use their typed Go struct, unregistered variants fall back to
+	// map[string]any. Without this, a single unregistered variant in a union
+	// downgrades every variant to map[string]any. Forwarded to the underlying
+	// confluent-avro-go Config of the same name.
+	PartialUnionTypeResolution bool
 }
 
 // NewSerializerConfig returns a new configuration instance with sane defaults.
@@ -37,6 +50,19 @@ func NewSerializerConfig() *SerializerConfig {
 // DeserializerConfig is used to pass multiple configuration options to the deserializers.
 type DeserializerConfig struct {
 	serde.DeserializerConfig
+
+	// UnionResolutionError, if true, causes decoding to return an error when
+	// a union type cannot be resolved. Forwarded to the underlying
+	// confluent-avro-go Config of the same name.
+	UnionResolutionError bool
+
+	// PartialUnionTypeResolution, if true, lets union type resolution succeed
+	// when only some of the union's variants have been registered: registered
+	// variants decode into their typed Go struct, unregistered variants fall
+	// back to map[string]any. Without this, a single unregistered variant in a
+	// union downgrades every variant to map[string]any. Forwarded to the
+	// underlying confluent-avro-go Config of the same name.
+	PartialUnionTypeResolution bool
 }
 
 // NewDeserializerConfig returns a new configuration instance with sane defaults.


### PR DESCRIPTION

<!--
Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
The underlying confluent-avro-go Config supports two knobs for union type resolution:

  - UnionResolutionError: if true, return an error when a union variant can't be resolved (instead of silently falling back to map).
  - PartialUnionTypeResolution: if true, allow union resolution to succeed when only some variants are registered — registered variants decode into their typed Go struct while unregistered variants fall back to map[string]any.

avrov3 was constructing its internal `avro.API` with a bare `avro.Config{}.Freeze()`, hiding both knobs from users. This forced consumers of unions with many variants to either register every variant (verbose, fragile to upstream schema additions) or accept that the entire union would decode as map[string]any.

This change adds both fields to avrov3.SerializerConfig and avrov3.DeserializerConfig and forwards them into the avro.Config used by NewSerializer/NewDeserializer. The zero value preserves existing behaviour, so this is backwards-compatible.

Tested via a new TestAvroSerdeUnionWithPartialResolution that:
  - registers only one variant of a two-variant union,
  - sets PartialUnionTypeResolution=true on the deserializer config,
  - asserts the registered variant decodes into its typed struct,
  - asserts the default (flag off) still falls back to map for the same bytes, guarding against a silent change to the default.


Checklist
------------------
- [x] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [x] Did you add sufficient unit test and/or integration test coverage for this PR?
  - If not, please explain why it is not required

References
----------
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow-ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
