### PR TITLE
NONJAVACLI-4488: Fix panic on truncated Schema Registry wire format prefix

### DIFF
--- a/schemaregistry/serde/avrov2/avro_test.go
+++ b/schemaregistry/serde/avrov2/avro_test.go
@@ -34,6 +34,7 @@ import (
 	_ "github.com/confluentinc/confluent-kafka-go/v2/schemaregistry/rules/encryption/localkms"
 	_ "github.com/confluentinc/confluent-kafka-go/v2/schemaregistry/rules/jsonata"
 
+	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 	"github.com/confluentinc/confluent-kafka-go/v2/schemaregistry"
 	"github.com/confluentinc/confluent-kafka-go/v2/schemaregistry/serde"
 )
@@ -512,6 +513,56 @@ func TestAvroSerdeWithSimple(t *testing.T) {
 
 	msg, err = deser.Deserialize("topic1", bytes)
 	serde.MaybeFail("deserialization", err, serde.Expect(msg, &obj))
+}
+
+func TestAvroSerdeWithTruncatedPrefix(t *testing.T) {
+	// A record value or schema ID header holding a truncated wire format prefix
+	// must fail deserialization rather than panic, so that one malformed record
+	// cannot take down a consumer that has no per record recovery boundary.
+	serde.MaybeFail = serde.InitFailFunc(t)
+	conf := schemaregistry.NewConfig("mock://")
+
+	client, err := schemaregistry.NewClient(conf)
+	serde.MaybeFail("Schema Registry configuration", err)
+
+	deser, err := NewDeserializer(client, serde.ValueSerde, NewDeserializerConfig())
+	serde.MaybeFail("Deserializer configuration", err)
+	deser.MessageFactory = testMessageFactory
+
+	tests := []struct {
+		name    string
+		headers []kafka.Header
+		payload []byte
+	}{
+		{
+			name:    "magic byte only",
+			payload: []byte{serde.MagicByteV0},
+		},
+		{
+			name:    "truncated id in header",
+			headers: []kafka.Header{{Key: serde.ValueSchemaIDHeader, Value: []byte{serde.MagicByteV0}}},
+			payload: []byte{serde.MagicByteV0, 0x00, 0x00, 0x00, 0x01, 0x02, 0x03},
+		},
+		{
+			name:    "truncated id in both header and payload",
+			headers: []kafka.Header{{Key: serde.ValueSchemaIDHeader, Value: []byte{serde.MagicByteV0}}},
+			payload: []byte{serde.MagicByteV0, 0x00},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("deserialization panicked on %v: %v", tc.payload, r)
+				}
+			}()
+
+			if _, err := deser.DeserializeWithHeaders("topic1", tc.headers, tc.payload); err == nil {
+				t.Errorf("expected an error for %v, got nil", tc.payload)
+			}
+		})
+	}
 }
 
 func TestAvroSerdeWithGuidInHeader(t *testing.T) {

--- a/schemaregistry/serde/serde.go
+++ b/schemaregistry/serde/serde.go
@@ -95,11 +95,20 @@ func NewSchemaID(schemaType string, id int, guid string) (*SchemaID, error) {
 // FromBytes converts the bytes to the SchemaID
 func (s *SchemaID) FromBytes(payload []byte) (int, error) {
 	var totalBytesRead int
+	if len(payload) < 1 {
+		return 0, fmt.Errorf("wire format payload is empty")
+	}
 	magicByte := payload[0]
 	if magicByte == MagicByteV0 {
+		if len(payload) < 5 {
+			return 0, fmt.Errorf("wire format payload too short: need 5 bytes for schema id, got %d", len(payload))
+		}
 		s.ID = int(binary.BigEndian.Uint32(payload[1:5]))
 		totalBytesRead = 5
 	} else if magicByte == MagicByteV1 {
+		if len(payload) < 17 {
+			return 0, fmt.Errorf("wire format payload too short: need 17 bytes for schema guid, got %d", len(payload))
+		}
 		guid, err := uuid.FromBytes(payload[1:17])
 		if err != nil {
 			return 0, err
@@ -1310,6 +1319,9 @@ func (s *BaseSerializer) WriteBytes(id int, msgBytes []byte) ([]byte, error) {
 // Deprecated: Use GetWriterSchema instead
 func (s *BaseDeserializer) GetSchema(topic string, payload []byte) (schemaregistry.SchemaInfo, error) {
 	info := schemaregistry.SchemaInfo{}
+	if len(payload) < 5 {
+		return info, fmt.Errorf("wire format payload too short: need 5 bytes, got %d", len(payload))
+	}
 	if payload[0] != MagicByteV0 {
 		return info, fmt.Errorf("unknown magic byte")
 	}

--- a/schemaregistry/serde/serde_test.go
+++ b/schemaregistry/serde/serde_test.go
@@ -96,6 +96,73 @@ func TestIdWithMessageIndexes(t *testing.T) {
 	MaybeFail("same bytes", err, Expect(output, input))
 }
 
+func TestFromBytesTruncatedPrefix(t *testing.T) {
+	// A truncated wire format prefix must return an error rather than panic:
+	// FromBytes used to slice the schema id or guid before checking that those
+	// bytes were present, so a record value holding only a magic byte took down
+	// the caller instead of failing deserialization.
+	guid := []byte{
+		0x89, 0x79, 0x17, 0x62, 0x23, 0x36, 0x41, 0x86, 0x96, 0x74, 0x29, 0x9b, 0x90,
+		0xa8, 0x02, 0xe2,
+	}
+	tests := []struct {
+		name    string
+		payload []byte
+	}{
+		{"empty payload", []byte{}},
+		{"magic byte v0 only", []byte{MagicByteV0}},
+		{"partial id", []byte{MagicByteV0, 0x00, 0x00}},
+		{"one byte short of an id", []byte{MagicByteV0, 0x00, 0x00, 0x00}},
+		{"magic byte v1 only", []byte{MagicByteV1}},
+		{"partial guid", append([]byte{MagicByteV1}, guid[:8]...)},
+		{"one byte short of a guid", append([]byte{MagicByteV1}, guid[:15]...)},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("FromBytes panicked on %v: %v", tc.payload, r)
+				}
+			}()
+
+			schemaID := SchemaID{SchemaType: "AVRO"}
+			if _, err := schemaID.FromBytes(tc.payload); err == nil {
+				t.Errorf("expected an error for %v, got nil", tc.payload)
+			}
+		})
+	}
+}
+
+func TestGetSchemaTruncatedPrefix(t *testing.T) {
+	// The deprecated GetSchema path carries its own copy of the prefix parsing
+	// and needs the same guard; the legacy avro deserializer reaches it with an
+	// ordinary zero length record value.
+	tests := []struct {
+		name    string
+		payload []byte
+	}{
+		{"empty payload", []byte{}},
+		{"magic byte only", []byte{MagicByteV0}},
+		{"one byte short of an id", []byte{MagicByteV0, 0x00, 0x00, 0x00}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("GetSchema panicked on %v: %v", tc.payload, r)
+				}
+			}()
+
+			deser := BaseDeserializer{}
+			if _, err := deser.GetSchema("topic1", tc.payload); err == nil {
+				t.Errorf("expected an error for %v, got nil", tc.payload)
+			}
+		})
+	}
+}
+
 func TestReadMessageIndexes(t *testing.T) {
 	MaybeFail = InitFailFunc(t)
 


### PR DESCRIPTION
What
----
The Schema Registry deserializers panic instead of returning an error when a record carries a truncated wire format prefix.

Every SR-framed record starts with a prefix naming the schema: a magic byte followed by either a 4-byte schema ID (`0x00`, 5 bytes total) or a 16-byte schema GUID (`0x01`, 17 bytes total). The prefix parsing read the magic byte and then immediately sliced out the ID or GUID **without checking those bytes were present**, so a short record sliced past the end of the buffer and panicked.

That panic matters more than a normal deserialization failure because the offending record stays in the topic. A consumer without a per-record `recover()` boundary crashes, restarts, reads the same record at the same offset, and crashes again — one malformed record becomes a permanent crash loop instead of a single failed message the application could log, skip, or route to a DLQ.

Two functions carried their own copy of the unguarded parsing:

- **`SchemaID.FromBytes`** — the current path, shared by `avrov2`, `avrov3`, `protobuf` and `jsonschema`. Reached both from the record value and from the schema ID header.
- **`BaseDeserializer.GetSchema`** — the deprecated path still used by the legacy `avro` (v1) deserializer. It has its own inline copy of the parsing, so fixing `FromBytes` alone does not cover it.

The fix adds length checks before each slice and returns an ordinary error. Well-formed records are unaffected: they have the bytes, pass every check, and take the identical path as before.

How it can occur
----------------
This is reachable through ordinary misconfiguration, not only through deliberate abuse:

- **Non-SR data on the topic.** A raw 4-byte big-endian `int32` below 16,777,216 begins with byte `0x00` — which *is* `MagicByteV0` — and is one byte short of a complete prefix. Ordinary counters, sequence numbers and small IDs land exactly here.
- **Zero-length record values.** `Message.Value` is built via `C.GoBytes`, which returns a non-nil empty slice for length 0, so the legacy v1 `payload == nil` guard does not catch it. (A true null tombstone is handled correctly; an *empty* value is not.)
- **Producers that set the schema ID header themselves** with a wrong-length value.
- **Any writer to the topic** sending a deliberately truncated record.

No serializer change is needed: `BaseSerializer.WriteBytes` always emits the magic byte plus a full 4-byte ID, so this client never produces such a record. The deserializer is a parser of untrusted input and is the correct place to be robust.

Checklist
------------------
- [x] Contains customer facing changes? Including API/behavior changes
  - Behavior change, non-breaking: inputs that previously panicked now return an error. No change in behavior for well-formed records.
- [x] Did you add sufficient unit test and/or integration test coverage for this PR?

References
----------
JIRA: https://confluentinc.atlassian.net/browse/NONJAVACLI-4488

Test & Review
------------
13 regression cases were added across three tests:

- `TestFromBytesTruncatedPrefix` (7 cases) — empty payload, and every truncation length for both the v0 ID and v1 GUID forms.
- `TestGetSchemaTruncatedPrefix` (3 cases) — the deprecated legacy path.
- `TestAvroSerdeWithTruncatedPrefix` (3 cases) — end-to-end at the reported entry point, covering both the record value and the schema ID header.

Each test recovers a panic and reports it as a failure, so a regression surfaces as a clear message rather than a crashed test binary.

**Verified red/green** by stashing the fix and re-running the tests unchanged.

Without the fix — all 13 cases panic:

```
FromBytes panicked on []:  runtime error: index out of range [0] with length 0
FromBytes panicked on [0]: runtime error: slice bounds out of range [:5] with capacity 1
FromBytes panicked on [1]: runtime error: slice bounds out of range [:17] with capacity 1
GetSchema panicked on []:  runtime error: index out of range [0] with length 0
deserialization panicked on [0]: runtime error: slice bounds out of range [:5] with capacity 1
--- FAIL: TestFromBytesTruncatedPrefix      (7/7 subtests)
--- FAIL: TestGetSchemaTruncatedPrefix      (3/3 subtests)
--- FAIL: TestAvroSerdeWithTruncatedPrefix  (3/3 subtests)
```

With the fix — all 13 pass, and the error messages are actionable:

```
wire format payload too short: need 5 bytes for schema id, got 1
wire format payload too short: need 17 bytes for schema guid, got 1
wire format payload too short: need 5 bytes, got 0
```

Full suite, no regressions:

```
go test ./schemaregistry/...   # 21 packages ok
go vet  ./schemaregistry/...   # clean
gofmt -l <changed files>       # clean
```

To reproduce the original panic on `master`:

```go
c, _ := schemaregistry.NewClient(schemaregistry.NewConfig("mock://demo"))
d, _ := avrov2.NewDeserializer(c, serde.ValueSerde, avrov2.NewDeserializerConfig())
d.Deserialize("t", []byte{0x00}) // panics before this change, returns an error after
```

Open questions / Follow-ups
--------------------------
- `DualSchemaIDDeserializer` deliberately swallows a header parse error and falls back to the payload prefix. With this change a malformed header no longer panics, but it still falls through silently rather than surfacing a header-specific error. Left as-is — changing it would be a semantic change beyond the scope of this fix.
- A CHANGELOG entry under `## v2.x.0` / `### Fixes` can be added if that is expected for this release.
