### PR TITLE
schemaregistry: remove kafka (CGo) dependency from REST client

### DIFF
--- a/schemaregistry/internal/rest_service.go
+++ b/schemaregistry/internal/rest_service.go
@@ -33,10 +33,11 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"runtime/debug" // Add Teuton
 	"strings"
 	"time"
 
-	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
+	// "github.com/confluentinc/confluent-kafka-go/v2/kafka" // remove Teuton
 	"github.com/confluentinc/confluent-kafka-go/v2/schemaregistry/rest"
 	"golang.org/x/oauth2/clientcredentials"
 )
@@ -84,15 +85,62 @@ const (
 
 	TargetSRClusterKey      = "Target-Sr-Cluster"
 	TargetIdentityPoolIDKey = "Confluent-Identity-Pool-Id"
+
+	modulePath = "github.com/confluentinc/confluent-kafka-go/v2"  // Add Teuton
+	unknownVersion = "devel" // Add Teuton
 )
 
 // getClientVersionHeaderValue returns the client version header value
 // in the format "go/{version}"
 // Note: currently the client version is tied to the librdkafka version
+/*
 func getClientVersionHeaderValue() string {
 	_, version := kafka.LibraryVersion()
 	return "go/" + version
 }
+*/
+
+
+/*
+getClientVersionHeaderValue returns the client version header value in the format "go/{version}".
+
+Historically this used kafka.LibraryVersion(), but that pulled the CGo-based
+kafka package into the schemaregistry client, forcing CGO_ENABLED=1 on all
+consumers and bloating binaries with librdkafka. We now resolve the version 
+from the build info instead, so schemaregistry stays pure Go.
+*/
+
+func getClientVersionHeaderValue() string {
+	return "go/" + clientVersion()
+}
+
+func clientVersion() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return unknownVersion
+	}
+	for _, dep := range info.Deps {
+		if dep.Path == modulePath {
+			return normalizeVersion(dep.Version)
+		}
+	}
+	if info.Main.Path == modulePath {
+		return normalizeVersion(info.Main.Version)
+	}
+	return unknownVersion
+}
+
+func normalizeVersion(version string) string {
+	switch version {
+	case "", "(devel)":
+		return unknownVersion
+	default:
+		return strings.TrimPrefix(version, "v")
+	}
+}
+
+
+
 
 // API represents a REST API request
 type API struct {


### PR DESCRIPTION
What
----
The Schema Registry client sends a `Confluent-Client-Version` header on every
request. Right now that value comes from `kafka.LibraryVersion()`, which imports
the `kafka` package. That package uses CGo/librdkafka, so it forces anyone
building `schemaregistry` to use `CGO_ENABLED=1` and have librdkafka installed —
even though the rest of `schemaregistry` is pure Go.

This PR resolves the client version from `runtime/debug.ReadBuildInfo()` instead.
The version is now read from the compiled module's build info, so the `kafka`
import is removed and the `schemaregistry` module builds without CGo.

Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes
  - Minor: the `Confluent-Client-Version` header now reports the
    confluent-kafka-go module version instead of the librdkafka version.
    Same `go/{version}` format, no API changes.
- [ ] Did you add sufficient unit test and/or integration test coverage for this PR?
  - Not required: behavior is covered by existing rest_service tests. The change
    only swaps the source of the version string.

References
----------
#1529 

Test & Review
------------
Verified locally:

    CGO_ENABLED=0 go build ./schemaregistry/...
    go test ./schemaregistry/...

The module now builds with CGo disabled (previously it failed), and the
`Confluent-Client-Version` header is still sent in the `go/{version}` format.

Open questions / Follow-ups
--------------------------
- The header now shows the confluent-kafka-go version, not the librdkafka
  version. Please confirm this is the intended value.