### PR TITLE
Performance: ability to disable cgo copying of message fields in consumer

### DIFF
--- a/examples/confluent_cloud_example/confluent_cloud_example.go
+++ b/examples/confluent_cloud_example/confluent_cloud_example.go
@@ -189,8 +189,6 @@ func createTopic(topic string) {
 
 	adminClient, err := kafka.NewAdminClient(&kafka.ConfigMap{
 		"bootstrap.servers":       bootstrapServers,
-		"broker.version.fallback": "0.10.0.0",
-		"api.version.fallback.ms": 0,
 		"sasl.mechanisms":         "PLAIN",
 		"security.protocol":       "SASL_SSL",
 		"sasl.username":           ccloudAPIKey,

--- a/kafka/README.md
+++ b/kafka/README.md
@@ -35,6 +35,18 @@ The format of testconf.json is a JSON object:
 
 See testconf-example.json for an example and full set of available options.
 
+For some setups, such as dockerized localhost brokers on OSX, you may need to
+set the `broker.address.family` Config in testconf.json to avoid failures to
+connect when the OSX resolver returns IPv6 addresses for localhost first, and
+docker is only listening on IPv4. e.g.
+
+```
+{
+  "Brokers": "localhost:9092",
+  "Config": ["broker.address.family=v4"]
+}
+```
+
 
 To run unit-tests:
 ```

--- a/kafka/consumer.go
+++ b/kafka/consumer.go
@@ -577,6 +577,9 @@ func (c *Consumer) Close() (err error) {
 //	                                     If set to true the app must handle the AssignedPartitions and
 //	                                     RevokedPartitions events and call Assign() and Unassign()
 //	                                     respectively.
+//	go.consumer.message.fields (string, "all") - Comma separated list of fields to copy from C messages.
+//	                                     Allowed values: all, none (or empty string), key, value, headers.
+//	                                     There is a performance penalty to include fields you don't need.
 //	go.events.channel.enable (bool, false) - [deprecated] Enable the Events() channel. Messages and events will be pushed on the Events() channel and the Poll() interface will be disabled.
 //	go.events.channel.size (int, 1000) - Events() channel size
 //	go.logs.channel.enable (bool, false) - Forward log to Logs() channel.
@@ -628,6 +631,15 @@ func NewConsumer(conf *ConfigMap) (*Consumer, error) {
 	}
 	eventsChanSize := v.(int)
 
+	v, err = confCopy.extract("go.consumer.message.fields", "all")
+	if err != nil {
+		return nil, err
+	}
+	msgFields, err := newMessageFieldsFrom(v)
+	if err != nil {
+		return nil, err
+	}
+
 	logsChanEnable, logsChan, err := confCopy.extractLogConfig()
 	if err != nil {
 		return nil, err
@@ -650,6 +662,7 @@ func NewConsumer(conf *ConfigMap) (*Consumer, error) {
 	C.rd_kafka_poll_set_consumer(c.handle.rk)
 
 	c.handle.c = c
+	c.handle.msgFields = msgFields
 	c.handle.setup()
 	c.readerTermChan = make(chan bool)
 	c.handle.rkq = C.rd_kafka_queue_get_consumer(c.handle.rk)

--- a/kafka/consumer_performance_test.go
+++ b/kafka/consumer_performance_test.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"math/rand"
 	"testing"
-	"time"
 )
 
 // consumerPerfTest measures the consumer performance using a pre-primed (produced to) topic
@@ -34,8 +33,6 @@ func consumerPerfTest(b *testing.B, testname string, msgcnt int, useChannel bool
 	if msgcnt == 0 {
 		msgcnt = r
 	}
-
-	rand.Seed(int64(time.Now().Unix()))
 
 	conf := ConfigMap{"bootstrap.servers": testconf.Brokers,
 		"go.events.channel.enable": useChannel,

--- a/kafka/consumer_performance_test.go
+++ b/kafka/consumer_performance_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 // consumerPerfTest measures the consumer performance using a pre-primed (produced to) topic
-func consumerPerfTest(b *testing.B, testname string, msgcnt int, useChannel bool, consumeFunc func(c *Consumer, rd *ratedisp, expCnt int), rebalanceCb func(c *Consumer, event Event) error) {
+func consumerPerfTest(b *testing.B, testname string, msgcnt int, useChannel bool, consumeFunc func(c *Consumer, rd *ratedisp, expCnt int), rebalanceCb func(c *Consumer, event Event) error, extraConfig ConfigMap) {
 
 	r := testconsumerInit(b)
 	if r == -1 {
@@ -54,6 +54,10 @@ func consumerPerfTest(b *testing.B, testname string, msgcnt int, useChannel bool
 	}
 
 	conf.updateFromTestconf()
+
+	for k, v := range extraConfig {
+		conf[k] = v
+	}
 
 	c, err := NewConsumer(&conf)
 
@@ -166,12 +170,12 @@ func testconsumerInit(b *testing.B) int {
 
 func BenchmarkConsumerChannelPerformance(b *testing.B) {
 	consumerPerfTest(b, "Channel Consumer",
-		0, true, eventChannelConsumer, nil)
+		0, true, eventChannelConsumer, nil, nil)
 }
 
 func BenchmarkConsumerPollPerformance(b *testing.B) {
 	consumerPerfTest(b, "Poll Consumer",
-		0, false, eventPollConsumer, nil)
+		0, false, eventPollConsumer, nil, nil)
 }
 
 func BenchmarkConsumerPollRebalancePerformance(b *testing.B) {
@@ -180,5 +184,14 @@ func BenchmarkConsumerPollRebalancePerformance(b *testing.B) {
 		func(c *Consumer, event Event) error {
 			b.Logf("Rebalanced: %s", event)
 			return nil
+		}, nil)
+}
+
+func BenchmarkConsumerMessageFieldsConfig(b *testing.B) {
+	for _, variant := range []string{"all", "key", "value", "headers", "none"} {
+		b.Run(fmt.Sprintf("variant=%s", variant), func(b *testing.B) {
+			consumerPerfTest(b, "Poll Consumer", 0, false, eventPollConsumer,
+				nil, ConfigMap{"go.consumer.message.fields": variant})
 		})
+	}
 }

--- a/kafka/consumer_performance_test.go
+++ b/kafka/consumer_performance_test.go
@@ -40,7 +40,18 @@ func consumerPerfTest(b *testing.B, testname string, msgcnt int, useChannel bool
 		"session.timeout.ms":       6000,
 		"enable.auto.commit":       false,
 		"debug":                    ",",
-		"auto.offset.reset":        "earliest"}
+		"auto.offset.reset":        "earliest",
+
+		// For benchmarks we want to avoid long fetch stalls when go can't keep
+		// up with librdkafka filling the fetch queue and then backing off by
+		// the default one second. When it's possible to consume all 2M messages
+		// within a second, losing the race with librdkafka and backing off for
+		// a whole second really slows us down and skews the overall timings,
+		// with consecutive runs varying by a whole second due to one
+		// additional backoff. So go lower than the default, but not too low so
+		// we avoid spinning.
+		"fetch.queue.backoff.ms": 10,
+	}
 
 	conf.updateFromTestconf()
 

--- a/kafka/consumer_performance_test.go
+++ b/kafka/consumer_performance_test.go
@@ -41,7 +41,6 @@ func consumerPerfTest(b *testing.B, testname string, msgcnt int, useChannel bool
 		"go.events.channel.enable": useChannel,
 		"group.id":                 fmt.Sprintf("go_cperf_%d", rand.Intn(1000000)),
 		"session.timeout.ms":       6000,
-		"api.version.request":      "true",
 		"enable.auto.commit":       false,
 		"debug":                    ",",
 		"auto.offset.reset":        "earliest"}

--- a/kafka/integration/integration_test.go
+++ b/kafka/integration/integration_test.go
@@ -393,11 +393,10 @@ func consumerTest(t *testing.T, testname string, assignmentStrategy string, msgc
 		"go.events.channel.enable": cc.useChannel,
 		"group.id": testconf.GroupID +
 			fmt.Sprintf("-%d", rand.Intn(1000000)),
-		"session.timeout.ms":  6000,
-		"api.version.request": "true",
-		"enable.auto.commit":  cc.autoCommit,
-		"debug":               ",",
-		"auto.offset.reset":   "earliest"}
+		"session.timeout.ms": 6000,
+		"enable.auto.commit": cc.autoCommit,
+		"debug":              ",",
+		"auto.offset.reset":  "earliest"}
 	if assignmentStrategy != "" {
 		conf["partition.assignment.strategy"] = assignmentStrategy
 	}

--- a/kafka/integration/testhelpers_test.go
+++ b/kafka/integration/testhelpers_test.go
@@ -51,8 +51,6 @@ const defaulttestconfGroupID = "testgroup"
 const defaulttestconfPerfMsgCount = 2000000
 const defaulttestconfPerfMsgSize = 100
 
-var defaulttestconfConfig = [1]string{"api.version.request=true"}
-
 const defaulttestconfBrokers = "localhost:9092"
 const defaulttestconfBrokersSasl = "localhost:9093"
 const defaultSaslUsername = "testuser"

--- a/kafka/producer_performance_test.go
+++ b/kafka/producer_performance_test.go
@@ -79,9 +79,22 @@ func producerPerfTest(b *testing.B, testname string, msgcnt int, withDr bool, ba
 
 	topic := testconf.TopicName
 	partition := int32(-1)
-	size := testconf.PerfMsgSize
+	msgValueSize := testconf.PerfMsgSize
 	pattern := "Hello"
-	buf := []byte(strings.Repeat(pattern, size/len(pattern)))
+	msgValue := []byte(strings.Repeat(pattern, msgValueSize/len(pattern)))
+
+	var msgKey []byte
+	if testconf.PerfMsgKey {
+		msgKey = []byte(strings.Repeat(pattern, testconf.PerfMsgKeySize/len(pattern)))
+	}
+
+	var msgHeaders []Header
+	for i := range testconf.PerfMsgHeaderCount {
+		msgHeaders = append(msgHeaders, Header{
+			Key:   fmt.Sprintf("%d", i),
+			Value: []byte(strings.Repeat(pattern, testconf.PerfMsgHeaderSize/len(pattern))),
+		})
+	}
 
 	var doneChan chan int64
 	var drChan chan Event
@@ -104,11 +117,16 @@ func producerPerfTest(b *testing.B, testname string, msgcnt int, withDr bool, ba
 	rdDelivery := ratedispStart(b, fmt.Sprintf("%s: delivery", testname), displayInterval)
 
 	for i := 0; i < msgcnt; i++ {
-		m := Message{TopicPartition: TopicPartition{Topic: &topic, Partition: partition}, Value: buf}
+		m := Message{
+			TopicPartition: TopicPartition{Topic: &topic, Partition: partition},
+			Key:            msgKey,
+			Value:          msgValue,
+			Headers:        msgHeaders,
+		}
 
 		produceFunc(p, &m, drChan)
 
-		rd.tick(1, int64(size))
+		rd.tick(1, int64(msgValueSize))
 	}
 
 	if !silent {
@@ -134,7 +152,7 @@ func producerPerfTest(b *testing.B, testname string, msgcnt int, withDr bool, ba
 		deliverySize = <-doneChan
 	} else {
 		deliveryCnt = int64(msgcnt)
-		deliverySize = deliveryCnt * int64(size)
+		deliverySize = deliveryCnt * int64(msgValueSize)
 	}
 	rdDelivery.tick(deliveryCnt, deliverySize)
 

--- a/kafka/producer_performance_test.go
+++ b/kafka/producer_performance_test.go
@@ -68,8 +68,6 @@ func producerPerfTest(b *testing.B, testname string, msgcnt int, withDr bool, ba
 		"go.batch.producer":            batchProducer,
 		"go.delivery.reports":          withDr,
 		"queue.buffering.max.messages": msgcnt,
-		"api.version.request":          "true",
-		"broker.version.fallback":      "0.9.0.1",
 		"acks":                         1}
 
 	conf.updateFromTestconf()

--- a/kafka/testhelpers_test.go
+++ b/kafka/testhelpers_test.go
@@ -27,19 +27,27 @@ import (
 )
 
 var testconf struct {
-	Brokers      string
-	TopicName    string
-	GroupID      string
-	PerfMsgCount int
-	PerfMsgSize  int
-	Config       []string
-	conf         ConfigMap
+	Brokers            string
+	TopicName          string
+	GroupID            string
+	PerfMsgCount       int
+	PerfMsgSize        int
+	PerfMsgHeaderCount int
+	PerfMsgHeaderSize  int
+	PerfMsgKey         bool
+	PerfMsgKeySize     int
+	Config             []string
+	conf               ConfigMap
 }
 
 const defaulttestconfTopicName = "test"
 const defaulttestconfGroupID = "testgroup"
 const defaulttestconfPerfMsgCount = 2000000
 const defaulttestconfPerfMsgSize = 100
+const defaulttestconfPerfMsgHeaderCount = 0
+const defaulttestconfPerfMsgHeaderSize = 100
+const defaulttestconfPerfMsgKey = false
+const defaulttestconfPerfMsgKeySize = 100
 
 // ratepdisp tracks and prints message & byte rates
 type ratedisp struct {
@@ -95,6 +103,10 @@ func testconfRead() bool {
 	// Default values
 	testconf.PerfMsgCount = defaulttestconfPerfMsgCount
 	testconf.PerfMsgSize = defaulttestconfPerfMsgSize
+	testconf.PerfMsgHeaderCount = defaulttestconfPerfMsgHeaderCount
+	testconf.PerfMsgHeaderSize = defaulttestconfPerfMsgHeaderSize
+	testconf.PerfMsgKey = defaulttestconfPerfMsgKey
+	testconf.PerfMsgKeySize = defaulttestconfPerfMsgKeySize
 	testconf.GroupID = defaulttestconfGroupID
 	testconf.TopicName = defaulttestconfTopicName
 	testconf.Brokers = ""


### PR DESCRIPTION
What
----
Adds a `go.consumer.message.fields` configuration property for the `Consumer`, analogous to the existing `go.delivery.report.fields` on the `Producer`. This allows applications to specify which message fields (key, value, headers) are copied from C messages during consumption.

For example, I have a consumer in a service which does minimal processing of message. My `pprof` profiles show that it spends 6% of its time in `setupHeadersFromGlueMsg` to populate `Message.Headers` which the application never looks at.

Also did a little tidy up of things I hit:
* documented how to avoid a test issue on OSX with IPv6
* removed deprecated config settings from test code that were spamming test output
* updated the benchmarks so they run more quickly and with less variance due to fetch stalls, 

Checklist
------------------
- [x] Contains customer facing changes? Including API/behavior changes
- [x] Did you add sufficient unit test and/or integration test coverage for this PR?
  - If not, please explain why it is not required

References
----------
We only have to add a new consumer config in this PR. The optimisations were already added in #530 but not hooked up to a consumer config. In this PR, we can pass the new config value to the existing `newMessageFieldsFrom` function to set `handle.msgFields` to get the benefits for consumers too.

The benchmark improvements in this PR may be useful for demonstrating the value of the performance fix in #1540 (consumers not opting out of headers will see a perf improvement from that fix)
* Update: Yes, had to push an extra commit (522b73efc8985b302f0df559bbff3b9fd0a14eb8) to make it possible to configure the performance tests to use messages that have headers - they didn't before. With 5 headers of 100 bytes each, the benefits of that patch are clear. See [my comment](https://github.com/confluentinc/confluent-kafka-go/pull/1540#issuecomment-5143701703) on #1540 for the results.

Test & Review
------------
New benchmarks added and run, details in commit messages included below.

Open questions / Follow-ups
--------------------------
Happy to discuss anything. Just want these perf boosts for my own services asap 🚀 

Commit-by-commit explanation of changes
-----------
`git log master..HEAD --reverse --pretty=format:---%n%n%B`

---

test: remove deprecated configs causing noise

These were causing lots of warnings in the output of the benchmarks.
Example:

```
%4|1785359737.528|CONFWARN|rdkafka#consumer-2| [thrd:app]: Configuration
%property api.version.request is deprecated: **Post-deprecation actions: remove
%this configuration property, brokers < 0.10.0 won't be supported anymore in
%librdkafka 3.x.** Request broker's supported API versions to adjust
%functionality to available protocol features. If set to false, or the
%ApiVersionRequest fails, the fallback version `broker.version.fallback` will
%be used. **NOTE**: Depends on broker version >=0.10.0. If the request is not
%supported by (an older) broker the `broker.version.fallback` fallback is used.
```

Removed configs, all deprecated:
* api.version.request - defaults to true anyway, no need to set explicitly
* api.version.fallback.ms - defaults to 0 anyway, no need to set explicitly
* broker.version.fallback - defaults to 0.10.0 (we had 0.10.0.0 and 0.9.0.1
  which isn't valid)

Note that defaulttestconfConfig was unused, so removed entirely.

---

docs: note to help avoid IPv6 confusion in tests

---

test: remove use of rand.Seed

rand.Seed is deprecated since go 1.20 and there is no longer any need to
explicitly seed with a non-deterministic value like the current time

---

test: quicker, more consistent perf benchmarks

Benchmark runs would often take roughly 5 seconds, plus or minus 1 whole
second, which made benchstat comparisons of throughput improvements
difficult due to the extreme variance. This resolves that and also
speeds up all the benhcmarks so they now run in just under 1 second on
my machine.

We can see variance go way down from ~15% to just ~2%, and overall
throughput dramatically increase, all due to no longer spending multiple
seconds in fetch queue backoffs with no useful work happening.

```
$ benchstat before.txt with-10-backoff.txt
goos: darwin
goarch: arm64
pkg: github.com/confluentinc/confluent-kafka-go/v2/kafka
cpu: Apple M4
                           │  before.txt   │         with-10-backoff.txt         │
                           │    sec/op     │   sec/op     vs base                │
ConsumerChannelPerformance     7.072 ± 15%    1.045 ± 1%  -85.22% (p=0.000 n=10)
ConsumerPollPerformance      6935.4m ± 14%   927.7m ± 2%  -86.62% (p=0.000 n=10)
geomean                        7.003         984.7m       -85.94%

                           │  before.txt   │          with-10-backoff.txt           │
                           │      B/s      │      B/s       vs base                 │
ConsumerChannelPerformance   26.97Mi ± 17%   182.47Mi ± 1%  +576.57% (p=0.000 n=10)
ConsumerPollPerformance      27.50Mi ± 17%   205.60Mi ± 2%  +647.67% (p=0.000 n=10)
geomean                      27.23Mi          193.7Mi       +611.23%
```

---

perf: go.consumer.message.fields config

Adds a "go.consumer.message.fields" configuration property for the
Consumer, analogous to the existing "go.delivery.report.fields" on the
Producer. This allows applications to specify which message fields (key,
value, headers) are copied from C messages during consumption.

Including headers requires extra CGo calls and deserialization per
consumed message. Applications that do not use headers can set this to
"key,value" to avoid that overhead.

---

test: benchmark new consumer config variants

From a single benchmark run like:

```
go test -run=^$$ \
  -bench '^BenchmarkConsumerMessageFieldsConfig$' \
  -benchmem -cpu 1 -benchtime 1x -count 10 -timeout 600s \
  github.com/confluentinc/confluent-kafka-go/v2/kafka/... \
  | tee bench-output.txt
```

we can now get a feel for the performance savings that setting the new
go.consumer.message.fields config gives using

```
benchstat -col '/variant@(all key value headers none)' bench-output.txt
```

and it looks good. e.g. Just getting value and ignoring key and headers
gives a 26% speed boost, 35% improved throughput in bytes payload and
14% reduction in allocations. Full output:

```
goos: darwin
goarch: arm64
pkg: github.com/confluentinc/confluent-kafka-go/v2/kafka
cpu: Apple M4
                            │     all     │                 key                 │                value                │              headers               │                none                 │
                            │   sec/op    │   sec/op     vs base                │   sec/op     vs base                │   sec/op     vs base               │   sec/op     vs base                │
ConsumerMessageFieldsConfig   935.3m ± 2%   665.9m ± 2%  -28.80% (p=0.000 n=10)   691.7m ± 2%  -26.04% (p=0.000 n=10)   887.7m ± 2%  -5.08% (p=0.000 n=10)   664.1m ± 1%  -28.99% (p=0.000 n=10)

                            │     all      │                value                 │
                            │     B/s      │     B/s       vs base                │
ConsumerMessageFieldsConfig   203.9Mi ± 2%   275.7Mi ± 2%  +35.20% (p=0.000 n=10)

                            │     all      │                 key                  │                value                 │               headers                │                 none                 │
                            │     B/op     │     B/op      vs base                │     B/op      vs base                │     B/op      vs base                │     B/op      vs base                │
ConsumerMessageFieldsConfig   808.7Mi ± 0%   503.5Mi ± 0%  -37.74% (p=0.000 n=10)   717.2Mi ± 0%  -11.32% (p=0.000 n=10)   595.1Mi ± 0%  -26.42% (p=0.000 n=10)   503.5Mi ± 0%  -37.74% (p=0.000 n=10)

                            │     all     │                 key                 │                value                │               headers               │                none                 │
                            │  allocs/op  │  allocs/op   vs base                │  allocs/op   vs base                │  allocs/op   vs base                │  allocs/op   vs base                │
ConsumerMessageFieldsConfig   14.00M ± 0%   10.00M ± 0%  -28.57% (p=0.000 n=10)   12.00M ± 0%  -14.29% (p=0.000 n=10)   12.00M ± 0%  -14.29% (p=0.000 n=10)   10.00M ± 0%  -28.57% (p=0.000 n=10)
```
