### PR TITLE
feat: add go.consumer.close.timeout.ms to bound Close() duration

### DIFF
--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -51,6 +51,13 @@ type Consumer struct {
 
 	isClosed  uint32
 	isClosing uint32
+
+	// closeTimeoutMs is the maximum time in milliseconds that Close() will
+	// wait for the consumer group to cleanly leave before force-destroying
+	// the handle via rd_kafka_destroy_flags. Zero means no timeout (the
+	// default, preserving existing behaviour).
+	// Configured via "go.consumer.close.timeout.ms".
+	closeTimeoutMs int
 }
 
 // IsClosed returns boolean representing if client is closed or not
@@ -528,6 +535,13 @@ func (c *Consumer) ReadMessage(timeout time.Duration) (*Message, error) {
 
 // Close Consumer instance.
 // The object is no longer usable after this call.
+//
+// If go.consumer.close.timeout.ms is configured with a positive value and the
+// consumer group has not finished closing within that period, Close() force-
+// destroys the client using rd_kafka_destroy_flags with
+// RD_KAFKA_DESTROY_F_NO_CONSUMER_CLOSE, releasing all resources without waiting
+// for broker acknowledgement. By default (value 0) Close() waits indefinitely,
+// preserving the original behaviour.
 func (c *Consumer) Close() (err error) {
 	// Check if the client is already closed.
 	err = c.verifyClient()
@@ -549,8 +563,12 @@ func (c *Consumer) Close() (err error) {
 
 	C.rd_kafka_consumer_close_queue(c.handle.rk, c.handle.rkq)
 
-	for C.rd_kafka_consumer_closed(c.handle.rk) != 1 {
-		c.Poll(100)
+	if c.closeTimeoutMs > 0 {
+		c.drainCloseWithTimeout(c.closeTimeoutMs)
+	} else {
+		for C.rd_kafka_consumer_closed(c.handle.rk) != 1 {
+			c.Poll(100)
+		}
 	}
 
 	// After this point, no more consumer methods may be called.
@@ -562,9 +580,27 @@ func (c *Consumer) Close() (err error) {
 
 	c.handle.cleanup()
 
-	C.rd_kafka_destroy(c.handle.rk)
+	if c.closeTimeoutMs > 0 && C.rd_kafka_consumer_closed(c.handle.rk) != 1 {
+		// Timed out waiting for broker acknowledgement of leave-group.
+		// Force-destroy to free all resources without broker cooperation.
+		C.rd_kafka_destroy_flags(c.handle.rk, C.RD_KAFKA_DESTROY_F_NO_CONSUMER_CLOSE)
+	} else {
+		C.rd_kafka_destroy(c.handle.rk)
+	}
 
 	return nil
+}
+
+// drainCloseWithTimeout polls until the consumer group has cleanly closed or
+// the timeout (in milliseconds) expires.
+func (c *Consumer) drainCloseWithTimeout(timeoutMs int) {
+	deadline := time.Now().Add(time.Duration(timeoutMs) * time.Millisecond)
+	for C.rd_kafka_consumer_closed(c.handle.rk) != 1 {
+		if time.Now().After(deadline) {
+			return
+		}
+		c.Poll(100)
+	}
 }
 
 // NewConsumer creates a new high-level Consumer instance.
@@ -627,6 +663,12 @@ func NewConsumer(conf *ConfigMap) (*Consumer, error) {
 		return nil, err
 	}
 	eventsChanSize := v.(int)
+
+	v, err = confCopy.extract("go.consumer.close.timeout.ms", 0)
+	if err != nil {
+		return nil, err
+	}
+	c.closeTimeoutMs = v.(int)
 
 	logsChanEnable, logsChan, err := confCopy.extractLogConfig()
 	if err != nil {

--- a/kafka/consumer_close_timeout_test.go
+++ b/kafka/consumer_close_timeout_test.go
@@ -1,0 +1,230 @@
+package kafka
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+// These tests demonstrate that Consumer.Close() hangs indefinitely when the
+// broker is unresponsive during static member leave-group, and that configuring
+// go.consumer.close.timeout.ms resolves the issue by force-destroying the
+// consumer after the timeout.
+//
+// Requirements: Docker (for testcontainers Kafka broker)
+//
+// Run: go test -v -timeout 5m -run TestConsumerCloseTimeout ./kafka/
+
+// startBroker starts a Kafka container and returns the bootstrap address.
+func startBroker(t *testing.T) (bootstraps string, containerID string, cleanup func()) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	cmd := exec.CommandContext(ctx, "docker", "run", "-d", "--rm",
+		"-e", "KAFKA_LISTENERS=PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093,EXTERNAL://0.0.0.0:29092",
+		"-e", "KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://localhost:9092,EXTERNAL://localhost:29092",
+		"-e", "KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT",
+		"-e", "KAFKA_INTER_BROKER_LISTENER_NAME=PLAINTEXT",
+		"-e", "KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER",
+		"-e", "KAFKA_PROCESS_ROLES=broker,controller",
+		"-e", "KAFKA_NODE_ID=1",
+		"-e", "KAFKA_CONTROLLER_QUORUM_VOTERS=1@localhost:9093",
+		"-e", "CLUSTER_ID=MkU3OEVBNTcwNTJENDM2Qk",
+		"-e", "KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1",
+		"-e", "KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS=0",
+		"-p", "29092:29092",
+		"confluentinc/confluent-local:8.0.0",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		cancel()
+		t.Fatalf("failed to start kafka: %v\n%s", err, out)
+	}
+	containerID = string(out[:12])
+	bootstraps = "localhost:29092"
+
+	// Wait for broker to be ready
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		admin, err := NewAdminClient(&ConfigMap{"bootstrap.servers": bootstraps})
+		if err == nil {
+			md, err := admin.GetMetadata(nil, true, 2000)
+			admin.Close()
+			if err == nil && len(md.Brokers) > 0 {
+				t.Logf("Kafka broker ready at %s (container %s)", bootstraps, containerID)
+				return bootstraps, containerID, func() {
+					exec.Command("docker", "rm", "-f", containerID).Run()
+					cancel()
+				}
+			}
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	exec.Command("docker", "rm", "-f", containerID).Run()
+	cancel()
+	t.Fatalf("kafka broker did not become ready within 30s")
+	return "", "", nil
+}
+
+func createTopicForTest(t *testing.T, bootstraps, topic string) {
+	t.Helper()
+	admin, err := NewAdminClient(&ConfigMap{"bootstrap.servers": bootstraps})
+	if err != nil {
+		t.Fatalf("failed to create admin: %v", err)
+	}
+	defer admin.Close()
+
+	results, err := admin.CreateTopics(context.Background(), []TopicSpecification{{
+		Topic:             topic,
+		NumPartitions:     6,
+		ReplicationFactor: 1,
+	}}, SetAdminOperationTimeout(10*time.Second))
+	if err != nil {
+		t.Fatalf("CreateTopics failed: %v", err)
+	}
+	for _, r := range results {
+		if r.Error.Code() != ErrNoError && r.Error.Code() != ErrTopicAlreadyExists {
+			t.Fatalf("failed to create topic: %v", r.Error)
+		}
+	}
+}
+
+func produceToTopic(t *testing.T, bootstraps, topic string, count int) {
+	t.Helper()
+	p, err := NewProducer(&ConfigMap{"bootstrap.servers": bootstraps})
+	if err != nil {
+		t.Fatalf("failed to create producer: %v", err)
+	}
+	defer p.Close()
+
+	for i := 0; i < count; i++ {
+		p.Produce(&Message{
+			TopicPartition: TopicPartition{Topic: &topic, Partition: PartitionAny},
+			Value:          []byte(fmt.Sprintf(`{"seq":%d}`, i)),
+		}, nil)
+	}
+	p.Flush(5000)
+}
+
+// TestConsumerCloseTimeout_HangsWithoutConfig demonstrates that Close() hangs
+// indefinitely when the broker is unresponsive and go.consumer.close.timeout.ms
+// is not configured (default 0).
+//
+// This reproduces the production bug: static membership consumers calling Close()
+// during broker unresponsiveness (e.g., coordinator overload during rebalance
+// storms) hang forever in the rd_kafka_consumer_closed polling loop.
+func TestConsumerCloseTimeout_HangsWithoutConfig(t *testing.T) {
+	bootstraps, containerID, cleanup := startBroker(t)
+	defer cleanup()
+
+	topic := "test-close-timeout-hang"
+	createTopicForTest(t, bootstraps, topic)
+	produceToTopic(t, bootstraps, topic, 100)
+
+	// Create consumer with static membership, NO close timeout (default behavior)
+	consumer, err := NewConsumer(&ConfigMap{
+		"bootstrap.servers":  bootstraps,
+		"group.id":           "test-close-hang",
+		"group.instance.id":  "test-close-hang",
+		"auto.offset.reset":  "earliest",
+		"session.timeout.ms": 30000,
+		"socket.timeout.ms":  5000,
+	})
+	if err != nil {
+		t.Fatalf("NewConsumer: %v", err)
+	}
+
+	consumer.SubscribeTopics([]string{topic}, nil)
+
+	// Wait for assignment
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		if a, _ := consumer.Assignment(); len(a) > 0 {
+			break
+		}
+		consumer.Poll(100)
+	}
+
+	// Pause broker (simulates unresponsive coordinator)
+	if out, err := exec.Command("docker", "pause", containerID).CombinedOutput(); err != nil {
+		t.Fatalf("docker pause: %v\n%s", err, out)
+	}
+	defer exec.Command("docker", "unpause", containerID).Run()
+
+	time.Sleep(500 * time.Millisecond)
+
+	// Close() should hang -- we give it 45s then declare it hung
+	t.Log("Calling Close() without go.consumer.close.timeout.ms (expecting hang)...")
+	done := make(chan error, 1)
+	go func() { done <- consumer.Close() }()
+
+	select {
+	case <-done:
+		t.Log("Close() returned -- hang not reproduced in this run")
+	case <-time.After(45 * time.Second):
+		t.Log("CONFIRMED: Close() hung for >45s without go.consumer.close.timeout.ms")
+		t.Log("The consumer goroutine is now permanently leaked with all C-heap resources.")
+	}
+}
+
+// TestConsumerCloseTimeout_CompletesWithConfig demonstrates that Close() completes
+// within a bounded time when go.consumer.close.timeout.ms is configured, even with
+// an unresponsive broker. Resources are freed via rd_kafka_destroy_flags.
+func TestConsumerCloseTimeout_CompletesWithConfig(t *testing.T) {
+	bootstraps, containerID, cleanup := startBroker(t)
+	defer cleanup()
+
+	topic := "test-close-timeout-fix"
+	createTopicForTest(t, bootstraps, topic)
+	produceToTopic(t, bootstraps, topic, 100)
+
+	// Create consumer with static membership AND close timeout (the fix)
+	consumer, err := NewConsumer(&ConfigMap{
+		"bootstrap.servers":           bootstraps,
+		"group.id":                    "test-close-fix",
+		"group.instance.id":           "test-close-fix",
+		"auto.offset.reset":           "earliest",
+		"session.timeout.ms":          30000,
+		"socket.timeout.ms":           5000,
+		"go.consumer.close.timeout.ms": 5000, // 5 second timeout
+	})
+	if err != nil {
+		t.Fatalf("NewConsumer: %v", err)
+	}
+
+	consumer.SubscribeTopics([]string{topic}, nil)
+
+	// Wait for assignment
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		if a, _ := consumer.Assignment(); len(a) > 0 {
+			break
+		}
+		consumer.Poll(100)
+	}
+
+	// Pause broker (same scenario as above)
+	if out, err := exec.Command("docker", "pause", containerID).CombinedOutput(); err != nil {
+		t.Fatalf("docker pause: %v\n%s", err, out)
+	}
+	defer exec.Command("docker", "unpause", containerID).Run()
+
+	time.Sleep(500 * time.Millisecond)
+
+	// Close() should complete within the timeout + socket.timeout.ms
+	t.Log("Calling Close() with go.consumer.close.timeout.ms=5000...")
+	start := time.Now()
+	err = consumer.Close()
+	elapsed := time.Since(start)
+
+	t.Logf("Close() returned in %v (err=%v)", elapsed, err)
+
+	if elapsed > 15*time.Second {
+		t.Fatalf("Close() took %v -- expected <15s with close timeout of 5s", elapsed)
+	}
+
+	t.Logf("CONFIRMED: Close() completed in %v with go.consumer.close.timeout.ms configured", elapsed)
+	t.Log("Resources freed via rd_kafka_destroy_flags -- no goroutine leak, no memory leak.")
+}


### PR DESCRIPTION
<!--
Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Consumer.Close() can hang indefinitely when the Kafka broker is unresponsive during the leave-group handshake (particularly with static membership). This adds an opt-in go.consumer.close.timeout.ms config property that bounds the rd_kafka_consumer_closed polling loop.

When the timeout expires, Close() calls rd_kafka_destroy_flags with RD_KAFKA_DESTROY_F_NO_CONSUMER_CLOSE to force-free all resources without waiting for broker acknowledgement.

Default value is 0 (no timeout), preserving existing behaviour. No breaking changes.

Resolves hangs reported in:
- #767 (Consumer hanging on Close() when redeploying)
- #1016 (rd_kafka_rebalance_protocol() hang during close)



Checklist
------------------
- [x] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [x] Did you add sufficient unit test and/or integration test coverage for this PR?
  - If not, please explain why it is not required

Tradeoffs
----------

When the timeout fires:
- The consumer does not perform a clean LeaveGroup — for static members, the broker retains the assignment until `session.timeout.ms` expires (identical to a pod crash)
- Any uncommitted offsets since the last auto-commit are lost (also identical to a crash)

These are acceptable tradeoffs vs. an indefinite hang that causes OOM kills.


Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->


```bash
# Requires Docker for the Kafka broker container
go test -v -timeout 5m -run TestConsumerCloseTimeout ./kafka/
```

- `TestConsumerCloseTimeout_HangsWithoutConfig`: pauses the broker and confirms Close() hangs >45s without the config
- `TestConsumerCloseTimeout_CompletesWithConfig`: same scenario but with `go.consumer.close.timeout.ms=5000`, confirms Close() returns in ~5-10s


Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow-ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
