### PR TITLE
schemaregistry/serde: allow injecting a per-serializer RuleRegistry

### DIFF
--- a/schemaregistry/serde/avrov2/avro.go
+++ b/schemaregistry/serde/avrov2/avro.go
@@ -81,7 +81,7 @@ func NewSerializer(client schemaregistry.Client, serdeType serde.Type, conf *Ser
 		return s.FieldTransform(s.Client, ctx, fieldTransform, msg)
 	}
 	s.FieldTransformer = fieldTransformer
-	err = s.SetRuleRegistry(serde.GlobalRuleRegistry(), conf.RuleConfig)
+	err = s.SetRuleRegistry(conf.RuleRegistry, conf.RuleConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +214,7 @@ func NewDeserializer(client schemaregistry.Client, serdeType serde.Type, conf *D
 		return s.FieldTransform(s.Client, ctx, fieldTransform, msg)
 	}
 	s.FieldTransformer = fieldTransformer
-	err = s.SetRuleRegistry(serde.GlobalRuleRegistry(), conf.RuleConfig)
+	err = s.SetRuleRegistry(conf.RuleRegistry, conf.RuleConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/schemaregistry/serde/avrov2/avro_ruleregistry_test.go
+++ b/schemaregistry/serde/avrov2/avro_ruleregistry_test.go
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2024 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package avrov2
+
+import (
+	"testing"
+
+	"github.com/confluentinc/confluent-kafka-go/v2/schemaregistry"
+	"github.com/confluentinc/confluent-kafka-go/v2/schemaregistry/serde"
+)
+
+// countingExecutor is a no-op rule executor that records how many times Configure was
+// called on it, used to observe which registry a serializer draws its executors from.
+type countingExecutor struct {
+	ruleType   string
+	configured int
+}
+
+func (e *countingExecutor) Configure(*schemaregistry.Config, map[string]string) error {
+	e.configured++
+	return nil
+}
+func (e *countingExecutor) Type() string { return e.ruleType }
+func (e *countingExecutor) Transform(_ serde.RuleContext, msg interface{}) (interface{}, error) {
+	return msg, nil
+}
+func (e *countingExecutor) Close() error { return nil }
+
+// TestSerializerDefaultsToGlobalRuleRegistry verifies that leaving SerializerConfig.RuleRegistry
+// nil preserves the pre-existing behavior of using the process-wide global registry.
+func TestSerializerDefaultsToGlobalRuleRegistry(t *testing.T) {
+	serde.MaybeFail = serde.InitFailFunc(t)
+	conf := schemaregistry.NewConfig("mock://")
+	client, err := schemaregistry.NewClient(conf)
+	serde.MaybeFail("Schema Registry configuration", err)
+
+	ser, err := NewSerializer(client, serde.ValueSerde, NewSerializerConfig())
+	serde.MaybeFail("Serializer configuration", err)
+
+	if ser.RuleRegistry != serde.GlobalRuleRegistry() {
+		t.Fatalf("expected a serializer with a nil RuleRegistry to use the global registry")
+	}
+}
+
+// TestSerializerRuleRegistryIsolation verifies that a serializer built with an injected
+// RuleRegistry configures only that registry's executors, and that a separately-built
+// default serializer does not reach into (and reconfigure) the injected registry - i.e.
+// the two serializers do not share rule-executor state. This is what makes it safe to
+// construct CSFLE-enabled serializers concurrently.
+func TestSerializerRuleRegistryIsolation(t *testing.T) {
+	serde.MaybeFail = serde.InitFailFunc(t)
+	conf := schemaregistry.NewConfig("mock://")
+	client, err := schemaregistry.NewClient(conf)
+	serde.MaybeFail("Schema Registry configuration", err)
+
+	reg := serde.NewRuleRegistry()
+	isolated := &countingExecutor{ruleType: "ISOLATED_TEST_RULE"}
+	reg.RegisterExecutor(isolated)
+
+	serConf := NewSerializerConfig()
+	serConf.RuleRegistry = &reg
+	ser, err := NewSerializer(client, serde.ValueSerde, serConf)
+	serde.MaybeFail("Serializer configuration", err)
+
+	if ser.RuleRegistry != &reg {
+		t.Fatalf("expected serializer to use the injected RuleRegistry")
+	}
+	if ser.RuleRegistry == serde.GlobalRuleRegistry() {
+		t.Fatalf("injected RuleRegistry must not be the global registry")
+	}
+	if isolated.configured != 1 {
+		t.Fatalf("expected the injected registry's executor to be configured exactly once, got %d", isolated.configured)
+	}
+
+	// A serializer using the default (global) registry must not touch the injected
+	// registry's executor - proving the two do not share executor state.
+	def, err := NewSerializer(client, serde.ValueSerde, NewSerializerConfig())
+	serde.MaybeFail("Default serializer configuration", err)
+	if def.RuleRegistry != serde.GlobalRuleRegistry() {
+		t.Fatalf("expected the default serializer to use the global registry")
+	}
+	if isolated.configured != 1 {
+		t.Fatalf("a default-registry serializer must not reconfigure the injected registry's executor; configured count is now %d", isolated.configured)
+	}
+}

--- a/schemaregistry/serde/avrov3/avro.go
+++ b/schemaregistry/serde/avrov3/avro.go
@@ -81,7 +81,7 @@ func NewSerializer(client schemaregistry.Client, serdeType serde.Type, conf *Ser
 		return s.FieldTransform(s.Client, ctx, fieldTransform, msg)
 	}
 	s.FieldTransformer = fieldTransformer
-	err = s.SetRuleRegistry(serde.GlobalRuleRegistry(), conf.RuleConfig)
+	err = s.SetRuleRegistry(conf.RuleRegistry, conf.RuleConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +214,7 @@ func NewDeserializer(client schemaregistry.Client, serdeType serde.Type, conf *D
 		return s.FieldTransform(s.Client, ctx, fieldTransform, msg)
 	}
 	s.FieldTransformer = fieldTransformer
-	err = s.SetRuleRegistry(serde.GlobalRuleRegistry(), conf.RuleConfig)
+	err = s.SetRuleRegistry(conf.RuleRegistry, conf.RuleConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/schemaregistry/serde/config.go
+++ b/schemaregistry/serde/config.go
@@ -30,6 +30,15 @@ type SerializerConfig struct {
 	NormalizeSchemas bool
 	// RuleConfig specifies configuration options to the rules
 	RuleConfig map[string]string
+	// RuleRegistry supplies an alternative registry of rule executors, actions, and
+	// overrides for this serializer to use instead of the global one. When nil (the
+	// default), the global registry is used - the same one the rules packages' Register
+	// functions populate. Provide a dedicated *RuleRegistry (see NewRuleRegistry) to
+	// isolate this serializer's rule executors from the process-wide global state, so
+	// that concurrently-constructed serializers do not share and reconfigure the same
+	// executor instances. Populate it via RegisterExecutor/RegisterAction; nothing is
+	// linked in on your behalf, exactly as with the global registry.
+	RuleRegistry *RuleRegistry
 	// SubjectNameStrategyType specifies the subject name strategy type
 	SubjectNameStrategyType SubjectNameStrategyType
 	// SubjectNameStrategyConfig specifies configuration options for the subject name strategy
@@ -70,6 +79,15 @@ type DeserializerConfig struct {
 	UseLatestWithMetadata map[string]string
 	// RuleConfig specifies configuration options to the rules
 	RuleConfig map[string]string
+	// RuleRegistry supplies an alternative registry of rule executors, actions, and
+	// overrides for this deserializer to use instead of the global one. When nil (the
+	// default), the global registry is used - the same one the rules packages' Register
+	// functions populate. Provide a dedicated *RuleRegistry (see NewRuleRegistry) to
+	// isolate this deserializer's rule executors from the process-wide global state, so
+	// that concurrently-constructed deserializers do not share and reconfigure the same
+	// executor instances. Populate it via RegisterExecutor/RegisterAction; nothing is
+	// linked in on your behalf, exactly as with the global registry.
+	RuleRegistry *RuleRegistry
 	// SubjectNameStrategyType specifies the subject name strategy type
 	SubjectNameStrategyType SubjectNameStrategyType
 	// SubjectNameStrategyConfig specifies configuration options for the subject name strategy

--- a/schemaregistry/serde/jsonschema/json_schema.go
+++ b/schemaregistry/serde/jsonschema/json_schema.go
@@ -83,7 +83,7 @@ func NewSerializer(client schemaregistry.Client, serdeType serde.Type, conf *Ser
 		return s.FieldTransform(s.Client, ctx, fieldTransform, msg)
 	}
 	s.FieldTransformer = fieldTransformer
-	err = s.SetRuleRegistry(serde.GlobalRuleRegistry(), conf.RuleConfig)
+	err = s.SetRuleRegistry(conf.RuleRegistry, conf.RuleConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -212,7 +212,7 @@ func NewDeserializer(client schemaregistry.Client, serdeType serde.Type, conf *D
 		return s.FieldTransform(s.Client, ctx, fieldTransform, msg)
 	}
 	s.FieldTransformer = fieldTransformer
-	err = s.SetRuleRegistry(serde.GlobalRuleRegistry(), conf.RuleConfig)
+	err = s.SetRuleRegistry(conf.RuleRegistry, conf.RuleConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/schemaregistry/serde/protobuf/protobuf.go
+++ b/schemaregistry/serde/protobuf/protobuf.go
@@ -184,7 +184,7 @@ func NewSerializer(client schemaregistry.Client, serdeType serde.Type, conf *Ser
 	if err != nil {
 		return nil, err
 	}
-	err = s.SetRuleRegistry(serde.GlobalRuleRegistry(), conf.RuleConfig)
+	err = s.SetRuleRegistry(conf.RuleRegistry, conf.RuleConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -586,7 +586,7 @@ func NewDeserializer(client schemaregistry.Client, serdeType serde.Type, conf *D
 		return s.FieldTransform(s.Client, ctx, fieldTransform, msg)
 	}
 	s.FieldTransformer = fieldTransformer
-	err = s.SetRuleRegistry(serde.GlobalRuleRegistry(), conf.RuleConfig)
+	err = s.SetRuleRegistry(conf.RuleRegistry, conf.RuleConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/schemaregistry/serde/serde.go
+++ b/schemaregistry/serde/serde.go
@@ -962,8 +962,13 @@ func (s *BaseSerializer) GetSchemaID(schemaType string, topic string, msg interf
 	return *schemaID, nil
 }
 
-// SetRuleRegistry sets the rule registry
+// SetRuleRegistry sets the rule registry. A nil registry selects the global one, so
+// callers threading through an optional per-serializer registry can pass it straight
+// through without a nil check.
 func (s *Serde) SetRuleRegistry(registry *RuleRegistry, ruleConfig map[string]string) error {
+	if registry == nil {
+		registry = GlobalRuleRegistry()
+	}
 	s.RuleRegistry = registry
 	for _, rule := range registry.GetExecutors() {
 		err := rule.Configure(s.Client.Config(), ruleConfig)


### PR DESCRIPTION
## Problem
The serializer/deserializer constructors hardcode `serde.GlobalRuleRegistry()`:

```go
err = s.SetRuleRegistry(serde.GlobalRuleRegistry(), conf.RuleConfig)
```

So every serializer in a process shares **one** set of rule executors, keyed only by rule type (`ENCRYPT`, `ENCRYPT_PAYLOAD`, …). Each construction runs `SetRuleRegistry`, which iterates those shared executors and calls `Configure()` on each — mutating the executor's `Client` field (`schemaregistry/rules/encryption/*.go`) with **no synchronization**.

When serializers are constructed concurrently — e.g. many parallel CSFLE-enabled tests in a single test binary — their goroutines race on that shared executor state. In practice this surfaces as a `SIGSEGV`/nil-pointer dereference inside the encryption executor that crashes the whole process. Even without a crash, two serializers built close together reconfigure and clobber each other's KMS/DEK client, so a serializer can end up encrypting against another's client.

There is currently no way to opt out of the global registry: `SerializerConfig`/`DeserializerConfig` expose only `RuleConfig`, and the constructors always pass the global one.

## Change
Add an optional `RuleRegistry *RuleRegistry` field to `SerializerConfig` and `DeserializerConfig`, and thread it through the `avrov2` / `avrov3` / `jsonschema` / `protobuf` serializer and deserializer constructors.

- **Backward compatible.** The field defaults to `nil`, which selects the global registry — identical to today's behavior. This mirrors the existing `ValidationRuleExecutor` field's "nil ⇒ take from the global registry" convention.
- **Opt-in isolation.** A caller that wants a serializer isolated from process-wide rule state builds a dedicated registry with the already-exported `serde.NewRuleRegistry()` + `RegisterExecutor`, and sets it on the config. Each such serializer then has its own executor instances, so concurrent construction has no shared mutable state to race on.
- `SetRuleRegistry` now treats a `nil` registry as the global one — both so the constructors can pass `conf.RuleRegistry` straight through, and as a small robustness improvement (previously `nil` would panic in `GetExecutors()`).

### Files
- `schemaregistry/serde/config.go` — new `RuleRegistry` field on both configs (documented).
- `schemaregistry/serde/serde.go` — `SetRuleRegistry` nil-safe.
- `schemaregistry/serde/{avrov2,avrov3,jsonschema,protobuf}/*.go` — 8 constructor sites pass `conf.RuleRegistry`.
- `schemaregistry/serde/avrov2/avro_ruleregistry_test.go` — new tests.

## Tests
- `TestSerializerDefaultsToGlobalRuleRegistry` — a nil `RuleRegistry` still resolves to `GlobalRuleRegistry()`.
- `TestSerializerRuleRegistryIsolation` — an injected registry's executor is configured exactly once, and a separately-built default serializer does **not** reach into / reconfigure the injected registry (proving no shared executor state).
- Full `./schemaregistry/serde/...` suite passes, including under `-race`.

```
ok  github.com/confluentinc/confluent-kafka-go/v2/schemaregistry/serde
ok  github.com/confluentinc/confluent-kafka-go/v2/schemaregistry/serde/avro
ok  github.com/confluentinc/confluent-kafka-go/v2/schemaregistry/serde/avrov2
ok  github.com/confluentinc/confluent-kafka-go/v2/schemaregistry/serde/avrov3
ok  github.com/confluentinc/confluent-kafka-go/v2/schemaregistry/serde/jsonschema
ok  github.com/confluentinc/confluent-kafka-go/v2/schemaregistry/serde/protobuf
```

## Notes for reviewers
- Draft — opening for design feedback on the config-field approach before polishing. Happy to add equivalent tests for `protobuf`/`jsonschema` if preferred.
- This does not change what populates the global registry or how the rules packages' `Register()` funcs behave; it only lets a caller supply an alternative registry.
- CLA/DCO: flag if any sign-off or contributor process is needed and I'll add it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)