### PR TITLE
Avoid panic for empty consumer group filters

### DIFF
--- a/kafka/adminapi_test.go
+++ b/kafka/adminapi_test.go
@@ -480,6 +480,26 @@ func testAdminAPIsListConsumerGroups(
 			what, listres, err)
 	}
 
+	testEmptyFilter := func(option ListConsumerGroupsAdminOption, filter string) {
+		ctx, cancel := context.WithTimeout(context.Background(), expDuration)
+		defer cancel()
+		listres, err := a.ListConsumerGroups(
+			ctx, SetAdminRequestTimeout(time.Second), option)
+		if err == nil {
+			t.Fatalf("%s: Expected ListConsumerGroups with empty %s filter to fail, but got result: %v, err: %v",
+				what, filter, listres, err)
+		}
+		if ctx.Err() != context.DeadlineExceeded {
+			t.Fatalf("%s: Expected DeadlineExceeded for empty %s filter, not %v",
+				what, filter, ctx.Err())
+		}
+	}
+
+	testEmptyFilter(
+		SetAdminMatchConsumerGroupStates([]ConsumerGroupState{}), "state")
+	testEmptyFilter(
+		SetAdminMatchConsumerGroupTypes([]ConsumerGroupType{}), "type")
+
 	// Successful call
 	ctx, cancel = context.WithTimeout(context.Background(), expDuration)
 	defer cancel()

--- a/kafka/adminapi_test.go
+++ b/kafka/adminapi_test.go
@@ -480,25 +480,20 @@ func testAdminAPIsListConsumerGroups(
 			what, listres, err)
 	}
 
-	testEmptyFilter := func(option ListConsumerGroupsAdminOption, filter string) {
-		ctx, cancel := context.WithTimeout(context.Background(), expDuration)
-		defer cancel()
-		listres, err := a.ListConsumerGroups(
-			ctx, SetAdminRequestTimeout(time.Second), option)
-		if err == nil {
-			t.Fatalf("%s: Expected ListConsumerGroups with empty %s filter to fail, but got result: %v, err: %v",
-				what, filter, listres, err)
-		}
-		if ctx.Err() != context.DeadlineExceeded {
-			t.Fatalf("%s: Expected DeadlineExceeded for empty %s filter, not %v",
-				what, filter, ctx.Err())
-		}
+	ctx, cancel = context.WithTimeout(context.Background(), expDuration)
+	defer cancel()
+	listres, err = a.ListConsumerGroups(
+		ctx, SetAdminRequestTimeout(time.Second),
+		SetAdminMatchConsumerGroupStates([]ConsumerGroupState{}),
+		SetAdminMatchConsumerGroupTypes([]ConsumerGroupType{}))
+	if err == nil {
+		t.Fatalf("%s: Expected ListConsumerGroups with empty filters to fail, but got result: %v, err: %v",
+			what, listres, err)
 	}
-
-	testEmptyFilter(
-		SetAdminMatchConsumerGroupStates([]ConsumerGroupState{}), "state")
-	testEmptyFilter(
-		SetAdminMatchConsumerGroupTypes([]ConsumerGroupType{}), "type")
+	if ctx.Err() != context.DeadlineExceeded {
+		t.Fatalf("%s: Expected DeadlineExceeded for empty filters, not %v",
+			what, ctx.Err())
+	}
 
 	// Successful call
 	ctx, cancel = context.WithTimeout(context.Background(), expDuration)

--- a/kafka/adminoptions.go
+++ b/kafka/adminoptions.go
@@ -335,7 +335,7 @@ func SetAdminRequireStableOffsets(val bool) (ao AdminOptionRequireStableOffsets)
 // AdminOptionMatchConsumerGroupStates decides groups in which state(s) should be
 // listed.
 //
-// Default: nil (lists groups in all states).
+// Default: nil or empty slice (lists groups in all states).
 //
 // Valid for ListConsumerGroups.
 type AdminOptionMatchConsumerGroupStates struct {
@@ -373,7 +373,7 @@ func (ao AdminOptionMatchConsumerGroupStates) apply(cOptions *C.rd_kafka_AdminOp
 // SetAdminMatchConsumerGroupStates sets the state(s) that must be
 // listed.
 //
-// Default: nil (lists groups in all states).
+// Default: nil or empty slice (lists groups in all states).
 //
 // Valid for ListConsumerGroups.
 func SetAdminMatchConsumerGroupStates(val []ConsumerGroupState) (ao AdminOptionMatchConsumerGroupStates) {
@@ -385,7 +385,7 @@ func SetAdminMatchConsumerGroupStates(val []ConsumerGroupState) (ao AdminOptionM
 // AdminOptionMatchConsumerGroupTypes decides the type(s) that must be
 // listed.
 //
-// Default: nil (lists groups of all types).
+// Default: nil or empty slice (lists groups of all types).
 //
 // Valid for ListConsumerGroups.
 type AdminOptionMatchConsumerGroupTypes struct {
@@ -423,7 +423,7 @@ func (ao AdminOptionMatchConsumerGroupTypes) apply(cOptions *C.rd_kafka_AdminOpt
 // SetAdminMatchConsumerGroupTypes set the type(s) that must be
 // listed.
 //
-// Default: nil (lists groups of all types).
+// Default: nil or empty slice (lists groups of all types).
 //
 // Valid for ListConsumerGroups.
 func SetAdminMatchConsumerGroupTypes(val []ConsumerGroupType) (ao AdminOptionMatchConsumerGroupTypes) {

--- a/kafka/adminoptions.go
+++ b/kafka/adminoptions.go
@@ -347,7 +347,7 @@ func (ao AdminOptionMatchConsumerGroupStates) supportsListConsumerGroups() {
 }
 
 func (ao AdminOptionMatchConsumerGroupStates) apply(cOptions *C.rd_kafka_AdminOptions_t) error {
-	if !ao.isSet || ao.val == nil {
+	if !ao.isSet || len(ao.val) == 0 {
 		return nil
 	}
 
@@ -397,7 +397,7 @@ func (ao AdminOptionMatchConsumerGroupTypes) supportsListConsumerGroups() {
 }
 
 func (ao AdminOptionMatchConsumerGroupTypes) apply(cOptions *C.rd_kafka_AdminOptions_t) error {
-	if !ao.isSet || ao.val == nil {
+	if !ao.isSet || len(ao.val) == 0 {
 		return nil
 	}
 


### PR DESCRIPTION
What
----
- Avoid a panic when ListConsumerGroups receives an empty consumer group state or type filter.
- Treat zero-length filters the same as unset filters.

Checklist
------------------
- [x] Contains customer facing changes? This prevents a runtime panic.
- [x] Did you add sufficient unit test and/or integration test coverage for this PR?
  - Added regression coverage for empty state and type filters.

Test & Review
------------
- `go test ./... -count=1`
