### PR TITLE
feat(kafka): add share consumer (Kafka Queues, KIP-932) bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## v2.x.0
 
 ### Enhancements
+* Add `ShareConsumer`, a Go binding for librdkafka's share-consumer (Kafka
+  Queues / KIP-932) API. Share groups give point-to-point queue semantics:
+  per-message acknowledgement (Accept/Release/Reject), implicit or explicit
+  acknowledgement modes, and consumer scaling independent of partition count.
+  See `examples/share_consumer_example`. Requires a broker with share groups
+  enabled (Apache Kafka 4.2.0+); the feature is in Preview.
 * Add support for saving Azure key version with DEK (#1577)
 * Pass context when clients make KEK calls to DEK Registry (#1579)
 * Add support for inline validation rules (#1592)

--- a/README.md
+++ b/README.md
@@ -296,6 +296,20 @@ It has direct mapping to underlying librdkafka functionality.
 
 See [examples/consumer_example](examples/consumer_example)
 
+Share Consumer (Kafka Queues / KIP-932)
+---------------------------------------
+
+`ShareConsumer` is a member of a share group, which gives point-to-point queue
+semantics on top of a topic: records are distributed across the group's members
+and acknowledged per message (Accept/Release/Reject), so consumers scale
+independently of the partition count. Poll returns a batch (`ShareMessageSet`);
+acknowledgement is implicit (auto-accept on the next poll) or explicit.
+
+This is a Preview feature and requires a broker with share groups enabled
+(Apache Kafka 4.2.0+).
+
+See [examples/share_consumer_example](examples/share_consumer_example)
+
 Function-Based Producer
 -----------------------
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -86,6 +86,8 @@ Examples
 
   [protobuf_producer_example](protobuf_producer_example) - producer with Schema Registry and Protocol Buffers Serializer
 
+  [share_consumer_example](share_consumer_example) - Share group (Kafka Queues / KIP-932) consumer with explicit acknowledgement
+
   [stats_example](stats_example) - Receiving stats events
 
   [transactions_example](transactions_example) - Showcasing a transactional consume-process-produce application

--- a/examples/share_consumer_example/share_consumer_example.go
+++ b/examples/share_consumer_example/share_consumer_example.go
@@ -1,0 +1,109 @@
+/**
+ * Copyright 2024 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Example share consumer (Kafka Queues / KIP-932) with explicit acknowledgement
+package main
+
+// share_consumer_example subscribes to one or more topics as a member of a
+// share group and processes each polled batch with explicit acknowledgement:
+// every record is acknowledged Accept, Release (redeliver later) or Reject
+// (drop). Share groups require a broker with the feature enabled (Apache Kafka
+// 4.2.0+).
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
+)
+
+func main() {
+
+	if len(os.Args) < 4 {
+		fmt.Fprintf(os.Stderr, "Usage: %s <bootstrap-servers> <group> <topics..>\n",
+			os.Args[0])
+		os.Exit(1)
+	}
+
+	bootstrapServers := os.Args[1]
+	group := os.Args[2]
+	topics := os.Args[3:]
+	sigchan := make(chan os.Signal, 1)
+	signal.Notify(sigchan, syscall.SIGINT, syscall.SIGTERM)
+
+	c, err := kafka.NewShareConsumer(&kafka.ConfigMap{
+		"bootstrap.servers": bootstrapServers,
+		"group.id":          group,
+		// "implicit" (the default) auto-accepts the previous poll's records on
+		// the next Poll(). "explicit" requires the application to acknowledge
+		// every record of a batch before the next Poll(), as shown below.
+		"share.acknowledgement.mode": "explicit",
+	})
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to create share consumer: %s\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Created share consumer %v\n", c)
+
+	err = c.SubscribeTopics(topics)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to subscribe to topics: %s\n", err)
+		os.Exit(1)
+	}
+
+	run := true
+	for run {
+		select {
+		case sig := <-sigchan:
+			fmt.Printf("Caught signal %v: terminating\n", sig)
+			run = false
+		default:
+			set, err := c.Poll(100)
+			if err != nil {
+				// Poll errors on a share consumer are typically fatal
+				// (misconfiguration, authorization); log and keep polling.
+				fmt.Fprintf(os.Stderr, "Poll error: %v\n", err)
+				continue
+			}
+			if set == nil {
+				// Timeout with no messages.
+				continue
+			}
+
+			for _, msg := range set.Messages() {
+				fmt.Printf("%% Message on %s:\n%s\n",
+					msg.TopicPartition, string(msg.Value))
+				// Acknowledge each record: Accept marks it processed, Release
+				// makes it available for redelivery, Reject drops it.
+				if err := set.Acknowledge(msg, kafka.ShareAcknowledgeTypeAccept); err != nil {
+					fmt.Fprintf(os.Stderr, "Acknowledge failed: %v\n", err)
+				}
+			}
+
+			// Flush the acknowledgements for this batch to the broker.
+			if _, err := c.CommitSync(5000); err != nil {
+				fmt.Fprintf(os.Stderr, "CommitSync failed: %v\n", err)
+			}
+		}
+	}
+
+	fmt.Printf("Closing share consumer\n")
+	c.Close()
+}

--- a/kafka/integration/testresources/docker-compose-sharegroup.yaml
+++ b/kafka/integration/testresources/docker-compose-sharegroup.yaml
@@ -1,0 +1,29 @@
+## Single-node KRaft broker with Kafka Queues / share groups (KIP-932) enabled.
+## Apache Kafka 4.2.0 (share groups are GA in 4.2). For a single broker the
+## share-coordinator state topic must use replication factor / min ISR of 1.
+##
+##   docker compose -f docker-compose-sharegroup.yaml up -d
+##   SHARE_GROUP_BROKER=localhost:9092 go test -tags sharegroup ./kafka/ -run Share -v
+##   docker compose -f docker-compose-sharegroup.yaml down -v
+services:
+  kafka:
+    image: apache/kafka:4.2.0
+    container_name: kafka-sharegroup
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@localhost:9093
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      # Share groups (KIP-932): single-broker requires RF/min-ISR of 1.
+      KAFKA_SHARE_COORDINATOR_STATE_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_SHARE_COORDINATOR_STATE_TOPIC_MIN_ISR: 1
+      KAFKA_GROUP_SHARE_ENABLE: "true"

--- a/kafka/share_consumer.go
+++ b/kafka/share_consumer.go
@@ -1,0 +1,515 @@
+/**
+ * Copyright 2024 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka
+
+// ShareConsumer implements a Kafka share consumer (Queues for Kafka, KIP-932),
+// exposing librdkafka's rd_kafka_share_* API. Share groups give point-to-point
+// queue semantics: multiple members of the same share group cooperatively read
+// from the same partitions with per-message acknowledgement, instead of the
+// exclusive partition assignment of a classic consumer group.
+//
+// PREVIEW: the underlying librdkafka share-consumer API is a preview feature and
+// may change before General Availability. It requires a broker with share groups
+// enabled (Apache Kafka 4.2.0+). The ShareConsumer handle is NOT safe for
+// concurrent use: a single instance must not be used from multiple goroutines
+// simultaneously.
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+	"unsafe"
+)
+
+/*
+#include <stdlib.h>
+#include "select_rdkafka.h"
+#include "glue_rdkafka.h"
+
+static rd_kafka_topic_partition_t *_share_topic_partition_list_entry(rd_kafka_topic_partition_list_t *rktparlist, int idx) {
+   return idx < rktparlist->cnt ? &rktparlist->elems[idx] : NULL;
+}
+*/
+import "C"
+
+// ShareAcknowledgeType is the acknowledgement type applied to a message
+// consumed by a ShareConsumer in explicit acknowledgement mode.
+type ShareAcknowledgeType int
+
+const (
+	// ShareAcknowledgeTypeAccept marks the message as processed successfully.
+	ShareAcknowledgeTypeAccept ShareAcknowledgeType = C.RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_ACCEPT
+	// ShareAcknowledgeTypeRelease marks the message as not processed; it is made
+	// available for redelivery (to this or another member of the share group).
+	ShareAcknowledgeTypeRelease ShareAcknowledgeType = C.RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_RELEASE
+	// ShareAcknowledgeTypeReject marks the message as rejected; it will not be
+	// delivered again.
+	ShareAcknowledgeTypeReject ShareAcknowledgeType = C.RD_KAFKA_SHARE_ACKNOWLEDGE_TYPE_REJECT
+)
+
+// String returns a human readable name for the acknowledgement type.
+func (t ShareAcknowledgeType) String() string {
+	switch t {
+	case ShareAcknowledgeTypeAccept:
+		return "accept"
+	case ShareAcknowledgeTypeRelease:
+		return "release"
+	case ShareAcknowledgeTypeReject:
+		return "reject"
+	default:
+		return fmt.Sprintf("ShareAcknowledgeType(%d)", int(t))
+	}
+}
+
+// ShareConsumer implements a high-level Apache Kafka share consumer (KIP-932).
+type ShareConsumer struct {
+	rkshare *C.rd_kafka_share_t
+
+	name      string
+	msgFields *messageFields
+
+	// rkt -> topic name cache. The share handle owns no rd_kafka_t, so topic
+	// names are resolved directly from the message's rkt instead of via the
+	// handle rkt cache used by the classic Consumer.
+	rktNameLock  sync.Mutex
+	rktNameCache map[*C.rd_kafka_topic_t]string
+
+	// The batch returned by the most recent Poll(). It is destroyed on the next
+	// Poll() or on Close(); this keeps the underlying C message pointers valid
+	// for acknowledgement between polls, as librdkafka requires.
+	curSet *ShareMessageSet
+
+	isClosed  uint32
+	isClosing uint32
+}
+
+// ShareMessageSet is a batch of messages returned by ShareConsumer.Poll().
+//
+// The Go Message values returned by Messages() are independent copies and remain
+// valid after the set is released. Acknowledge*() however operate on the
+// underlying librdkafka messages, which are only valid until the next Poll() or
+// Close(); acknowledging a released set returns ErrState.
+type ShareMessageSet struct {
+	consumer *ShareConsumer
+	cmsgs    *C.rd_kafka_messages_t
+	messages []*Message
+	cptrs    []*C.rd_kafka_message_t
+	released uint32
+}
+
+// IsClosed returns true if the share consumer has been closed.
+func (c *ShareConsumer) IsClosed() bool {
+	return atomic.LoadUint32(&c.isClosed) == 1
+}
+
+func (c *ShareConsumer) verifyClient() error {
+	if c.IsClosed() {
+		return getOperationNotAllowedErrorForClosedClient()
+	}
+	return nil
+}
+
+// String returns a human readable name for the share consumer instance.
+func (c *ShareConsumer) String() string {
+	return c.name
+}
+
+// NewShareConsumer creates a new high-level ShareConsumer instance.
+//
+// conf is a *ConfigMap with standard librdkafka configuration properties.
+// group.id is required. share.acknowledgement.mode is optional and selects the
+// acknowledgement mode: "implicit" (default) auto-accepts the previous poll's
+// records on the next Poll()/CommitSync()/CommitAsync(); "explicit" requires the
+// application to acknowledge every record of a batch before the next Poll().
+//
+// Supported special (go.*) configuration properties:
+//
+//	go.message.fields (string, "all") - The fields to enable for consumed
+//	    messages, comma-separated list of "key", "value", "headers", or "all"/"none".
+func NewShareConsumer(conf *ConfigMap) (*ShareConsumer, error) {
+	err := versionCheck()
+	if err != nil {
+		return nil, err
+	}
+
+	// Copy so the caller's ConfigMap is not mutated.
+	confCopy := conf.clone()
+
+	groupid, _ := confCopy.get("group.id", nil)
+	if groupid == nil {
+		return nil, newErrorFromString(ErrInvalidArg,
+			"Required property group.id not set")
+	}
+
+	c := &ShareConsumer{
+		rktNameCache: make(map[*C.rd_kafka_topic_t]string),
+	}
+
+	v, err := confCopy.extract("go.message.fields", "all")
+	if err != nil {
+		return nil, err
+	}
+	c.msgFields, err = newMessageFieldsFrom(v)
+	if err != nil {
+		return nil, err
+	}
+
+	cConf, err := confCopy.convert()
+	if err != nil {
+		return nil, err
+	}
+
+	cErrstr := (*C.char)(C.malloc(C.size_t(256)))
+	defer C.free(unsafe.Pointer(cErrstr))
+
+	// rd_kafka_share_consumer_new frees cConf on success.
+	c.rkshare = C.rd_kafka_share_consumer_new(cConf, cErrstr, 256)
+	if c.rkshare == nil {
+		return nil, newErrorFromCString(C.RD_KAFKA_RESP_ERR__INVALID_ARG, cErrstr)
+	}
+
+	c.name = fmt.Sprintf("rdkafka#share-consumer-%v", groupid)
+
+	return c, nil
+}
+
+// Subscribe subscribes the share consumer to a single topic, replacing the
+// current subscription.
+func (c *ShareConsumer) Subscribe(topic string) error {
+	return c.SubscribeTopics([]string{topic})
+}
+
+// SubscribeTopics subscribes the share consumer to the provided list of topics,
+// replacing the current subscription. Wildcard (regex) topics are not supported.
+//
+// The call is asynchronous: partition assignment is entirely broker-driven via
+// the share group heartbeat; there is no client-side rebalance callback.
+func (c *ShareConsumer) SubscribeTopics(topics []string) error {
+	err := c.verifyClient()
+	if err != nil {
+		return err
+	}
+
+	ctopics := C.rd_kafka_topic_partition_list_new(C.int(len(topics)))
+	defer C.rd_kafka_topic_partition_list_destroy(ctopics)
+
+	for _, topic := range topics {
+		ctopic := C.CString(topic)
+		C.rd_kafka_topic_partition_list_add(ctopics, ctopic, C.RD_KAFKA_PARTITION_UA)
+		C.free(unsafe.Pointer(ctopic))
+	}
+
+	cErr := C.rd_kafka_share_subscribe(c.rkshare, ctopics)
+	if cErr != C.RD_KAFKA_RESP_ERR_NO_ERROR {
+		return newError(cErr)
+	}
+
+	return nil
+}
+
+// Unsubscribe clears the current subscription; the broker removes this member
+// from the share group.
+func (c *ShareConsumer) Unsubscribe() error {
+	err := c.verifyClient()
+	if err != nil {
+		return err
+	}
+
+	cErr := C.rd_kafka_share_unsubscribe(c.rkshare)
+	if cErr != C.RD_KAFKA_RESP_ERR_NO_ERROR {
+		return newError(cErr)
+	}
+
+	return nil
+}
+
+// Subscription returns the current topic subscription as set by Subscribe() /
+// SubscribeTopics().
+func (c *ShareConsumer) Subscription() (topics []string, err error) {
+	err = c.verifyClient()
+	if err != nil {
+		return nil, err
+	}
+
+	var cTopics *C.rd_kafka_topic_partition_list_t
+	cErr := C.rd_kafka_share_subscription(c.rkshare, &cTopics)
+	if cErr != C.RD_KAFKA_RESP_ERR_NO_ERROR {
+		return nil, newError(cErr)
+	}
+	defer C.rd_kafka_topic_partition_list_destroy(cTopics)
+
+	topicCnt := int(cTopics.cnt)
+	topics = make([]string, topicCnt)
+	for i := 0; i < topicCnt; i++ {
+		elem := C._share_topic_partition_list_entry(cTopics, C.int(i))
+		topics[i] = C.GoString(elem.topic)
+	}
+
+	return topics, nil
+}
+
+// Poll polls the share consumer for a batch of messages, blocking for at most
+// timeoutMs milliseconds.
+//
+// Returns (nil, nil) on timeout with no messages. Otherwise returns a
+// *ShareMessageSet whose Messages() holds the batch. The set from a previous
+// Poll() is released automatically by this call.
+func (c *ShareConsumer) Poll(timeoutMs int) (*ShareMessageSet, error) {
+	err := c.verifyClient()
+	if err != nil {
+		return nil, err
+	}
+
+	// Release the previous batch. In implicit ack mode librdkafka accepts the
+	// prior poll's records on this call; the C container is now safe to free.
+	c.releaseCurrentSet()
+
+	var cmsgs *C.rd_kafka_messages_t
+	cError := C.rd_kafka_share_poll(c.rkshare, C.int(timeoutMs), &cmsgs)
+	if cError != nil {
+		return nil, newErrorFromCErrorDestroy(cError)
+	}
+
+	if cmsgs == nil {
+		// Timeout with no messages.
+		return nil, nil
+	}
+
+	count := int(C.rd_kafka_messages_count(cmsgs))
+	set := &ShareMessageSet{
+		consumer: c,
+		cmsgs:    cmsgs,
+		messages: make([]*Message, count),
+		cptrs:    make([]*C.rd_kafka_message_t, count),
+	}
+	for i := 0; i < count; i++ {
+		cmsg := C.rd_kafka_messages_get(cmsgs, C.size_t(i))
+		set.cptrs[i] = cmsg
+		set.messages[i] = c.messageFromCShare(cmsg)
+	}
+
+	c.curSet = set
+	return set, nil
+}
+
+// releaseCurrentSet destroys the C batch held from the previous Poll(), if any.
+func (c *ShareConsumer) releaseCurrentSet() {
+	if c.curSet == nil {
+		return
+	}
+	if atomic.CompareAndSwapUint32(&c.curSet.released, 0, 1) {
+		C.rd_kafka_messages_destroy(c.curSet.cmsgs)
+		c.curSet.cmsgs = nil
+	}
+	c.curSet = nil
+}
+
+// messageFromCShare converts a librdkafka rd_kafka_message_t from a share poll
+// batch into a Go Message. It resolves the topic name directly from the
+// message's rkt (the share handle owns no rd_kafka_t).
+func (c *ShareConsumer) messageFromCShare(cmsg *C.rd_kafka_message_t) *Message {
+	msg := &Message{}
+
+	if cmsg.rkt != nil {
+		msg.TopicPartition.Topic = c.topicNameFromRkt(cmsg.rkt)
+	}
+	msg.TopicPartition.Partition = int32(cmsg.partition)
+	msg.TopicPartition.Offset = Offset(cmsg.offset)
+
+	if cmsg.payload != nil && c.msgFields.Value {
+		msg.Value = C.GoBytes(unsafe.Pointer(cmsg.payload), C.int(cmsg.len))
+	}
+	if cmsg.key != nil && c.msgFields.Key {
+		msg.Key = C.GoBytes(unsafe.Pointer(cmsg.key), C.int(cmsg.key_len))
+	}
+
+	var gMsg C.glue_msg_t
+	gMsg.msg = cmsg
+	gMsg.ts = C.rd_kafka_message_timestamp(cmsg, &gMsg.tstype)
+	if gMsg.ts != -1 {
+		ts := int64(gMsg.ts)
+		msg.TimestampType = TimestampType(gMsg.tstype)
+		msg.Timestamp = time.Unix(ts/1000, (ts%1000)*1000000)
+	}
+
+	if c.msgFields.Headers {
+		gMsg.want_hdrs = C.int8_t(1)
+		chdrsToTmphdrs(&gMsg)
+		if gMsg.tmphdrsCnt > 0 {
+			setupHeadersFromGlueMsg(msg, &gMsg)
+		}
+	}
+
+	if cmsg.err != 0 {
+		msg.TopicPartition.Error = newError(cmsg.err)
+	}
+
+	leaderEpoch := int32(C.rd_kafka_message_leader_epoch(cmsg))
+	if leaderEpoch >= 0 {
+		msg.LeaderEpoch = &leaderEpoch
+		msg.TopicPartition.LeaderEpoch = &leaderEpoch
+	}
+
+	return msg
+}
+
+// topicNameFromRkt returns the topic name for a C topic handle, using a local
+// cache to avoid repeated cgo calls.
+func (c *ShareConsumer) topicNameFromRkt(crkt *C.rd_kafka_topic_t) *string {
+	c.rktNameLock.Lock()
+	defer c.rktNameLock.Unlock()
+
+	if topic, ok := c.rktNameCache[crkt]; ok {
+		return &topic
+	}
+	topic := C.GoString(C.rd_kafka_topic_name(crkt))
+	c.rktNameCache[crkt] = topic
+	return &topic
+}
+
+// CommitSync synchronously commits all pending acknowledgements to the broker,
+// blocking until all replies are received or timeoutMs elapses.
+//
+// In implicit ack mode all records acquired by the previous poll are accepted
+// first. The returned partition list carries the per-partition result (inspect
+// each TopicPartition's Error); it is nil if no acknowledgements were pending.
+func (c *ShareConsumer) CommitSync(timeoutMs int) ([]TopicPartition, error) {
+	err := c.verifyClient()
+	if err != nil {
+		return nil, err
+	}
+
+	var cParts *C.rd_kafka_topic_partition_list_t
+	cError := C.rd_kafka_share_commit_sync(c.rkshare, C.int(timeoutMs), &cParts)
+	if cError != nil {
+		return nil, newErrorFromCErrorDestroy(cError)
+	}
+
+	if cParts == nil {
+		return nil, nil
+	}
+	defer C.rd_kafka_topic_partition_list_destroy(cParts)
+
+	return newTopicPartitionsFromCparts(cParts), nil
+}
+
+// CommitAsync sends all pending acknowledgements to the broker without fetching
+// new records and returns immediately. Per-partition outcomes are not reported
+// by this call (they are delivered to librdkafka's acknowledgement-commit
+// callback, which this binding does not yet surface); failed acknowledgements
+// are not retried.
+func (c *ShareConsumer) CommitAsync() error {
+	err := c.verifyClient()
+	if err != nil {
+		return err
+	}
+
+	cError := C.rd_kafka_share_commit_async(c.rkshare)
+	if cError != nil {
+		return newErrorFromCErrorDestroy(cError)
+	}
+	return nil
+}
+
+// Close closes the share consumer. It commits pending acknowledgements, leaves
+// the share group, and destroys the underlying handle. The instance is no longer
+// usable after this call.
+func (c *ShareConsumer) Close() error {
+	if err := c.verifyClient(); err != nil {
+		return err
+	}
+	if !atomic.CompareAndSwapUint32(&c.isClosing, 0, 1) {
+		return newErrorFromString(ErrState, "ShareConsumer is already closing")
+	}
+
+	c.releaseCurrentSet()
+
+	var closeErr error
+	if cError := C.rd_kafka_share_consumer_close(c.rkshare); cError != nil {
+		closeErr = newErrorFromCErrorDestroy(cError)
+	}
+
+	if cError := C.rd_kafka_share_destroy(c.rkshare); cError != nil && closeErr == nil {
+		closeErr = newErrorFromCErrorDestroy(cError)
+	} else if cError != nil {
+		C.rd_kafka_error_destroy(cError)
+	}
+	c.rkshare = nil
+
+	atomic.StoreUint32(&c.isClosed, 1)
+
+	return closeErr
+}
+
+// Messages returns the batch of consumed messages. The returned Message values
+// are independent Go copies and remain valid after the set is released.
+func (s *ShareMessageSet) Messages() []*Message {
+	return s.messages
+}
+
+// Len returns the number of messages in the set.
+func (s *ShareMessageSet) Len() int {
+	return len(s.messages)
+}
+
+func (s *ShareMessageSet) ackByIndex(i int, t ShareAcknowledgeType) error {
+	if atomic.LoadUint32(&s.released) == 1 {
+		return newErrorFromString(ErrState,
+			"cannot acknowledge a message set released by a subsequent Poll or Close")
+	}
+	if i < 0 || i >= len(s.cptrs) {
+		return newErrorFromString(ErrInvalidArg,
+			fmt.Sprintf("message index %d out of range [0,%d)", i, len(s.cptrs)))
+	}
+	cErr := C.rd_kafka_share_acknowledge_type(s.consumer.rkshare, s.cptrs[i],
+		C.rd_kafka_share_AcknowledgeType_t(t))
+	if cErr != C.RD_KAFKA_RESP_ERR_NO_ERROR {
+		return newError(cErr)
+	}
+	return nil
+}
+
+// AcknowledgeIndex acknowledges the message at index i in the set (as returned
+// by Messages()) with the given acknowledgement type. Only valid in explicit
+// acknowledgement mode and only before the next Poll() or Close().
+func (s *ShareMessageSet) AcknowledgeIndex(i int, t ShareAcknowledgeType) error {
+	return s.ackByIndex(i, t)
+}
+
+// Acknowledge acknowledges the given message (which must be one of the messages
+// returned by this set's Messages()) with the given acknowledgement type.
+func (s *ShareMessageSet) Acknowledge(m *Message, t ShareAcknowledgeType) error {
+	for i, candidate := range s.messages {
+		if candidate == m {
+			return s.ackByIndex(i, t)
+		}
+	}
+	return newErrorFromString(ErrInvalidArg,
+		"message does not belong to this ShareMessageSet")
+}
+
+// AcknowledgeAll acknowledges every message in the set with the given
+// acknowledgement type.
+func (s *ShareMessageSet) AcknowledgeAll(t ShareAcknowledgeType) error {
+	for i := range s.cptrs {
+		if err := s.ackByIndex(i, t); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/kafka/share_consumer_integration_test.go
+++ b/kafka/share_consumer_integration_test.go
@@ -1,0 +1,283 @@
+//go:build sharegroup
+
+/**
+ * Copyright 2024 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka
+
+// Integration tests for the ShareConsumer (Kafka Queues / KIP-932).
+//
+// These require a broker with share groups enabled (Apache Kafka 4.2.0+). Bring
+// one up with:
+//
+//	docker compose -f integration/testresources/docker-compose-sharegroup.yaml up -d
+//
+// then run:
+//
+//	SHARE_GROUP_BROKER=localhost:9092 go test -tags sharegroup ./kafka/ -run Share -v
+//
+// The tests are skipped unless SHARE_GROUP_BROKER is set.
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+)
+
+func shareBroker(t *testing.T) string {
+	b := os.Getenv("SHARE_GROUP_BROKER")
+	if b == "" {
+		t.Skip("SHARE_GROUP_BROKER not set; skipping share group integration test")
+	}
+	return b
+}
+
+// createShareTestTopic creates a fresh topic and returns its name.
+func createShareTestTopic(t *testing.T, broker string, partitions int) string {
+	t.Helper()
+	admin, err := NewAdminClient(&ConfigMap{"bootstrap.servers": broker})
+	if err != nil {
+		t.Fatalf("NewAdminClient: %s", err)
+	}
+	defer admin.Close()
+
+	topic := fmt.Sprintf("share-it-%d", time.Now().UnixNano())
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	results, err := admin.CreateTopics(ctx, []TopicSpecification{{
+		Topic:             topic,
+		NumPartitions:     partitions,
+		ReplicationFactor: 1,
+	}})
+	if err != nil {
+		t.Fatalf("CreateTopics: %s", err)
+	}
+	for _, r := range results {
+		if r.Error.Code() != ErrNoError {
+			t.Fatalf("CreateTopics(%s): %s", r.Topic, r.Error)
+		}
+	}
+	// Give the broker a moment to make the topic fully available.
+	time.Sleep(2 * time.Second)
+	return topic
+}
+
+// setShareGroupEarliest sets the share group's start offset to earliest so a
+// share group reads from the beginning of the log regardless of when it joins.
+// This makes the tests independent of produce/subscribe ordering.
+func setShareGroupEarliest(t *testing.T, broker, groupID string) {
+	t.Helper()
+	admin, err := NewAdminClient(&ConfigMap{"bootstrap.servers": broker})
+	if err != nil {
+		t.Fatalf("NewAdminClient: %s", err)
+	}
+	defer admin.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	results, err := admin.IncrementalAlterConfigs(ctx, []ConfigResource{{
+		Type: ResourceGroup,
+		Name: groupID,
+		Config: []ConfigEntry{{
+			Name:                 "share.auto.offset.reset",
+			Value:                "earliest",
+			IncrementalOperation: AlterConfigOpTypeSet,
+		}},
+	}})
+	if err != nil {
+		t.Fatalf("IncrementalAlterConfigs(group %s): %s", groupID, err)
+	}
+	for _, r := range results {
+		if r.Error.Code() != ErrNoError {
+			t.Fatalf("IncrementalAlterConfigs(group %s): %s", r.Name, r.Error)
+		}
+	}
+}
+
+// produceShareTestMessages produces n messages with keys "0".."n-1".
+func produceShareTestMessages(t *testing.T, broker, topic string, n int) {
+	t.Helper()
+	p, err := NewProducer(&ConfigMap{"bootstrap.servers": broker})
+	if err != nil {
+		t.Fatalf("NewProducer: %s", err)
+	}
+	defer p.Close()
+
+	dr := make(chan Event, n)
+	for i := 0; i < n; i++ {
+		err := p.Produce(&Message{
+			TopicPartition: TopicPartition{Topic: &topic, Partition: PartitionAny},
+			Key:            []byte(fmt.Sprintf("%d", i)),
+			Value:          []byte(fmt.Sprintf("value-%d", i)),
+		}, dr)
+		if err != nil {
+			t.Fatalf("Produce: %s", err)
+		}
+	}
+	for i := 0; i < n; i++ {
+		ev := <-dr
+		m := ev.(*Message)
+		if m.TopicPartition.Error != nil {
+			t.Fatalf("delivery failed: %s", m.TopicPartition.Error)
+		}
+	}
+	if remaining := p.Flush(15000); remaining > 0 {
+		t.Fatalf("Flush: %d messages still queued", remaining)
+	}
+}
+
+// TestShareConsumerImplicitIntegration produces N messages and consumes them
+// with a single implicit-mode share consumer, verifying every key is received.
+func TestShareConsumerImplicitIntegration(t *testing.T) {
+	broker := shareBroker(t)
+	const n = 100
+
+	topic := createShareTestTopic(t, broker, 4)
+	groupID := fmt.Sprintf("share-it-implicit-%d", time.Now().UnixNano())
+	setShareGroupEarliest(t, broker, groupID)
+	produceShareTestMessages(t, broker, topic, n)
+
+	c, err := NewShareConsumer(&ConfigMap{
+		"bootstrap.servers":          broker,
+		"group.id":                   groupID,
+		"share.acknowledgement.mode": "implicit",
+	})
+	if err != nil {
+		t.Fatalf("NewShareConsumer: %s", err)
+	}
+	defer c.Close()
+
+	if err := c.Subscribe(topic); err != nil {
+		t.Fatalf("Subscribe: %s", err)
+	}
+
+	seen := map[string]bool{}
+	deadline := time.Now().Add(60 * time.Second)
+	for len(seen) < n && time.Now().Before(deadline) {
+		set, err := c.Poll(1000)
+		if err != nil {
+			t.Fatalf("Poll: %s", err)
+		}
+		if set == nil {
+			continue
+		}
+		for _, m := range set.Messages() {
+			if m.TopicPartition.Error != nil {
+				t.Logf("record error: %s", m.TopicPartition.Error)
+				continue
+			}
+			seen[string(m.Key)] = true
+		}
+	}
+
+	if len(seen) != n {
+		t.Fatalf("implicit share consumer received %d/%d distinct keys", len(seen), n)
+	}
+	t.Logf("implicit share consumer received all %d keys", n)
+}
+
+// TestShareConsumerExplicitAckIntegration produces N messages and consumes them
+// cooperatively with two explicit-ack share consumers in the same share group,
+// accepting each record and verifying the union covers every key.
+func TestShareConsumerExplicitAckIntegration(t *testing.T) {
+	broker := shareBroker(t)
+	const n = 200
+
+	topic := createShareTestTopic(t, broker, 4)
+	groupID := fmt.Sprintf("share-it-explicit-%d", time.Now().UnixNano())
+	setShareGroupEarliest(t, broker, groupID)
+	produceShareTestMessages(t, broker, topic, n)
+
+	newExplicit := func() *ShareConsumer {
+		c, err := NewShareConsumer(&ConfigMap{
+			"bootstrap.servers":          broker,
+			"group.id":                   groupID,
+			"share.acknowledgement.mode": "explicit",
+		})
+		if err != nil {
+			t.Fatalf("NewShareConsumer: %s", err)
+		}
+		if err := c.Subscribe(topic); err != nil {
+			t.Fatalf("Subscribe: %s", err)
+		}
+		return c
+	}
+
+	type result struct {
+		keys  map[string]bool
+		total int
+	}
+	results := make(chan result, 2)
+
+	consume := func(c *ShareConsumer) {
+		defer c.Close()
+		keys := map[string]bool{}
+		total := 0
+		idle := 0
+		for idle < 8 { // stop after ~8s of empty polls
+			set, err := c.Poll(1000)
+			if err != nil {
+				t.Errorf("Poll: %s", err)
+				break
+			}
+			if set == nil {
+				idle++
+				continue
+			}
+			idle = 0
+			for _, m := range set.Messages() {
+				if m.TopicPartition.Error != nil {
+					continue
+				}
+				keys[string(m.Key)] = true
+				total++
+			}
+			if err := set.AcknowledgeAll(ShareAcknowledgeTypeAccept); err != nil {
+				t.Errorf("AcknowledgeAll: %s", err)
+			}
+			if _, err := c.CommitSync(5000); err != nil {
+				t.Errorf("CommitSync: %s", err)
+			}
+		}
+		results <- result{keys: keys, total: total}
+	}
+
+	c1 := newExplicit()
+	c2 := newExplicit()
+	go consume(c1)
+	go consume(c2)
+
+	union := map[string]bool{}
+	grandTotal := 0
+	for i := 0; i < 2; i++ {
+		r := <-results
+		grandTotal += r.total
+		for k := range r.keys {
+			union[k] = true
+		}
+	}
+
+	if len(union) != n {
+		t.Fatalf("explicit share consumers received %d/%d distinct keys (total records %d)",
+			len(union), n, grandTotal)
+	}
+	t.Logf("two explicit share consumers received all %d keys (total records delivered: %d)",
+		n, grandTotal)
+}

--- a/kafka/share_consumer_test.go
+++ b/kafka/share_consumer_test.go
@@ -1,0 +1,124 @@
+/**
+ * Copyright 2024 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kafka
+
+import (
+	"testing"
+)
+
+// TestShareConsumerAPIs dry-tests the ShareConsumer APIs; no broker is needed.
+func TestShareConsumerAPIs(t *testing.T) {
+	// group.id is required.
+	_, err := NewShareConsumer(&ConfigMap{})
+	if err == nil {
+		t.Fatalf("Expected NewShareConsumer() to fail without group.id")
+	}
+
+	c, err := NewShareConsumer(&ConfigMap{
+		"group.id":          "gotest-share",
+		"socket.timeout.ms": 10,
+	})
+	if err != nil {
+		t.Fatalf("NewShareConsumer failed: %s", err)
+	}
+	t.Logf("ShareConsumer %s", c)
+
+	if c.IsClosed() {
+		t.Errorf("Expected IsClosed()==false for a fresh consumer")
+	}
+
+	// Exercise the APIs on an open consumer (no broker: async/timeout paths).
+	testShareConsumerAPIs(t, c, false)
+
+	if err := c.Close(); err != nil {
+		t.Fatalf("Close() failed: %s", err)
+	}
+	if !c.IsClosed() {
+		t.Errorf("Expected IsClosed()==true after Close()")
+	}
+
+	// Every API must reject calls on a closed consumer.
+	testShareConsumerAPIs(t, c, true)
+
+	// Close() again should report the closed-client error, not panic.
+	if err := c.Close(); err == nil {
+		t.Errorf("Expected Close() on a closed consumer to return an error")
+	}
+}
+
+// testShareConsumerAPIs calls each ShareConsumer method. When closed is true,
+// every call must return the closed-client error.
+func testShareConsumerAPIs(t *testing.T, c *ShareConsumer, closed bool) {
+	wantClosed := getOperationNotAllowedErrorForClosedClient()
+
+	check := func(name string, err error) {
+		if closed {
+			if err != wantClosed {
+				t.Errorf("%s on closed consumer: want %v, got %v", name, wantClosed, err)
+			}
+		}
+	}
+
+	check("Subscribe", c.Subscribe("gotest-share-topic"))
+	check("SubscribeTopics", c.SubscribeTopics([]string{"t1", "t2"}))
+
+	_, err := c.Subscription()
+	check("Subscription", err)
+
+	// Poll with a short timeout returns (nil, nil) on timeout when open.
+	set, err := c.Poll(10)
+	check("Poll", err)
+	if !closed {
+		if err != nil {
+			t.Errorf("Poll() on open consumer (no broker) should time out, got err: %s", err)
+		}
+		if set != nil {
+			t.Errorf("Poll() timeout should return a nil set, got %d messages", set.Len())
+		}
+	}
+
+	_, err = c.CommitSync(10)
+	check("CommitSync", err)
+
+	check("CommitAsync", c.CommitAsync())
+
+	check("Unsubscribe", c.Unsubscribe())
+}
+
+// TestShareAcknowledgeTypeString verifies the acknowledgement-type string forms
+// and that the constants map to the librdkafka enum values.
+func TestShareAcknowledgeTypeString(t *testing.T) {
+	cases := []struct {
+		t    ShareAcknowledgeType
+		want string
+	}{
+		{ShareAcknowledgeTypeAccept, "accept"},
+		{ShareAcknowledgeTypeRelease, "release"},
+		{ShareAcknowledgeTypeReject, "reject"},
+	}
+	for _, c := range cases {
+		if got := c.t.String(); got != c.want {
+			t.Errorf("ShareAcknowledgeType(%d).String() = %q, want %q", int(c.t), got, c.want)
+		}
+	}
+
+	// librdkafka enum values: ACCEPT=1, RELEASE=2, REJECT=3.
+	if ShareAcknowledgeTypeAccept != 1 || ShareAcknowledgeTypeRelease != 2 || ShareAcknowledgeTypeReject != 3 {
+		t.Errorf("ShareAcknowledgeType constants do not match the librdkafka enum: %d,%d,%d",
+			ShareAcknowledgeTypeAccept, ShareAcknowledgeTypeRelease, ShareAcknowledgeTypeReject)
+	}
+}


### PR DESCRIPTION
What
----
Adds Go bindings for librdkafka's **share consumer** (Kafka Queues / KIP-932), which `confluent-kafka-go` does not yet surface. Share groups give point-to-point queue semantics on top of a topic (cooperative consumption, per-message acknowledgement), so consumers scale independently of the partition count. librdkafka already wraps the C API (`rd_kafka_share_*`); this binds it for Go, mirroring the existing `Consumer` type.

- `kafka/share_consumer.go` — `ShareConsumer`:
  - `NewShareConsumer`, `Subscribe` / `SubscribeTopics` / `Unsubscribe` / `Subscription`
  - `Poll(timeoutMs) -> *ShareMessageSet` (share poll returns a batch)
  - `ShareMessageSet.Messages()` / `Acknowledge` / `AcknowledgeIndex` / `AcknowledgeAll`
  - `CommitSync` / `CommitAsync`, `Close`, `IsClosed`, `String`
  - `ShareAcknowledgeType` (Accept / Release / Reject)
- Implicit and explicit acknowledgement modes (`share.acknowledgement.mode`).
- `kafka/share_consumer_test.go` — broker-free dry unit tests.
- `kafka/share_consumer_integration_test.go` (build tag `sharegroup`, gated on `SHARE_GROUP_BROKER`) — implicit and two-consumer explicit-ack tests. Stdlib-only, so it adds no dependencies to the module.
- `kafka/integration/testresources/docker-compose-sharegroup.yaml` — single-node Kafka 4.2 share-group broker fixture.
- `examples/share_consumer_example/` — explicit-ack share consumer, mirroring `consumer_example`'s Poll/signal structure; listed in `examples/README.md`.
- `README.md` — Share Consumer (Kafka Queues / KIP-932) section with the Preview caveat.
- `CHANGELOG.md` — Enhancement entry under the unreleased section.

Implementation notes:
- **No librdkafka bump required**: master already bundles librdkafka v2.15.0, whose bundled headers and prebuilt static libs export the share-consumer C API. This change is Go-only; existing producers/consumers are untouched.
- The librdkafka share consumer is a **Preview** feature and requires a broker with share groups enabled (Apache Kafka 4.2.0+). The handle is single-threaded (not safe for concurrent use), matching librdkafka's design.
- The async acknowledgement-commit callback (`rd_kafka_share_set_acknowledgement_commit_cb`) is not yet surfaced; `CommitSync` returns per-partition results synchronously, and `CommitAsync` cannot yet report per-partition outcomes.

Checklist
------------------
- [x] Contains customer facing changes? Including API/behavior changes — yes, a new public `ShareConsumer` API. It is purely additive; no existing type or behavior changes.
- [x] Did you add sufficient unit test and/or integration test coverage for this PR? — dry unit tests (no broker) plus broker-gated integration tests behind the `sharegroup` build tag.

References
----------
KIP-932 (Queues for Kafka): https://cwiki.apache.org/confluence/display/KAFKA/KIP-932%3A+Queues+for+Kafka
librdkafka share consumer API (`rd_kafka_share_*`): https://github.com/confluentinc/librdkafka

Test & Review
------------
- `go build ./kafka/` (static bundle) — clean.
- `go vet` / `go build` of `examples/share_consumer_example` — clean.
- Dry unit tests pass (no broker).
- Broker-gated tests (implicit-ack, and two-consumer explicit-ack covering redelivery of released records and non-redelivery of rejected records) run behind the `sharegroup` build tag. To run them:

      docker compose -f kafka/integration/testresources/docker-compose-sharegroup.yaml up -d
      SHARE_GROUP_BROKER=localhost:9092 go test -tags sharegroup ./kafka/ -run Share -v

Open questions / Follow-ups
--------------------------
- Surface the async acknowledgement-commit callback so `CommitAsync` can report per-partition outcomes.
- `SetOAuthBearerToken` / OAuth token-refresh parity with the classic `Consumer`, if desired for share consumers.
