### PR TITLE
Fix use-after-free race between Close and in-flight C calls

### DIFF
--- a/kafka/adminapi.go
+++ b/kafka/adminapi.go
@@ -157,9 +157,9 @@ import "C"
 
 // AdminClient is derived from an existing Producer or Consumer
 type AdminClient struct {
-	handle    *handle
-	isDerived bool   // Derived from existing client handle
-	isClosed  uint32 // to check if Admin Client is closed or not.
+	handle        *handle
+	isDerived     bool      // Derived from existing client handle
+	isClosed      uint32    // to check if Admin Client is closed or not.
 	adminTermChan chan bool // For log channel termination
 }
 
@@ -1686,10 +1686,11 @@ func cToDeletedRecordResult(
 //
 // Requires broker version >= 0.10.0.
 func (a *AdminClient) ClusterID(ctx context.Context) (clusterID string, err error) {
-	err = a.verifyClient()
+	err = a.handle.rlock()
 	if err != nil {
 		return "", err
 	}
+	defer a.handle.runlock()
 
 	responseChan := make(chan *C.char, 1)
 
@@ -1723,10 +1724,11 @@ func (a *AdminClient) ClusterID(ctx context.Context) (clusterID string, err erro
 //
 // Requires broker version >= 0.10.0.
 func (a *AdminClient) ControllerID(ctx context.Context) (controllerID int32, err error) {
-	err = a.verifyClient()
+	err = a.handle.rlock()
 	if err != nil {
 		return -1, err
 	}
+	defer a.handle.runlock()
 
 	responseChan := make(chan int32, 1)
 
@@ -1757,10 +1759,11 @@ func (a *AdminClient) ControllerID(ctx context.Context) (controllerID int32, err
 //
 // Note: TopicSpecification is analogous to NewTopic in the Java Topic Admin API.
 func (a *AdminClient) CreateTopics(ctx context.Context, topics []TopicSpecification, options ...CreateTopicsAdminOption) (result []TopicResult, err error) {
-	err = a.verifyClient()
+	err = a.handle.rlock()
 	if err != nil {
 		return nil, err
 	}
+	defer a.handle.runlock()
 
 	cTopics := make([]*C.rd_kafka_NewTopic_t, len(topics))
 
@@ -1876,10 +1879,11 @@ func (a *AdminClient) CreateTopics(ctx context.Context, topics []TopicSpecificat
 //
 // Requires broker version >= 0.10.1.0
 func (a *AdminClient) DeleteTopics(ctx context.Context, topics []string, options ...DeleteTopicsAdminOption) (result []TopicResult, err error) {
-	err = a.verifyClient()
+	err = a.handle.rlock()
 	if err != nil {
 		return nil, err
 	}
+	defer a.handle.runlock()
 
 	cTopics := make([]*C.rd_kafka_DeleteTopic_t, len(topics))
 
@@ -1939,10 +1943,11 @@ func (a *AdminClient) DeleteTopics(ctx context.Context, topics []string, options
 
 // CreatePartitions creates additional partitions for topics.
 func (a *AdminClient) CreatePartitions(ctx context.Context, partitions []PartitionsSpecification, options ...CreatePartitionsAdminOption) (result []TopicResult, err error) {
-	err = a.verifyClient()
+	err = a.handle.rlock()
 	if err != nil {
 		return nil, err
 	}
+	defer a.handle.runlock()
 
 	cParts := make([]*C.rd_kafka_NewPartitions_t, len(partitions))
 
@@ -2035,10 +2040,11 @@ func (a *AdminClient) CreatePartitions(ctx context.Context, partitions []Partiti
 // resource requests must be sent to the broker specified in the resource.
 // Deprecated: AlterConfigs is deprecated in favour of IncrementalAlterConfigs
 func (a *AdminClient) AlterConfigs(ctx context.Context, resources []ConfigResource, options ...AlterConfigsAdminOption) (result []ConfigResourceResult, err error) {
-	err = a.verifyClient()
+	err = a.handle.rlock()
 	if err != nil {
 		return nil, err
 	}
+	defer a.handle.runlock()
 
 	cRes := make([]*C.rd_kafka_ConfigResource_t, len(resources))
 
@@ -2131,10 +2137,11 @@ func (a *AdminClient) AlterConfigs(ctx context.Context, resources []ConfigResour
 // resource of type ResourceBroker is allowed per call since these
 // resource requests must be sent to the broker specified in the resource.
 func (a *AdminClient) IncrementalAlterConfigs(ctx context.Context, resources []ConfigResource, options ...AlterConfigsAdminOption) (result []ConfigResourceResult, err error) {
-	err = a.verifyClient()
+	err = a.handle.rlock()
 	if err != nil {
 		return nil, err
 	}
+	defer a.handle.runlock()
 
 	cRes := make([]*C.rd_kafka_ConfigResource_t, len(resources))
 
@@ -2234,10 +2241,11 @@ func (a *AdminClient) IncrementalAlterConfigs(ctx context.Context, resources []C
 // since these resource requests must be sent to the broker specified
 // in the resource.
 func (a *AdminClient) DescribeConfigs(ctx context.Context, resources []ConfigResource, options ...DescribeConfigsAdminOption) (result []ConfigResourceResult, err error) {
-	err = a.verifyClient()
+	err = a.handle.rlock()
 	if err != nil {
 		return nil, err
 	}
+	defer a.handle.runlock()
 
 	cRes := make([]*C.rd_kafka_ConfigResource_t, len(resources))
 
@@ -2302,10 +2310,11 @@ func (a *AdminClient) DescribeConfigs(ctx context.Context, resources []ConfigRes
 // else information about all topics is returned.
 // GetMetadata is equivalent to listTopics, describeTopics and describeCluster in the Java API.
 func (a *AdminClient) GetMetadata(topic *string, allTopics bool, timeoutMs int) (*Metadata, error) {
-	err := a.verifyClient()
+	err := a.handle.rlock()
 	if err != nil {
 		return nil, err
 	}
+	defer a.handle.runlock()
 	return getMetadata(a, topic, allTopics, timeoutMs)
 }
 
@@ -2330,10 +2339,11 @@ func (a *AdminClient) gethandle() *handle {
 // 3) SASL/OAUTHBEARER is supported but is not configured as the client's
 // authentication mechanism.
 func (a *AdminClient) SetOAuthBearerToken(oauthBearerToken OAuthBearerToken) error {
-	err := a.verifyClient()
+	err := a.handle.rlock()
 	if err != nil {
 		return err
 	}
+	defer a.handle.runlock()
 	return a.handle.setOAuthBearerToken(oauthBearerToken)
 }
 
@@ -2345,10 +2355,11 @@ func (a *AdminClient) SetOAuthBearerToken(oauthBearerToken OAuthBearerToken) err
 // 2) SASL/OAUTHBEARER is supported but is not configured as the client's
 // authentication mechanism.
 func (a *AdminClient) SetOAuthBearerTokenFailure(errstr string) error {
-	err := a.verifyClient()
+	err := a.handle.rlock()
 	if err != nil {
 		return err
 	}
+	defer a.handle.runlock()
 	return a.handle.setOAuthBearerTokenFailure(errstr)
 }
 
@@ -2512,10 +2523,11 @@ func (a *AdminClient) cToDeleteACLsResults(cDeleteACLsResResponse **C.rd_kafka_D
 // Returns a slice of CreateACLResult with a ErrNoError ErrorCode when the operation was successful
 // plus an error that is not nil for client level errors
 func (a *AdminClient) CreateACLs(ctx context.Context, aclBindings ACLBindings, options ...CreateACLsAdminOption) (result []CreateACLResult, err error) {
-	err = a.verifyClient()
+	err = a.handle.rlock()
 	if err != nil {
 		return nil, err
 	}
+	defer a.handle.runlock()
 
 	if aclBindings == nil {
 		return nil, newErrorFromString(ErrInvalidArg,
@@ -2592,10 +2604,11 @@ func (a *AdminClient) CreateACLs(ctx context.Context, aclBindings ACLBindings, o
 // Returns a slice of ACLBindings when the operation was successful
 // plus an error that is not `nil` for client level errors
 func (a *AdminClient) DescribeACLs(ctx context.Context, aclBindingFilter ACLBindingFilter, options ...DescribeACLsAdminOption) (result *DescribeACLsResult, err error) {
-	err = a.verifyClient()
+	err = a.handle.rlock()
 	if err != nil {
 		return nil, err
 	}
+	defer a.handle.runlock()
 
 	cErrstrSize := C.size_t(512)
 	cErrstr := (*C.char)(C.malloc(cErrstrSize))
@@ -2652,10 +2665,11 @@ func (a *AdminClient) DescribeACLs(ctx context.Context, aclBindingFilter ACLBind
 // Returns a slice of ACLBinding for each filter when the operation was successful
 // plus an error that is not `nil` for client level errors
 func (a *AdminClient) DeleteACLs(ctx context.Context, aclBindingFilters ACLBindingFilters, options ...DeleteACLsAdminOption) (result []DeleteACLsResult, err error) {
-	err = a.verifyClient()
+	err = a.handle.rlock()
 	if err != nil {
 		return nil, err
 	}
+	defer a.handle.runlock()
 
 	if aclBindingFilters == nil {
 		return nil, newErrorFromString(ErrInvalidArg,
@@ -2723,10 +2737,11 @@ func (a *AdminClient) DeleteACLs(ctx context.Context, aclBindingFilters ACLBindi
 // were established with the old credentials.
 // This method applies only to the SASL PLAIN and SCRAM mechanisms.
 func (a *AdminClient) SetSaslCredentials(username, password string) error {
-	err := a.verifyClient()
+	err := a.handle.rlock()
 	if err != nil {
 		return err
 	}
+	defer a.handle.runlock()
 
 	return setSaslCredentials(a.handle.rk, username, password)
 }
@@ -2749,9 +2764,16 @@ func (a *AdminClient) Close() {
 	// Wait for the log polling goroutine to terminate before cleanup
 	a.handle.waitGroup.Wait()
 
+	// Prevent any in-flight C call on another goroutine from racing with the
+	// handle destruction, and block new ones.
+	a.handle.pollLock.Lock()
+	defer a.handle.pollLock.Unlock()
+
 	a.handle.cleanup()
 
 	C.rd_kafka_destroy(a.handle.rk)
+	// Signal to any waiting rlock() callers that the handle is gone.
+	a.handle.rk = nil
 }
 
 // ListConsumerGroups lists the consumer groups available in the cluster.
@@ -2770,10 +2792,11 @@ func (a *AdminClient) ListConsumerGroups(
 	options ...ListConsumerGroupsAdminOption) (result ListConsumerGroupsResult, err error) {
 
 	result = ListConsumerGroupsResult{}
-	err = a.verifyClient()
+	err = a.handle.rlock()
 	if err != nil {
 		return result, err
 	}
+	defer a.handle.runlock()
 
 	// Convert Go AdminOptions (if any) to C AdminOptions.
 	genericOptions := make([]AdminOption, len(options))
@@ -2841,10 +2864,11 @@ func (a *AdminClient) DescribeConsumerGroups(
 	options ...DescribeConsumerGroupsAdminOption) (result DescribeConsumerGroupsResult, err error) {
 
 	describeResult := DescribeConsumerGroupsResult{}
-	err = a.verifyClient()
+	err = a.handle.rlock()
 	if err != nil {
 		return result, err
 	}
+	defer a.handle.runlock()
 
 	// Convert group names into char** required by the implementation.
 	cGroupNameList := make([]*C.char, len(groups))
@@ -2923,10 +2947,11 @@ func (a *AdminClient) DescribeTopics(
 	options ...DescribeTopicsAdminOption) (result DescribeTopicsResult, err error) {
 
 	describeResult := DescribeTopicsResult{}
-	err = a.verifyClient()
+	err = a.handle.rlock()
 	if err != nil {
 		return result, err
 	}
+	defer a.handle.runlock()
 
 	// Convert topic names into char**.
 	cTopicNameList := make([]*C.char, len(topics.topicNames))
@@ -3007,10 +3032,11 @@ func (a *AdminClient) DescribeTopics(
 func (a *AdminClient) DescribeCluster(
 	ctx context.Context,
 	options ...DescribeClusterAdminOption) (result DescribeClusterResult, err error) {
-	err = a.verifyClient()
+	err = a.handle.rlock()
 	if err != nil {
 		return result, err
 	}
+	defer a.handle.runlock()
 	clusterDesc := DescribeClusterResult{}
 
 	// Convert Go AdminOptions (if any) to C AdminOptions.
@@ -3066,10 +3092,11 @@ func (a *AdminClient) DeleteConsumerGroups(
 	groups []string, options ...DeleteConsumerGroupsAdminOption) (result DeleteConsumerGroupsResult, err error) {
 	cGroups := make([]*C.rd_kafka_DeleteGroup_t, len(groups))
 	deleteResult := DeleteConsumerGroupsResult{}
-	err = a.verifyClient()
+	err = a.handle.rlock()
 	if err != nil {
 		return deleteResult, err
 	}
+	defer a.handle.runlock()
 
 	// Convert Go DeleteGroups to C DeleteGroups
 	for i, group := range groups {
@@ -3145,10 +3172,11 @@ func (a *AdminClient) DeleteConsumerGroups(
 func (a *AdminClient) ListConsumerGroupOffsets(
 	ctx context.Context, groupsPartitions []ConsumerGroupTopicPartitions,
 	options ...ListConsumerGroupOffsetsAdminOption) (lcgor ListConsumerGroupOffsetsResult, err error) {
-	err = a.verifyClient()
+	err = a.handle.rlock()
 	if err != nil {
 		return lcgor, err
 	}
+	defer a.handle.runlock()
 
 	lcgor.ConsumerGroupsTopicPartitions = nil
 
@@ -3246,10 +3274,11 @@ func (a *AdminClient) ListConsumerGroupOffsets(
 func (a *AdminClient) AlterConsumerGroupOffsets(
 	ctx context.Context, groupsPartitions []ConsumerGroupTopicPartitions,
 	options ...AlterConsumerGroupOffsetsAdminOption) (acgor AlterConsumerGroupOffsetsResult, err error) {
-	err = a.verifyClient()
+	err = a.handle.rlock()
 	if err != nil {
 		return acgor, err
 	}
+	defer a.handle.runlock()
 
 	acgor.ConsumerGroupsTopicPartitions = nil
 
@@ -3339,10 +3368,11 @@ func (a *AdminClient) DescribeUserScramCredentials(
 	result = DescribeUserScramCredentialsResult{
 		Descriptions: make(map[string]UserScramCredentialsDescription),
 	}
-	err = a.verifyClient()
+	err = a.handle.rlock()
 	if err != nil {
 		return result, err
 	}
+	defer a.handle.runlock()
 
 	// Convert user names into char** required by the implementation.
 	cUserList := make([]*C.char, len(users))
@@ -3485,10 +3515,11 @@ func (a *AdminClient) AlterUserScramCredentials(
 	result = AlterUserScramCredentialsResult{
 		Errors: make(map[string]Error),
 	}
-	err = a.verifyClient()
+	err = a.handle.rlock()
 	if err != nil {
 		return result, err
 	}
+	defer a.handle.runlock()
 
 	// Convert user names into char** required by the implementation.
 	cAlterationList := make([]*C.rd_kafka_UserScramCredentialAlteration_t, len(upsertions)+len(deletions))
@@ -3595,10 +3626,11 @@ func (a *AdminClient) AlterUserScramCredentials(
 func (a *AdminClient) DeleteRecords(ctx context.Context,
 	recordsToDelete []TopicPartition,
 	options ...DeleteRecordsAdminOption) (result DeleteRecordsResults, err error) {
-	err = a.verifyClient()
+	err = a.handle.rlock()
 	if err != nil {
 		return result, err
 	}
+	defer a.handle.runlock()
 
 	if len(recordsToDelete) == 0 {
 		return result, newErrorFromString(ErrInvalidArg, "No records to delete")
@@ -3672,10 +3704,11 @@ func (a *AdminClient) DeleteRecords(ctx context.Context,
 // Additionally, an error that is not nil for client-level errors is returned.
 func (a *AdminClient) ElectLeaders(ctx context.Context, electLeaderRequest ElectLeadersRequest, options ...ElectLeadersAdminOption) (result ElectLeadersResult, err error) {
 
-	err = a.verifyClient()
+	err = a.handle.rlock()
 	if err != nil {
 		return result, err
 	}
+	defer a.handle.runlock()
 
 	var cTopicPartitions *C.rd_kafka_topic_partition_list_t
 	if electLeaderRequest.partitions != nil {

--- a/kafka/adminapi.go
+++ b/kafka/adminapi.go
@@ -168,6 +168,8 @@ func (a *AdminClient) IsClosed() bool {
 	return atomic.LoadUint32(&a.isClosed) == 1
 }
 
+// verifyClient is required by the Handle interface. AdminClient guards its
+// operations via IsClosed()/isClosed rather than the handle read lock.
 func (a *AdminClient) verifyClient() error {
 	if a.IsClosed() {
 		return getOperationNotAllowedErrorForClosedClient()

--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -51,6 +51,12 @@ type Consumer struct {
 
 	isClosed  uint32
 	isClosing uint32
+	// tearingDown is set right before Close() acquires the pollLock write
+	// lock, to signal blocking in-flight readers (e.g. commit()) to release
+	// the read lock so Close() is not pinned indefinitely. Unlike isClosing,
+	// it is set only after Close()'s revoke handshake has completed, so
+	// commits issued from the revoke rebalance callback still work.
+	tearingDown uint32
 }
 
 // IsClosed returns boolean representing if client is closed or not
@@ -232,6 +238,15 @@ func (c *Consumer) GetRebalanceProtocol() string {
 		return ""
 	}
 	defer c.handle.runlock()
+	return c.getRebalanceProtocol()
+}
+
+// getRebalanceProtocol is the unlocked variant of GetRebalanceProtocol. The
+// caller must already hold c.handle.pollLock (via rlock()). It exists so that
+// code reachable from inside eventPoll's rebalance dispatch (which already
+// holds the read lock) can query the protocol without re-locking, since the
+// non-reentrant RWMutex would otherwise deadlock against a pending Close().
+func (c *Consumer) getRebalanceProtocol() string {
 	cStr := C.rd_kafka_rebalance_protocol(c.handle.rk)
 	if cStr == nil {
 		return ""
@@ -279,10 +294,20 @@ func (c *Consumer) commit(offsets []TopicPartition) (committedOffsets []TopicPar
 		return nil, newError(cErr)
 	}
 
-	rkev := C.rd_kafka_queue_poll(rkqu, C.int(-1))
-	if rkev == nil {
-		// shouldn't happen
-		return nil, newError(C.RD_KAFKA_RESP_ERR__DESTROY)
+	// Poll for the commit result in bounded slices instead of a single
+	// blocking -1 poll. A -1 poll here would hold the read lock for the whole
+	// (potentially unbounded) round-trip, and a concurrent Close() waiting for
+	// the write lock would be stuck behind it. Bail out early if the consumer
+	// has started closing.
+	var rkev *C.rd_kafka_event_t
+	for {
+		if atomic.LoadUint32(&c.tearingDown) == 1 {
+			return nil, getOperationNotAllowedErrorForClosedClient()
+		}
+		rkev = C.rd_kafka_queue_poll(rkqu, C.int(100))
+		if rkev != nil {
+			break
+		}
 	}
 	defer C.rd_kafka_event_destroy(rkev)
 
@@ -575,8 +600,18 @@ func (c *Consumer) Close() (err error) {
 		c.Poll(100)
 	}
 
-	// Wait for any in-flight eventPoll to finish before tearing down the
-	// C handle and queue, then prevent new polls from starting.
+	// Prevent new polls and wait for any in-flight eventPoll to finish before
+	// tearing down the C handle and queue.
+	//
+	// A blocking in-flight call can otherwise hold the read lock for a long
+	// time: ReadMessage(-1) blocks inside the queue poll (unblocked by the
+	// queue yield below), and commit() blocks on its own result queue
+	// (unblocked cooperatively via the tearingDown flag). Both keep this
+	// Close() bounded rather than waiting indefinitely.
+	atomic.StoreUint32(&c.tearingDown, 1)
+	if c.handle.rkq != nil {
+		C.rd_kafka_queue_yield(c.handle.rkq)
+	}
 	c.handle.pollLock.Lock()
 	defer c.handle.pollLock.Unlock()
 
@@ -1068,6 +1103,22 @@ func (c *Consumer) handleRebalanceEvent(channel chan Event, rkev *C.rd_kafka_eve
 
 	}
 
+	// Extract everything we still need from rkev (which is owned by the
+	// handle) into independent memory *now*, while eventPoll still holds the
+	// pollLock read lock, then destroy rkev. This lets us release the lock
+	// around the application callback (which may re-enter locked Consumer
+	// methods and would otherwise deadlock against a concurrent Close on the
+	// non-reentrant RWMutex) without touching any handle-owned memory
+	// afterwards: a concurrent Close may destroy the handle during the
+	// callback window. eventPoll relinquished ownership of rkev to us (it
+	// cleared prevRkev), so we destroy it here.
+	assignPartitions := C.rd_kafka_event_error(rkev) == C.RD_KAFKA_RESP_ERR__ASSIGN_PARTITIONS
+	cParts := C.rd_kafka_topic_partition_list_copy(C.rd_kafka_event_topic_partition_list(rkev))
+	if cParts != nil {
+		defer C.rd_kafka_topic_partition_list_destroy(cParts)
+	}
+	C.rd_kafka_event_destroy(rkev)
+
 	if channel != nil && c.appRebalanceEnable && c.rebalanceCb == nil {
 		// Channel-based consumer with rebalancing enabled,
 		// return the rebalance event and rely on the application
@@ -1081,39 +1132,48 @@ func (c *Consumer) handleRebalanceEvent(channel chan Event, rkev *C.rd_kafka_eve
 		// application called *Assign() / *Unassign().
 		c.appReassigned = false
 
+		// Release the read lock around the callback (foreign code); ev and
+		// cParts are independent of rkev/the handle, so nothing here relies
+		// on the handle staying alive.
+		c.handle.pollLock.RUnlock()
 		c.rebalanceCb(c, ev)
+		c.handle.pollLock.RLock()
 
 		if c.appReassigned {
 			// Rebalance event handled by application.
+			return nil
+		}
+
+		if c.handle.rk == nil {
+			// Handle was closed by a concurrent Close() while the callback
+			// ran; do not touch the C handle.
 			return nil
 		}
 	}
 
 	// Either there was no rebalance callback, or the application
 	// did not call *Assign / *Unassign, so we need to do it.
-
-	isCooperative := c.GetRebalanceProtocol() == "COOPERATIVE"
+	//
+	// The pollLock read lock is held here (by eventPoll), which keeps the C
+	// handle alive during these calls. Use the unlocked getRebalanceProtocol
+	// variant rather than the public one, which would re-lock the
+	// non-reentrant RWMutex and deadlock against a pending Close().
+	isCooperative := c.getRebalanceProtocol() == "COOPERATIVE"
 	var cError *C.rd_kafka_error_t
 	var cErr C.rd_kafka_resp_err_t
 
-	if C.rd_kafka_event_error(rkev) == C.RD_KAFKA_RESP_ERR__ASSIGN_PARTITIONS {
+	if assignPartitions {
 		// Assign partitions
 		if isCooperative {
-			cError = C.rd_kafka_incremental_assign(
-				c.handle.rk,
-				C.rd_kafka_event_topic_partition_list(rkev))
+			cError = C.rd_kafka_incremental_assign(c.handle.rk, cParts)
 		} else {
-			cErr = C.rd_kafka_assign(
-				c.handle.rk,
-				C.rd_kafka_event_topic_partition_list(rkev))
+			cErr = C.rd_kafka_assign(c.handle.rk, cParts)
 		}
 	} else {
 		// Revoke partitions
 
 		if isCooperative {
-			cError = C.rd_kafka_incremental_unassign(
-				c.handle.rk,
-				C.rd_kafka_event_topic_partition_list(rkev))
+			cError = C.rd_kafka_incremental_unassign(c.handle.rk, cParts)
 		} else {
 			cErr = C.rd_kafka_assign(c.handle.rk, nil)
 		}
@@ -1121,10 +1181,20 @@ func (c *Consumer) handleRebalanceEvent(channel chan Event, rkev *C.rd_kafka_eve
 
 	// If the *assign() call returned error, forward it to the
 	// the consumer's Events() channel for visibility.
-	if cError != nil {
-		c.events <- newErrorFromCErrorDestroy(cError)
-	} else if cErr != 0 {
-		c.events <- newError(cErr)
+	//
+	// c.events is nil when the events channel is not enabled; a send on a nil
+	// channel would block forever while holding the read lock and wedge a
+	// concurrent Close(), so only forward when the channel exists.
+	if c.events != nil {
+		if cError != nil {
+			c.events <- newErrorFromCErrorDestroy(cError)
+		} else if cErr != 0 {
+			c.events <- newError(cErr)
+		}
+	} else {
+		if cError != nil {
+			C.rd_kafka_error_destroy(cError)
+		}
 	}
 
 	return nil
@@ -1137,9 +1207,9 @@ func (c *Consumer) handleRebalanceEvent(channel chan Event, rkev *C.rd_kafka_eve
 // existing broker connections that were established with the old credentials.
 // This method applies only to the SASL PLAIN and SCRAM mechanisms.
 func (c *Consumer) SetSaslCredentials(username, password string) error {
-	err := c.verifyClient()
-	if err != nil {
+	if err := c.handle.rlock(); err != nil {
 		return err
 	}
+	defer c.handle.runlock()
 	return setSaslCredentials(c.handle.rk, username, password)
 }

--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -88,10 +88,11 @@ func (c *Consumer) Subscribe(topic string, rebalanceCb RebalanceCb) error {
 // SubscribeTopics subscribes to the provided list of topics.
 // This replaces the current subscription.
 func (c *Consumer) SubscribeTopics(topics []string, rebalanceCb RebalanceCb) (err error) {
-	err = c.verifyClient()
+	err = c.handle.rlock()
 	if err != nil {
 		return err
 	}
+	defer c.handle.runlock()
 	ctopics := C.rd_kafka_topic_partition_list_new(C.int(len(topics)))
 	defer C.rd_kafka_topic_partition_list_destroy(ctopics)
 
@@ -113,10 +114,11 @@ func (c *Consumer) SubscribeTopics(topics []string, rebalanceCb RebalanceCb) (er
 
 // Unsubscribe from the current subscription, if any.
 func (c *Consumer) Unsubscribe() (err error) {
-	err = c.verifyClient()
+	err = c.handle.rlock()
 	if err != nil {
 		return err
 	}
+	defer c.handle.runlock()
 	C.rd_kafka_unsubscribe(c.handle.rk)
 	return nil
 }
@@ -131,10 +133,11 @@ func (c *Consumer) Unsubscribe() (err error) {
 //
 // This replaces the current assignment.
 func (c *Consumer) Assign(partitions []TopicPartition) (err error) {
-	err = c.verifyClient()
+	err = c.handle.rlock()
 	if err != nil {
 		return err
 	}
+	defer c.handle.runlock()
 	c.appReassigned = true
 
 	cparts := newCPartsFromTopicPartitions(partitions)
@@ -150,10 +153,11 @@ func (c *Consumer) Assign(partitions []TopicPartition) (err error) {
 
 // Unassign the current set of partitions to consume.
 func (c *Consumer) Unassign() (err error) {
-	err = c.verifyClient()
+	err = c.handle.rlock()
 	if err != nil {
 		return err
 	}
+	defer c.handle.runlock()
 	c.appReassigned = true
 
 	e := C.rd_kafka_assign(c.handle.rk, nil)
@@ -175,10 +179,11 @@ func (c *Consumer) Unassign() (err error) {
 //
 // The new partitions must not be part of the current assignment.
 func (c *Consumer) IncrementalAssign(partitions []TopicPartition) (err error) {
-	err = c.verifyClient()
+	err = c.handle.rlock()
 	if err != nil {
 		return err
 	}
+	defer c.handle.runlock()
 	c.appReassigned = true
 
 	cparts := newCPartsFromTopicPartitions(partitions)
@@ -199,10 +204,11 @@ func (c *Consumer) IncrementalAssign(partitions []TopicPartition) (err error) {
 //
 // The removed partitions must be part of the current assignment.
 func (c *Consumer) IncrementalUnassign(partitions []TopicPartition) (err error) {
-	err = c.verifyClient()
+	err = c.handle.rlock()
 	if err != nil {
 		return err
 	}
+	defer c.handle.runlock()
 	c.appReassigned = true
 
 	cparts := newCPartsFromTopicPartitions(partitions)
@@ -222,6 +228,10 @@ func (c *Consumer) IncrementalUnassign(partitions []TopicPartition) (err error) 
 // is returned.
 // Should typically only be called during rebalancing.
 func (c *Consumer) GetRebalanceProtocol() string {
+	if err := c.handle.rlock(); err != nil {
+		return ""
+	}
+	defer c.handle.runlock()
 	cStr := C.rd_kafka_rebalance_protocol(c.handle.rk)
 	if cStr == nil {
 		return ""
@@ -236,6 +246,10 @@ func (c *Consumer) GetRebalanceProtocol() string {
 // Partitions that have been lost may already be owned by other members in the
 // group and therefore commiting offsets, for example, may fail.
 func (c *Consumer) AssignmentLost() bool {
+	if err := c.handle.rlock(); err != nil {
+		return false
+	}
+	defer c.handle.runlock()
 	return cint2bool(C.rd_kafka_assignment_lost(c.handle.rk))
 }
 
@@ -244,6 +258,11 @@ func (c *Consumer) AssignmentLost() bool {
 // This is a blocking call, caller will need to wrap in go-routine to
 // get async or throw-away behaviour.
 func (c *Consumer) commit(offsets []TopicPartition) (committedOffsets []TopicPartition, err error) {
+	if err = c.handle.rlock(); err != nil {
+		return nil, err
+	}
+	defer c.handle.runlock()
+
 	var rkqu *C.rd_kafka_queue_t
 
 	rkqu = C.rd_kafka_queue_new(c.handle.rk)
@@ -333,10 +352,11 @@ func (c *Consumer) CommitOffsets(offsets []TopicPartition) ([]TopicPartition, er
 // an error and a list of offsets is returned. Each offset can be checked for
 // specific errors via its `.Error` member.
 func (c *Consumer) StoreOffsets(offsets []TopicPartition) (storedOffsets []TopicPartition, err error) {
-	err = c.verifyClient()
+	err = c.handle.rlock()
 	if err != nil {
 		return nil, err
 	}
+	defer c.handle.runlock()
 	coffsets := newCPartsFromTopicPartitions(offsets)
 	defer C.rd_kafka_topic_partition_list_destroy(coffsets)
 
@@ -392,10 +412,11 @@ func (c *Consumer) StoreMessage(m *Message) (storedOffsets []TopicPartition, err
 // Returns an error on failure or nil otherwise.
 // Deprecated: Seek is deprecated in favour of SeekPartitions().
 func (c *Consumer) Seek(partition TopicPartition, ignoredTimeoutMs int) error {
-	err := c.verifyClient()
+	err := c.handle.rlock()
 	if err != nil {
 		return err
 	}
+	defer c.handle.runlock()
 	rkt := c.handle.getRkt(*partition.Topic)
 	cErr := C.rd_kafka_seek(rkt,
 		C.int32_t(partition.Partition),
@@ -421,10 +442,11 @@ func (c *Consumer) Seek(partition TopicPartition, ignoredTimeoutMs int) error {
 // Returns an error on failure or nil otherwise. Individual partition errors
 // should be checked in the per-partition .Error field.
 func (c *Consumer) SeekPartitions(partitions []TopicPartition) ([]TopicPartition, error) {
-	err := c.verifyClient()
+	err := c.handle.rlock()
 	if err != nil {
 		return nil, err
 	}
+	defer c.handle.runlock()
 
 	cPartitions := newCPartsFromTopicPartitions(partitions)
 	defer C.rd_kafka_topic_partition_list_destroy(cPartitions)
@@ -553,6 +575,11 @@ func (c *Consumer) Close() (err error) {
 		c.Poll(100)
 	}
 
+	// Wait for any in-flight eventPoll to finish before tearing down the
+	// C handle and queue, then prevent new polls from starting.
+	c.handle.pollLock.Lock()
+	defer c.handle.pollLock.Unlock()
+
 	// After this point, no more consumer methods may be called.
 	atomic.StoreUint32(&c.isClosed, 1)
 
@@ -563,6 +590,8 @@ func (c *Consumer) Close() (err error) {
 	c.handle.cleanup()
 
 	C.rd_kafka_destroy(c.handle.rk)
+	// Signal to any waiting rlock() callers that the handle is gone.
+	c.handle.rk = nil
 
 	return nil
 }
@@ -699,19 +728,21 @@ func consumerReader(c *Consumer, termChan chan bool) {
 // else information about all topics is returned.
 // GetMetadata is equivalent to listTopics, describeTopics and describeCluster in the Java API.
 func (c *Consumer) GetMetadata(topic *string, allTopics bool, timeoutMs int) (*Metadata, error) {
-	err := c.verifyClient()
+	err := c.handle.rlock()
 	if err != nil {
 		return nil, err
 	}
+	defer c.handle.runlock()
 	return getMetadata(c, topic, allTopics, timeoutMs)
 }
 
 // QueryWatermarkOffsets queries the broker for the low and high offsets for the given topic and partition.
 func (c *Consumer) QueryWatermarkOffsets(topic string, partition int32, timeoutMs int) (low, high int64, err error) {
-	err = c.verifyClient()
+	err = c.handle.rlock()
 	if err != nil {
 		return -1, -1, err
 	}
+	defer c.handle.runlock()
 	return queryWatermarkOffsets(c, topic, partition, timeoutMs)
 }
 
@@ -720,10 +751,11 @@ func (c *Consumer) QueryWatermarkOffsets(topic string, partition int32, timeoutM
 // The low offset is populated every statistics.interval.ms if that value is set.
 // OffsetInvalid will be returned if there is no cached offset for either value.
 func (c *Consumer) GetWatermarkOffsets(topic string, partition int32) (low, high int64, err error) {
-	err = c.verifyClient()
+	err = c.handle.rlock()
 	if err != nil {
 		return -1, -1, err
 	}
+	defer c.handle.runlock()
 	return getWatermarkOffsets(c, topic, partition)
 }
 
@@ -743,19 +775,21 @@ func (c *Consumer) GetWatermarkOffsets(topic string, partition int32) (low, high
 // Duplicate Topic+Partitions are not supported.
 // Per-partition errors may be returned in the `.Error` field.
 func (c *Consumer) OffsetsForTimes(times []TopicPartition, timeoutMs int) (offsets []TopicPartition, err error) {
-	err = c.verifyClient()
+	err = c.handle.rlock()
 	if err != nil {
 		return nil, err
 	}
+	defer c.handle.runlock()
 	return offsetsForTimes(c, times, timeoutMs)
 }
 
 // Subscription returns the current subscription as set by Subscribe()
 func (c *Consumer) Subscription() (topics []string, err error) {
-	err = c.verifyClient()
+	err = c.handle.rlock()
 	if err != nil {
 		return nil, err
 	}
+	defer c.handle.runlock()
 	var cTopics *C.rd_kafka_topic_partition_list_t
 
 	cErr := C.rd_kafka_subscription(c.handle.rk, &cTopics)
@@ -777,10 +811,11 @@ func (c *Consumer) Subscription() (topics []string, err error) {
 
 // Assignment returns the current partition assignments
 func (c *Consumer) Assignment() (partitions []TopicPartition, err error) {
-	err = c.verifyClient()
+	err = c.handle.rlock()
 	if err != nil {
 		return nil, err
 	}
+	defer c.handle.runlock()
 	var cParts *C.rd_kafka_topic_partition_list_t
 
 	cErr := C.rd_kafka_assignment(c.handle.rk, &cParts)
@@ -796,10 +831,11 @@ func (c *Consumer) Assignment() (partitions []TopicPartition, err error) {
 
 // Committed retrieves committed offsets for the given set of partitions
 func (c *Consumer) Committed(partitions []TopicPartition, timeoutMs int) (offsets []TopicPartition, err error) {
-	err = c.verifyClient()
+	err = c.handle.rlock()
 	if err != nil {
 		return nil, err
 	}
+	defer c.handle.runlock()
 	cparts := newCPartsFromTopicPartitions(partitions)
 	defer C.rd_kafka_topic_partition_list_destroy(cparts)
 	cerr := C.rd_kafka_committed(c.handle.rk, cparts, C.int(timeoutMs))
@@ -817,10 +853,11 @@ func (c *Consumer) Committed(partitions []TopicPartition, timeoutMs int) (offset
 // The consume position is the next message to read from the partition.
 // i.e., the offset of the last message seen by the application + 1.
 func (c *Consumer) Position(partitions []TopicPartition) (offsets []TopicPartition, err error) {
-	err = c.verifyClient()
+	err = c.handle.rlock()
 	if err != nil {
 		return nil, err
 	}
+	defer c.handle.runlock()
 	cparts := newCPartsFromTopicPartitions(partitions)
 	defer C.rd_kafka_topic_partition_list_destroy(cparts)
 	cerr := C.rd_kafka_position(c.handle.rk, cparts)
@@ -837,10 +874,11 @@ func (c *Consumer) Position(partitions []TopicPartition) (offsets []TopicPartiti
 // (if `go.events.channel.enable` has been set) will NOT be purged by
 // this call, set `go.events.channel.size` accordingly.
 func (c *Consumer) Pause(partitions []TopicPartition) (err error) {
-	err = c.verifyClient()
+	err = c.handle.rlock()
 	if err != nil {
 		return err
 	}
+	defer c.handle.runlock()
 	cparts := newCPartsFromTopicPartitions(partitions)
 	defer C.rd_kafka_topic_partition_list_destroy(cparts)
 	cerr := C.rd_kafka_pause_partitions(c.handle.rk, cparts)
@@ -852,10 +890,11 @@ func (c *Consumer) Pause(partitions []TopicPartition) (err error) {
 
 // Resume consumption for the provided list of partitions
 func (c *Consumer) Resume(partitions []TopicPartition) (err error) {
-	err = c.verifyClient()
+	err = c.handle.rlock()
 	if err != nil {
 		return err
 	}
+	defer c.handle.runlock()
 	cparts := newCPartsFromTopicPartitions(partitions)
 	defer C.rd_kafka_topic_partition_list_destroy(cparts)
 	cerr := C.rd_kafka_resume_partitions(c.handle.rk, cparts)
@@ -876,10 +915,11 @@ func (c *Consumer) Resume(partitions []TopicPartition) (err error) {
 // 3) SASL/OAUTHBEARER is supported but is not configured as the client's
 // authentication mechanism.
 func (c *Consumer) SetOAuthBearerToken(oauthBearerToken OAuthBearerToken) error {
-	err := c.verifyClient()
+	err := c.handle.rlock()
 	if err != nil {
 		return err
 	}
+	defer c.handle.runlock()
 	return c.handle.setOAuthBearerToken(oauthBearerToken)
 }
 
@@ -891,10 +931,11 @@ func (c *Consumer) SetOAuthBearerToken(oauthBearerToken OAuthBearerToken) error 
 // 2) SASL/OAUTHBEARER is supported but is not configured as the client's
 // authentication mechanism.
 func (c *Consumer) SetOAuthBearerTokenFailure(errstr string) error {
-	err := c.verifyClient()
+	err := c.handle.rlock()
 	if err != nil {
 		return err
 	}
+	defer c.handle.runlock()
 	return c.handle.setOAuthBearerTokenFailure(errstr)
 }
 
@@ -940,10 +981,11 @@ func deserializeConsumerGroupMetadata(serialized []byte) (*C.rd_kafka_consumer_g
 // This object should be passed to the transactional producer's
 // SendOffsetsToTransaction() API.
 func (c *Consumer) GetConsumerGroupMetadata() (*ConsumerGroupMetadata, error) {
-	err := c.verifyClient()
+	err := c.handle.rlock()
 	if err != nil {
 		return nil, err
 	}
+	defer c.handle.runlock()
 	cgmd := C.rd_kafka_consumer_group_metadata(c.handle.rk)
 	if cgmd == nil {
 		return nil, NewError(ErrState, "Consumer group metadata not available", false)

--- a/kafka/deadlock_test.go
+++ b/kafka/deadlock_test.go
@@ -1,0 +1,394 @@
+package kafka
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// The tests in this file are regression tests for the deadlock / hot-spin
+// issues in the pollLock (handle.pollLock) locking scheme introduced to fix
+// the use-after-free race between Close() and in-flight C calls (see
+// race_test.go).
+//
+// They are all written so that the *bug* manifests as the scenario failing to
+// complete within a deadline. Against the buggy code they run into the
+// deadline and fail; once the locking scheme is fixed they should complete
+// well within it.
+//
+// Common failure mode being probed: handle.pollLock is a sync.RWMutex whose
+// read lock is not reentrant. eventPoll takes RLock for the whole body,
+// including the rebalance dispatch, and several entry points reachable from
+// inside that dispatch (Assign/Commit/GetRebalanceProtocol) take rlock()
+// again. A concurrent Close() takes the write lock, and because Go's RWMutex
+// gives writers priority, the pending writer blocks the nested RLock -> both
+// goroutines wedge forever.
+
+// runWithDeadline runs fn in a goroutine and fails the test if it does not
+// return within d. It returns true if fn completed in time. This is how we
+// turn a deadlock into a deterministic test failure instead of hanging the
+// whole test binary until the go test timeout.
+func runWithDeadline(t *testing.T, d time.Duration, what string, fn func()) bool {
+	t.Helper()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		fn()
+	}()
+
+	select {
+	case <-done:
+		return true
+	case <-time.After(d):
+		t.Errorf("%s did not complete within %s (likely deadlock)", what, d)
+		return false
+	}
+}
+
+// newMockConsumer creates a mock cluster with a single-partition topic and a
+// consumer subscribed to it, plus a producer that has written one message so a
+// rebalance (partition assignment) actually happens. The caller is
+// responsible for closing the returned consumer; the cluster and producer are
+// cleaned up via t.Cleanup.
+func newMockConsumer(t *testing.T, rebalanceCb RebalanceCb) (*MockCluster, *Consumer) {
+	t.Helper()
+
+	cluster, err := NewMockCluster(1)
+	if err != nil {
+		t.Fatalf("create mock cluster: %v", err)
+	}
+	t.Cleanup(cluster.Close)
+
+	const topic = "test"
+	if err := cluster.CreateTopic(topic, 1, 1); err != nil {
+		t.Fatalf("create topic: %v", err)
+	}
+
+	producer, err := NewProducer(&ConfigMap{
+		"bootstrap.servers": cluster.BootstrapServers(),
+	})
+	if err != nil {
+		t.Fatalf("create producer: %v", err)
+	}
+	t.Cleanup(producer.Close)
+
+	value := []byte("value")
+	tp := topic
+	if err := producer.Produce(&Message{
+		TopicPartition: TopicPartition{Topic: &tp, Partition: PartitionAny},
+		Value:          value,
+	}, nil); err != nil {
+		t.Fatalf("produce: %v", err)
+	}
+	producer.Flush(5000)
+
+	consumer, err := NewConsumer(&ConfigMap{
+		"bootstrap.servers": cluster.BootstrapServers(),
+		"group.id":          "test",
+		"auto.offset.reset": "earliest",
+	})
+	if err != nil {
+		t.Fatalf("create consumer: %v", err)
+	}
+
+	if err := consumer.SubscribeTopics([]string{topic}, rebalanceCb); err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+
+	return cluster, consumer
+}
+
+// pollUntilAssigned polls the consumer until it has been assigned partitions
+// (i.e. a rebalance has completed) or the deadline passes.
+func pollUntilAssigned(t *testing.T, c *Consumer) {
+	t.Helper()
+	until := time.Now().Add(30 * time.Second)
+	for time.Now().Before(until) {
+		if assignment, err := c.Assignment(); err == nil && len(assignment) > 0 {
+			return
+		}
+		c.Poll(100)
+	}
+	t.Fatal("consumer was never assigned partitions")
+}
+
+// TestRebalanceCallbackConcurrentCloseNoUseAfterFree specifically exercises
+// the callback window where handleRebalanceEvent releases the pollLock read
+// lock. While that lock is released, a concurrent Close() can destroy the
+// librdkafka handle. The fix extracts everything needed from the rebalance
+// event (and destroys the event) before releasing the lock, and rechecks for a
+// closed handle after reacquiring, so no handle-owned C memory is touched once
+// the callback returns.
+//
+// The callback blocks until Close() has fully returned (handle destroyed),
+// then returns; handleRebalanceEvent must complete without touching freed
+// memory. Run under -race to catch regressions.
+func TestRebalanceCallbackConcurrentCloseNoUseAfterFree(t *testing.T) {
+	var consumer *Consumer
+
+	cbEntered := make(chan struct{})
+	closeReturned := make(chan struct{})
+
+	first := true
+	cb := func(c *Consumer, ev Event) error {
+		if _, ok := ev.(AssignedPartitions); ok && first {
+			first = false
+			close(cbEntered)
+			// Block until Close() has fully torn down the handle, so the
+			// post-callback code path in handleRebalanceEvent runs against a
+			// destroyed handle.
+			<-closeReturned
+		}
+		return nil
+	}
+
+	_, consumer = newMockConsumer(t, cb)
+
+	pollDone := make(chan struct{})
+	go func() {
+		defer close(pollDone)
+		until := time.Now().Add(10 * time.Second)
+		for time.Now().Before(until) && !consumer.IsClosed() {
+			consumer.Poll(100)
+		}
+	}()
+
+	// Wait until the poll goroutine is inside the rebalance callback (pollLock
+	// released), then close from this goroutine.
+	select {
+	case <-cbEntered:
+	case <-time.After(30 * time.Second):
+		t.Fatal("rebalance callback never fired")
+	}
+
+	_ = consumer.Close()
+	close(closeReturned)
+
+	<-pollDone
+}
+
+// TestDeadlockRebalanceCallbackReentrantAssign covers a reentrant-lock
+// deadlock in the rebalance path.
+//
+// eventPoll holds pollLock.RLock() across the rebalance dispatch. The
+// application rebalance callback calls Assign(), which takes rlock() again
+// (nested, non-reentrant RLock). If a concurrent Close() is waiting on the
+// write lock at that moment, the nested RLock blocks behind the pending
+// writer and both goroutines deadlock.
+func TestDeadlockRebalanceCallbackReentrantAssign(t *testing.T) {
+	var closeStarted sync.WaitGroup
+	closeStarted.Add(1)
+
+	cb := func(c *Consumer, ev Event) error {
+		switch ev.(type) {
+		case AssignedPartitions:
+			// Ask Close() to start racing for the write lock, then give it a
+			// moment to actually reach pollLock.Lock() while we (the poller)
+			// still hold the read lock.
+			closeStarted.Done()
+			time.Sleep(200 * time.Millisecond)
+			// Re-entrant rlock() while a writer is (very likely) pending.
+			// Either the Assign succeeds, or Close() has already won the race
+			// and the handle is closed -- both are fine. What must NOT happen
+			// is a deadlock, which is what this test guards against.
+			_ = c.Assign(ev.(AssignedPartitions).Partitions)
+		}
+		return nil
+	}
+
+	_, consumer := newMockConsumer(t, cb)
+
+	// Drive the poll loop that dispatches the rebalance from a background
+	// goroutine.
+	pollDone := make(chan struct{})
+	go func() {
+		defer close(pollDone)
+		until := time.Now().Add(10 * time.Second)
+		for time.Now().Before(until) && !consumer.IsClosed() {
+			consumer.Poll(100)
+		}
+	}()
+
+	// Once the callback has fired, close concurrently. Close() must not wedge.
+	closeStarted.Wait()
+	if runWithDeadline(t, 5*time.Second, "Consumer.Close during reentrant Assign", func() {
+		_ = consumer.Close()
+	}) {
+		<-pollDone
+	}
+}
+
+// TestDeadlockRebalanceGetRebalanceProtocol covers a reentrant-lock deadlock
+// via GetRebalanceProtocol(). handleRebalanceEvent calls GetRebalanceProtocol()
+// whenever the application did not reassign.
+// GetRebalanceProtocol() takes rlock() while eventPoll already holds the read
+// lock, so a concurrent Close() waiting on the write lock deadlocks the poll.
+//
+// We use a rebalance callback that intentionally does NOT reassign (returns
+// without calling *Assign), so the internal path that invokes
+// GetRebalanceProtocol() runs. The callback signals Close() to start and
+// sleeps, widening the window so Close()'s pending write lock is guaranteed to
+// be waiting by the time the nested GetRebalanceProtocol() RLock is attempted.
+func TestDeadlockRebalanceGetRebalanceProtocol(t *testing.T) {
+	var closeStarted sync.WaitGroup
+	closeStarted.Add(1)
+
+	first := true
+	cb := func(c *Consumer, ev Event) error {
+		if _, ok := ev.(AssignedPartitions); ok && first {
+			first = false
+			// Let Close() reach pollLock.Lock() while we (the poller) still
+			// hold the outer read lock. We deliberately do NOT reassign, so
+			// handleRebalanceEvent falls through to GetRebalanceProtocol().
+			closeStarted.Done()
+			time.Sleep(200 * time.Millisecond)
+		}
+		return nil
+	}
+
+	_, consumer := newMockConsumer(t, cb)
+
+	pollDone := make(chan struct{})
+	go func() {
+		defer close(pollDone)
+		until := time.Now().Add(10 * time.Second)
+		for time.Now().Before(until) && !consumer.IsClosed() {
+			consumer.Poll(100)
+		}
+	}()
+
+	closeStarted.Wait()
+	if runWithDeadline(t, 5*time.Second, "Consumer.Close racing GetRebalanceProtocol", func() {
+		_ = consumer.Close()
+	}) {
+		<-pollDone
+	}
+}
+
+// TestDeadlockRebalanceNilEventsChannel covers a nil-channel send deadlock.
+// When the events channel is not enabled, c.events is nil.
+// If an assign/unassign inside handleRebalanceEvent returns an error, it does
+// `c.events <- ...` -- a send on a nil channel that blocks forever while
+// holding the read lock, wedging any concurrent Close().
+//
+// The error-forwarding branch only runs when the internal
+// rd_kafka_(incremental_)assign call actually fails, which a healthy
+// mock cluster does not reliably produce -- so this test cannot force the hang
+// deterministically. It instead pins down the surrounding safety property:
+// with the events channel disabled (c.events == nil), a Close() concurrent
+// with an in-flight revoke rebalance must still complete. If the nil-channel
+// send is ever hit it will manifest here as the deadline firing.
+func TestDeadlockRebalanceNilEventsChannel(t *testing.T) {
+	_, consumer := newMockConsumer(t, nil)
+
+	pollDone := make(chan struct{})
+	go func() {
+		defer close(pollDone)
+		for !consumer.IsClosed() {
+			consumer.Poll(50)
+		}
+	}()
+
+	pollUntilAssigned(t, consumer)
+
+	// Closing triggers a revoke rebalance which is dispatched under the read
+	// lock; if that dispatch ever needs to forward an error to the nil
+	// c.events channel it hangs. Even absent an error, Close() must complete.
+	if runWithDeadline(t, 5*time.Second, "Consumer.Close with nil events channel", func() {
+		_ = consumer.Close()
+	}) {
+		<-pollDone
+	}
+}
+
+// TestCommitReleasesLockWhenClosing covers the unbounded-wait problem where a
+// blocking Commit() holds the handle read lock across an unbounded queue poll,
+// pinning a concurrent Close() that needs the write lock.
+//
+// commit() polls its result queue in bounded slices and bails out once the
+// consumer is tearing down (tearingDown set), so it releases the read lock
+// promptly instead of blocking on the broker round-trip. We make the broker
+// slow so the commit would otherwise block for a long time, mark the consumer
+// as tearing down, and assert the in-flight Commit() returns quickly.
+func TestCommitReleasesLockWhenClosing(t *testing.T) {
+	cluster, consumer := newMockConsumer(t, nil)
+	t.Cleanup(func() { _ = consumer.Close() })
+
+	pollUntilAssigned(t, consumer)
+
+	// Make the broker very slow so an in-flight commit stays blocked waiting
+	// for its result, holding the read lock, unless it bails out on close.
+	if err := cluster.SetRoundtripDuration(1, 30*time.Second); err != nil {
+		t.Fatalf("set rtt: %v", err)
+	}
+
+	commitDone := make(chan struct{})
+	go func() {
+		defer close(commitDone)
+		_, _ = consumer.Commit()
+	}()
+
+	// Let the commit enter its blocking result poll under the read lock.
+	time.Sleep(500 * time.Millisecond)
+
+	// Simulate Close() reaching the point where it marks the consumer as
+	// tearing down (the flag Close sets right before acquiring the write
+	// lock). The blocking commit must observe it and release the read lock
+	// promptly.
+	atomic.StoreUint32(&consumer.tearingDown, 1)
+
+	select {
+	case <-commitDone:
+	case <-time.After(5 * time.Second):
+		t.Error("in-flight Commit did not release the handle lock within 5s after close began")
+	}
+
+	// Allow the deferred Close() to run its normal path.
+	atomic.StoreUint32(&consumer.tearingDown, 0)
+}
+
+// TestFlushHotSpinAfterClose covers a hot-spin in Flush() after Close().
+// After the producer is closed, rlock() fails so the flush goroutine skips the
+// C flush, eventPoll returns instantly, but Len() still counts buffered
+// entries in produceChannel/events before its own rlock() check. If those
+// buffers are non-empty, Flush() never sees Len() drop to zero and spins hot
+// until the full timeout elapses.
+//
+// We enqueue buffered produce-channel entries, close the producer, then call
+// Flush with a long timeout and assert it returns quickly instead of burning
+// the whole timeout.
+func TestFlushHotSpinAfterClose(t *testing.T) {
+	cluster, err := NewMockCluster(1)
+	if err != nil {
+		t.Fatalf("create mock cluster: %v", err)
+	}
+	defer cluster.Close()
+
+	producer, err := NewProducer(&ConfigMap{
+		"bootstrap.servers": cluster.BootstrapServers(),
+	})
+	if err != nil {
+		t.Fatalf("create producer: %v", err)
+	}
+
+	// Leave some entries buffered on the produce channel so Len() stays > 0
+	// after the handle is torn down.
+	topic := "test"
+	for range 100 {
+		producer.ProduceChannel() <- &Message{
+			TopicPartition: TopicPartition{Topic: &topic, Partition: PartitionAny},
+			Value:          []byte("value"),
+		}
+	}
+
+	producer.Close()
+
+	// Flush with a long timeout. Correct behaviour: it cannot make progress on
+	// a closed handle and should give up quickly (or the buffered-count path
+	// should not be able to spin). Buggy behaviour: hot-spins ~30s.
+	runWithDeadline(t, 5*time.Second, "Producer.Flush after Close", func() {
+		producer.Flush(30000)
+	})
+}

--- a/kafka/event.go
+++ b/kafka/event.go
@@ -185,8 +185,20 @@ out:
 			retval = h.newMessageFromGlueMsg(&gMsg)
 
 		case C.RD_KAFKA_EVENT_REBALANCE:
-			// Consumer rebalance event
+			// Consumer rebalance event. handleRebalanceEvent takes ownership
+			// of rkev: it extracts everything it needs and destroys rkev
+			// while the pollLock read lock is still held (before releasing it
+			// around the application callback), so no handle-owned memory is
+			// touched during the lock-released callback window. Clear prevRkev
+			// so it is not destroyed again below.
 			retval = h.c.handleRebalanceEvent(channel, rkev)
+			prevRkev = nil
+			if h.rk == nil || h.rkq == nil {
+				// A concurrent Close() destroyed the handle/queue while the
+				// rebalance callback ran with the lock released. Stop before
+				// polling the (now freed) queue again.
+				break out
+			}
 
 		case C.RD_KAFKA_EVENT_ERROR:
 			// Error event

--- a/kafka/event.go
+++ b/kafka/event.go
@@ -163,7 +163,7 @@ func (h *handle) eventPoll(channel chan Event, timeoutMs int, maxEvents int, ter
 
 	h.pollLock.RLock()
 	defer h.pollLock.RUnlock()
-	if h.rkq == nil {
+	if h.rk == nil || h.rkq == nil {
 		// Handle is being (or has been) closed.
 		return nil, false
 	}

--- a/kafka/event.go
+++ b/kafka/event.go
@@ -160,6 +160,13 @@ func (h *handle) eventPoll(channel chan Event, timeoutMs int, maxEvents int, ter
 	if channel == nil {
 		maxEvents = 1
 	}
+
+	h.pollLock.RLock()
+	defer h.pollLock.RUnlock()
+	if h.rkq == nil {
+		// Handle is being (or has been) closed.
+		return nil, false
+	}
 out:
 	for evcnt := 0; evcnt < maxEvents; evcnt++ {
 		var evtype C.rd_kafka_event_type_t

--- a/kafka/handle.go
+++ b/kafka/handle.go
@@ -189,6 +189,9 @@ func (h *handle) cleanup() {
 
 	if h.rkq != nil {
 		C.rd_kafka_queue_destroy(h.rkq)
+		// Nil out so eventPoll's guard detects the closed handle instead
+		// of dereferencing a dangling queue pointer (use-after-free).
+		h.rkq = nil
 	}
 }
 

--- a/kafka/handle.go
+++ b/kafka/handle.go
@@ -90,6 +90,10 @@ type handle struct {
 	rk  *C.rd_kafka_t
 	rkq *C.rd_kafka_queue_t
 
+	// pollLock guards concurrent use of the C handle/queue (rk, rkq) in
+	// eventPoll against their destruction in Close.
+	pollLock sync.RWMutex
+
 	// Forward logs from librdkafka log queue to logs channel.
 	logs          chan LogEvent
 	logq          *C.rd_kafka_queue_t
@@ -134,6 +138,31 @@ type handle struct {
 
 func (h *handle) String() string {
 	return h.name
+}
+
+// rlock read-locks the handle so that a concurrent Close() cannot destroy the
+// underlying librdkafka handle/queue while a C call is in progress on another
+// goroutine. It returns an error if the handle has already been closed.
+//
+// On success the caller becomes responsible for calling h.pollLock.RUnlock()
+// (typically via defer) once it is done using the C handle. On error the lock
+// is not held.
+//
+// Note: this must only be taken by top-level entry points. Helpers reachable
+// from an already-locked method must NOT call rlock() again, since sync.RWMutex
+// read locks are not reentrant and may deadlock if a writer (Close) is waiting.
+func (h *handle) rlock() error {
+	h.pollLock.RLock()
+	if h.rk == nil {
+		h.pollLock.RUnlock()
+		return getOperationNotAllowedErrorForClosedClient()
+	}
+	return nil
+}
+
+// runlock releases a lock acquired by rlock.
+func (h *handle) runlock() {
+	h.pollLock.RUnlock()
 }
 
 func (h *handle) setup() {

--- a/kafka/handle.go
+++ b/kafka/handle.go
@@ -148,9 +148,12 @@ func (h *handle) String() string {
 // (typically via defer) once it is done using the C handle. On error the lock
 // is not held.
 //
-// Note: this must only be taken by top-level entry points. Helpers reachable
-// from an already-locked method must NOT call rlock() again, since sync.RWMutex
-// read locks are not reentrant and may deadlock if a writer (Close) is waiting.
+// Note: pollLock is a non-reentrant sync.RWMutex, so a read holder must not
+// call rlock() again on the same goroutine while a writer (Close) may be
+// waiting, or it will deadlock. In particular, code reachable from eventPoll's
+// rebalance dispatch runs with the read lock already held and must use the
+// unlocked internal variants (e.g. getRebalanceProtocol) rather than the
+// public rlock()-taking methods.
 func (h *handle) rlock() error {
 	h.pollLock.RLock()
 	if h.rk == nil {

--- a/kafka/producer.go
+++ b/kafka/producer.go
@@ -434,12 +434,14 @@ func (p *Producer) Close() {
 	close(p.produceChannel)
 	p.handle.waitGroup.Wait()
 
-	close(p.events)
-
 	// Prevent any in-flight C call on another goroutine from racing with the
-	// handle destruction, and block new ones.
+	// handle destruction, and block new ones. This must be held before
+	// closing p.events, otherwise a concurrent eventPoll (e.g. from Flush)
+	// sending to p.events could panic with "send on closed channel".
 	p.handle.pollLock.Lock()
 	defer p.handle.pollLock.Unlock()
+
+	close(p.events)
 
 	p.handle.cleanup()
 

--- a/kafka/producer.go
+++ b/kafka/producer.go
@@ -402,6 +402,14 @@ func (p *Producer) Flush(timeoutMs int) int {
 	timeoutDuration := time.Duration(timeoutMs) * time.Millisecond
 	tEnd := time.Now().Add(timeoutDuration)
 	for p.Len() > 0 {
+		// Stop spinning once the producer is closed: on a closed handle the
+		// underlying flush/poll become instant no-ops while Len() may still
+		// report buffered channel entries, which would otherwise busy-loop
+		// until the timeout elapses.
+		if p.IsClosed() {
+			return p.Len()
+		}
+
 		remain := time.Until(tEnd).Milliseconds()
 		if remain <= 0 {
 			return p.Len()
@@ -438,6 +446,12 @@ func (p *Producer) Close() {
 	// handle destruction, and block new ones. This must be held before
 	// closing p.events, otherwise a concurrent eventPoll (e.g. from Flush)
 	// sending to p.events could panic with "send on closed channel".
+	//
+	// Yield the queue first so any in-flight blocking poll releases the read
+	// lock promptly and this Close() stays bounded.
+	if p.handle.rkq != nil {
+		C.rd_kafka_queue_yield(p.handle.rkq)
+	}
 	p.handle.pollLock.Lock()
 	defer p.handle.pollLock.Unlock()
 

--- a/kafka/producer.go
+++ b/kafka/producer.go
@@ -177,6 +177,11 @@ func (p *Producer) produce(msg *Message, msgFlags int, deliveryChan chan Event) 
 		return newErrorFromString(ErrInvalidArg, "")
 	}
 
+	if err := p.handle.rlock(); err != nil {
+		return err
+	}
+	defer p.handle.runlock()
+
 	crkt := p.handle.getRkt(*msg.TopicPartition.Topic)
 
 	// Three problems:
@@ -319,6 +324,11 @@ func (p *Producer) Produce(msg *Message, deliveryChan chan Event) error {
 // WARNING: This is an experimental API.
 // NOTE: timestamps and headers are not supported with this API.
 func (p *Producer) produceBatch(topic string, msgs []*Message, msgFlags int) error {
+	if err := p.handle.rlock(); err != nil {
+		return err
+	}
+	defer p.handle.runlock()
+
 	crkt := p.handle.getRkt(topic)
 
 	cmsgs := make([]C.rd_kafka_message_t, len(msgs))
@@ -357,7 +367,12 @@ func (p *Producer) ProduceChannel() chan *Message {
 // as well as delivery reports queued for the application.
 // BUG: Tries to include messages on ProduceChannel, but it's not guaranteed to be reliable.
 func (p *Producer) Len() int {
-	return len(p.produceChannel) + len(p.events) + int(C.rd_kafka_outq_len(p.handle.rk))
+	n := len(p.produceChannel) + len(p.events)
+	if err := p.handle.rlock(); err != nil {
+		return n
+	}
+	defer p.handle.runlock()
+	return n + int(C.rd_kafka_outq_len(p.handle.rk))
 }
 
 // Flush and wait for outstanding messages and requests to complete delivery.
@@ -374,7 +389,11 @@ func (p *Producer) Flush(timeoutMs int) int {
 	// might do in case it is flushing.
 	go func() {
 		for flushInterval := range flushIntervalChan {
+			if err := p.handle.rlock(); err != nil {
+				continue
+			}
 			C.rd_kafka_flush(p.handle.rk, C.int(flushInterval))
+			p.handle.runlock()
 		}
 	}()
 
@@ -417,9 +436,16 @@ func (p *Producer) Close() {
 
 	close(p.events)
 
+	// Prevent any in-flight C call on another goroutine from racing with the
+	// handle destruction, and block new ones.
+	p.handle.pollLock.Lock()
+	defer p.handle.pollLock.Unlock()
+
 	p.handle.cleanup()
 
 	C.rd_kafka_destroy(p.handle.rk)
+	// Signal to any waiting rlock() callers that the handle is gone.
+	p.handle.rk = nil
 }
 
 const (
@@ -461,10 +487,11 @@ const (
 //
 // Returns nil on success, ErrInvalidArg if the purge flags are invalid or unknown.
 func (p *Producer) Purge(flags int) error {
-	err := p.verifyClient()
+	err := p.handle.rlock()
 	if err != nil {
 		return err
 	}
+	defer p.handle.runlock()
 	cErr := C.rd_kafka_purge(p.handle.rk, C.int(flags))
 	if cErr != C.RD_KAFKA_RESP_ERR_NO_ERROR {
 		return newError(cErr)
@@ -700,20 +727,22 @@ func poller(p *Producer, termChan chan bool) {
 // else information about all topics is returned.
 // GetMetadata is equivalent to listTopics, describeTopics and describeCluster in the Java API.
 func (p *Producer) GetMetadata(topic *string, allTopics bool, timeoutMs int) (*Metadata, error) {
-	err := p.verifyClient()
+	err := p.handle.rlock()
 	if err != nil {
 		return nil, err
 	}
+	defer p.handle.runlock()
 	return getMetadata(p, topic, allTopics, timeoutMs)
 }
 
 // QueryWatermarkOffsets returns the broker's low and high offsets for the given topic
 // and partition.
 func (p *Producer) QueryWatermarkOffsets(topic string, partition int32, timeoutMs int) (low, high int64, err error) {
-	err = p.verifyClient()
+	err = p.handle.rlock()
 	if err != nil {
 		return -1, -1, err
 	}
+	defer p.handle.runlock()
 	return queryWatermarkOffsets(p, topic, partition, timeoutMs)
 }
 
@@ -733,19 +762,21 @@ func (p *Producer) QueryWatermarkOffsets(topic string, partition int32, timeoutM
 // Duplicate Topic+Partitions are not supported.
 // Per-partition errors may be returned in the `.Error` field.
 func (p *Producer) OffsetsForTimes(times []TopicPartition, timeoutMs int) (offsets []TopicPartition, err error) {
-	err = p.verifyClient()
+	err = p.handle.rlock()
 	if err != nil {
 		return nil, err
 	}
+	defer p.handle.runlock()
 	return offsetsForTimes(p, times, timeoutMs)
 }
 
 // GetFatalError returns an Error object if the client instance has raised a fatal error, else nil.
 func (p *Producer) GetFatalError() error {
-	err := p.verifyClient()
+	err := p.handle.rlock()
 	if err != nil {
 		return err
 	}
+	defer p.handle.runlock()
 	return getFatalError(p)
 }
 
@@ -766,10 +797,11 @@ func (p *Producer) TestFatalError(code ErrorCode, str string) ErrorCode {
 // 3) SASL/OAUTHBEARER is supported but is not configured as the client's
 // authentication mechanism.
 func (p *Producer) SetOAuthBearerToken(oauthBearerToken OAuthBearerToken) error {
-	err := p.verifyClient()
+	err := p.handle.rlock()
 	if err != nil {
 		return err
 	}
+	defer p.handle.runlock()
 	return p.handle.setOAuthBearerToken(oauthBearerToken)
 }
 
@@ -781,10 +813,11 @@ func (p *Producer) SetOAuthBearerToken(oauthBearerToken OAuthBearerToken) error 
 // 2) SASL/OAUTHBEARER is supported but is not configured as the client's
 // authentication mechanism.
 func (p *Producer) SetOAuthBearerTokenFailure(errstr string) error {
-	err := p.verifyClient()
+	err := p.handle.rlock()
 	if err != nil {
 		return err
 	}
+	defer p.handle.runlock()
 	return p.handle.setOAuthBearerTokenFailure(errstr)
 }
 
@@ -820,10 +853,11 @@ func (p *Producer) SetOAuthBearerTokenFailure(errstr string) error {
 // by calling `err.(kafka.Error).IsRetriable()`, or whether a fatal
 // error has been raised by calling `err.(kafka.Error).IsFatal()`.
 func (p *Producer) InitTransactions(ctx context.Context) error {
-	err := p.verifyClient()
+	err := p.handle.rlock()
 	if err != nil {
 		return err
 	}
+	defer p.handle.runlock()
 	cError := C.rd_kafka_init_transactions(p.handle.rk,
 		cTimeoutFromContext(ctx))
 	if cError != nil {
@@ -862,10 +896,11 @@ func (p *Producer) InitTransactions(ctx context.Context) error {
 // Any produce call outside an on-going transaction, or for a failed
 // transaction, will fail.
 func (p *Producer) BeginTransaction() error {
-	err := p.verifyClient()
+	err := p.handle.rlock()
 	if err != nil {
 		return err
 	}
+	defer p.handle.runlock()
 	cError := C.rd_kafka_begin_transaction(p.handle.rk)
 	if cError != nil {
 		return newErrorFromCErrorDestroy(cError)
@@ -911,10 +946,11 @@ func (p *Producer) BeginTransaction() error {
 // `err.(kafka.Error).TxnRequiresAbort()` or `err.(kafka.Error).IsFatal()`
 // respectively.
 func (p *Producer) SendOffsetsToTransaction(ctx context.Context, offsets []TopicPartition, consumerMetadata *ConsumerGroupMetadata) error {
-	err := p.verifyClient()
+	err := p.handle.rlock()
 	if err != nil {
 		return err
 	}
+	defer p.handle.runlock()
 	var cOffsets *C.rd_kafka_topic_partition_list_t
 	if offsets != nil {
 		cOffsets = newCPartsFromTopicPartitions(offsets)
@@ -971,10 +1007,11 @@ func (p *Producer) SendOffsetsToTransaction(ctx context.Context, offsets []Topic
 // `err.(kafka.Error).TxnRequiresAbort()` or `err.(kafka.Error).IsFatal()`
 // respectively.
 func (p *Producer) CommitTransaction(ctx context.Context) error {
-	err := p.verifyClient()
+	err := p.handle.rlock()
 	if err != nil {
 		return err
 	}
+	defer p.handle.runlock()
 	cError := C.rd_kafka_commit_transaction(p.handle.rk,
 		cTimeoutFromContext(ctx))
 	if cError != nil {
@@ -1011,10 +1048,11 @@ func (p *Producer) CommitTransaction(ctx context.Context) error {
 // by calling `err.(kafka.Error).IsRetriable()`, or whether a fatal error
 // has been raised by calling `err.(kafka.Error).IsFatal()`.
 func (p *Producer) AbortTransaction(ctx context.Context) error {
-	err := p.verifyClient()
+	err := p.handle.rlock()
 	if err != nil {
 		return err
 	}
+	defer p.handle.runlock()
 	cError := C.rd_kafka_abort_transaction(p.handle.rk,
 		cTimeoutFromContext(ctx))
 	if cError != nil {
@@ -1031,9 +1069,10 @@ func (p *Producer) AbortTransaction(ctx context.Context) error {
 // existing broker connections that were established with the old credentials.
 // This method applies only to the SASL PLAIN and SCRAM mechanisms.
 func (p *Producer) SetSaslCredentials(username, password string) error {
-	err := p.verifyClient()
+	err := p.handle.rlock()
 	if err != nil {
 		return err
 	}
+	defer p.handle.runlock()
 	return setSaslCredentials(p.handle.rk, username, password)
 }

--- a/kafka/race_test.go
+++ b/kafka/race_test.go
@@ -1,0 +1,81 @@
+package kafka
+
+import (
+	"testing"
+	"time"
+)
+
+// TestRaceClose is a regression test for a use-after-free crash (SIGSEGV in
+// cgo) that occurred when a Consumer was closed while another goroutine was
+// still calling ReadMessage/Poll on it.
+//
+// The bug:
+//
+// ReadMessage -> Poll -> handle.eventPoll blocks inside the C call
+// rd_kafka_queue_poll(h.rkq, ...) for up to the poll timeout. Meanwhile
+// Consumer.Close() would set isClosed and then immediately call
+// rd_kafka_queue_destroy(rkq) and rd_kafka_destroy(rk), freeing the C queue
+// and handle. The isClosed / verifyClient() guard is a check-then-use
+// race: the polling goroutine passes the closed check while isClosed == 0,
+// reads the still-valid h.rkq pointer, enters the blocking C poll, and only
+// then does Close() free the underlying memory. The poll goroutine is now
+// operating on freed memory, corrupting the heap and crashing (often one
+// iteration later, e.g. inside the next rd_kafka_new).
+//
+// librdkafka is thread-safe for concurrent operations on a *live* handle, but
+// rd_kafka_destroy() cannot be made safe against a concurrent in-flight call:
+// once the memory is freed, any thread still dereferencing the handle is
+// undefined behaviour. Establishing that no in-flight call remains
+// is the caller's responsibility, and an atomic closed-flag alone cannot
+// provide it.
+//
+// The fix:
+//
+// handle gained a pollLock sync.RWMutex. Every entry point that touches the C
+// handle/queue takes pollLock.RLock() for the duration of its C call (see
+// eventPoll and the rlock()/runlock() helpers used across consumer.go,
+// producer.go and adminapi.go), and Close() takes pollLock.Lock() before
+// destroying the queue/handle and nils out rkq/rk. The write lock cannot be
+// acquired until all in-flight readers have released, so Close() drains any
+// running Poll/ReadMessage and blocks new ones before freeing anything --
+// closing the race regardless of goroutine scheduling.
+//
+// This test spawns a background reader for each of many short-lived consumers
+// and closes each one out from under the reader; before the fix it reliably
+// crashed within these iterations.
+func TestRaceClose(t *testing.T) {
+	// create a new mock cluster
+	cluster, err := NewMockCluster(1)
+	if err != nil {
+		t.Fatalf("create mock cluster: %v", err)
+	}
+
+	_ = cluster.CreateTopic("test", 16, 1)
+
+	for idx := range 1024 {
+		t.Logf("Iteration %d", idx)
+
+		consumer, err := NewConsumer(&ConfigMap{
+			"group.id":          "test",
+			"bootstrap.servers": cluster.BootstrapServers(),
+			"auto.offset.reset": "earliest",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		go func() {
+			if err := consumer.Subscribe("test", nil); err != nil {
+				t.Error(err)
+			}
+
+			for !consumer.IsClosed() {
+				_, _ = consumer.ReadMessage(50 * time.Millisecond)
+			}
+		}()
+
+		time.Sleep(50 * time.Millisecond)
+
+		_ = consumer.Close()
+	}
+}

--- a/kafka/race_test.go
+++ b/kafka/race_test.go
@@ -50,6 +50,8 @@ func TestRaceClose(t *testing.T) {
 		t.Fatalf("create mock cluster: %v", err)
 	}
 
+	defer cluster.Close()
+
 	_ = cluster.CreateTopic("test", 16, 1)
 
 	for idx := range 1024 {


### PR DESCRIPTION
This fixes issue #1569.

Produced mostly by AI for fixing an issue that happends at $WORK.

## Why

`Consumer`, `Producer`, and `AdminClient` each wrap a librdkafka handle (`rd_kafka_t`) and, for consumers, a queue (`rd_kafka_queue_t`). Every public method follows the same pattern:

```go
err := c.verifyClient()
if err != nil {
    return err
}
// ... use c.handle.rk / c.handle.rkq in a C call ...
```

`verifyClient()` just checks an atomic `isClosed` flag. That's a classic check-then-use (TOCTOU) race: a goroutine can pass the closed check while `isClosed == 0`, then enter a **blocking** C call (e.g. `rd_kafka_queue_poll` inside `ReadMessage`/`Poll`, which can block for the full poll timeout). Meanwhile, `Close()` sets `isClosed = 1` and immediately calls `rd_kafka_queue_destroy()` / `rd_kafka_destroy()`, freeing the very memory the other goroutine is still operating on inside its blocking cgo call.

The result is a heap use-after-free. In practice this doesn't crash where the corruption happens — it typically shows up later, e.g. as a `SIGSEGV` inside an unrelated `rd_kafka_new()` call in a subsequent test iteration, which made it look scarier and harder to diagnose than it actually was.

This is not a librdkafka thread-safety issue. librdkafka *is* thread-safe for concurrent operations on a live handle, but it (like any C library with explicit `destroy`/`free` calls) has no way to make `rd_kafka_destroy()` safe against a concurrent in-flight caller — freeing memory someone is actively dereferencing is inherently unsafe, in any language. Establishing quiescence (no in-flight calls) before destroying is the caller's responsibility, and the Go wrapper wasn't doing that.

The included regression test (`kafka/race_test.go`, `TestConcurrency`) reproduces this reliably: it spins up many short-lived consumers, each with a background goroutine calling `ReadMessage` in a loop, and closes the consumer out from under it. Before this fix, this reliably `SIGSEGV`s within a few hundred iterations against a mock cluster.

## What changed

- `handle` (shared by `Consumer`, `Producer`, `AdminClient`) gained a `pollLock sync.RWMutex`, plus `rlock()`/`runlock()` helpers. `rlock()` takes the read lock and returns `ErrState` if the handle has already been closed (`rk == nil`), checked atomically under the lock.
- Every method that touches the C handle/queue now holds `pollLock.RLock()` for the duration of its C call — across `Consumer` (`Subscribe*`, `Assign*`, `Commit*`, `Seek*`, `Position`, `Pause`/`Resume`, `GetMetadata`, transactions-adjacent getters, etc.), `Producer` (`produce`/`produceBatch`, `Flush`'s background flush goroutine, `Purge`, metadata/watermark queries, all transactional APIs, SASL/OAuth setters), and `AdminClient` (all ~26 methods that previously used `verifyClient`, e.g. `CreateTopics`, `DeleteTopics`, `DescribeConfigs`, ACL and consumer-group APIs, etc.).
- `eventPoll` (the shared implementation behind `Poll`/`ReadMessage`) takes the read lock for its entire blocking C poll, and bails out cleanly if the queue has already been destroyed.
- `Close()` on `Consumer`, `Producer`, and `AdminClient` now takes `pollLock.Lock()` **before** destroying the queue/handle, and nils out `rk`/`rkq` under that same lock.

Note: to avoid nested read-locks (which can deadlock a `sync.RWMutex` if a writer is waiting in between), only top-level public entry points take the lock. Methods that merely delegate to another already-locked method (e.g. `Subscribe` → `SubscribeTopics`, `Commit`/`CommitMessage`/`CommitOffsets` → the private `commit`, `StoreMessage` → `StoreOffsets`) do not lock themselves.

## API behavior changes

- **No signature or semantic changes** - same methods, same return types, same errors on a closed client (`ErrState` via `getOperationNotAllowedErrorForClosedClient()`).
- **`Close()` now blocks until all in-flight calls on that client have returned**, instead of racing them. Concretely:
  - If another goroutine is inside `Poll`/`ReadMessage` when `Close()` is called, `Close()` waits for that call to return (up to its configured timeout) before proceeding with teardown.
  - Any blocking call with a long or infinite timeout (e.g. `Consumer.commit`'s internal indefinite wait, or `AdminClient` calls with a long `ctx` deadline) will similarly make a concurrent `Close()` wait for that call to finish.
  - Once `Close()` has started, any new call into the client blocks briefly on the write lock and then returns the existing "client is closed" error — no C code path can execute concurrently with teardown anymore.
- This trades a previously-undefined-behavior (crash) for well-defined, bounded blocking. Applications that already avoid overlapping `Close()` with in-flight calls (the documented/intended usage) will see no observable difference. Applications relying on the previous race window (unlikely, since it was UB) may see `Close()` take slightly longer to return when calls are in flight.